### PR TITLE
[P2-A] ETL sync: Articulos + catalog

### DIFF
--- a/etl/sync/articulos.py
+++ b/etl/sync/articulos.py
@@ -1,0 +1,248 @@
+"""ETL sync for Articulos and catalog dimension tables.
+
+Full-refresh nightly strategy:
+- Articulos: all 41K rows have FechaModifica >= 2025-03-26 (batch update rendered
+  delta sync useless).  Truncate and reload every night.
+- Catalog dimension tables (FamiGrupMarc, DepaSeccFabr, CCOPColores, CCOPTempTipo,
+  CCOPMarcTrat) are trivially small (10–147 rows each) — full refresh is simplest.
+
+Column mapping convention
+-------------------------
+safe_fetch returns lowercase keys (4D returns column names uppercase; fourd.py
+normalises them).  The mapping dicts below translate those lowercase 4D names to
+the snake_case PostgreSQL column names defined in etl/schema/init.sql.
+
+PK precision warning
+--------------------
+4D PKs are REAL (float) with a .99 suffix pattern.  They are stored as NUMERIC in
+PostgreSQL to avoid binary-float precision loss.  All PK/FK values are converted to
+decimal.Decimal before being passed to the PostgreSQL insert helpers.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_NUMERIC_FIELDS = {
+    # ps_articulos
+    "regarticulo",
+    "numfamilia",
+    "numdepartament",
+    "numcolor",
+    "numtemporada",
+    "nummarca",
+    "numproveedor",
+    "preciocoste",
+    "prcostene",
+    "piva",
+    # ps_familias
+    "regfamilia",
+    "coeficiente1",
+    "coeficiente2",
+    "presupuesto",
+    # ps_departamentos
+    "regdepartament",
+    "joiva",
+    # ps_colores
+    "regcolor",
+    # ps_temporadas
+    "regtemporada",
+    # ps_marcas
+    "regmarca",
+    "descuentocompra",
+}
+
+
+def _to_decimal(value: Any) -> Any:
+    """Convert float to Decimal; pass other types through unchanged."""
+    if isinstance(value, float):
+        return Decimal(str(value))
+    return value
+
+
+def _map_row(source: dict[str, Any], mapping: dict[str, str]) -> dict[str, Any]:
+    """Return a new dict with keys renamed according to *mapping*.
+
+    Keys in *source* that are absent from *mapping* are silently dropped.
+    Values that are floats (in known numeric fields) are converted to Decimal.
+    """
+    result: dict[str, Any] = {}
+    for src_key, pg_key in mapping.items():
+        value = source.get(src_key)
+        if src_key in _NUMERIC_FIELDS:
+            value = _to_decimal(value)
+        result[pg_key] = value
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Column mapping: 4D lowercase name → PostgreSQL column name
+# ---------------------------------------------------------------------------
+
+_ARTICULOS_MAPPING: dict[str, str] = {
+    "regarticulo": "reg_articulo",
+    "codigo": "codigo",
+    "ccrefejofacm": "ccrefejofacm",
+    "descripcion": "descripcion",
+    "codigobarra": "codigo_barra",
+    "numfamilia": "num_familia",
+    "numdepartament": "num_departament",
+    "numcolor": "num_color",
+    "numtemporada": "num_temporada",
+    "nummarca": "num_marca",
+    "numproveedor": "num_proveedor",
+    "preciocoste": "precio_coste",
+    "prcostene": "pr_coste_ne",
+    "piva": "p_iva",
+    "anulado": "anulado",
+    "fechacreacion": "fecha_creacion",
+    "fechamodifica": "fecha_modifica",
+    "color": "color",
+    "clavetemporada": "clave_temporada",
+    "modelo": "modelo",
+    "sexo": "sexo",
+}
+
+_FAMILIAS_MAPPING: dict[str, str] = {
+    "regfamilia": "reg_familia",
+    "clave": "clave",
+    "famigrupmarc": "fami_grup_marc",
+    "coeficiente1": "coeficiente1",
+    "coeficiente2": "coeficiente2",
+    "cuentaventas": "cuenta_ventas",
+    "presupuesto": "presupuesto",
+    "anulado": "anulado",
+    "serietallas": "serie_tallas",
+    "claveseccion": "clave_seccion",
+}
+
+_DEPARTAMENTOS_MAPPING: dict[str, str] = {
+    "regdepartament": "reg_departament",
+    "clave": "clave",
+    "depaseccfabr": "depa_secc_fabr",
+    "joiva": "jo_iva",
+    "presupuesto": "presupuesto",
+    "anulado": "anulado",
+}
+
+_COLORES_MAPPING: dict[str, str] = {
+    "regcolor": "reg_color",
+    "clave": "clave",
+    "color": "color",
+}
+
+_TEMPORADAS_MAPPING: dict[str, str] = {
+    "regtemporada": "reg_temporada",
+    "clave": "clave",
+    "temporadatipo": "temporada_tipo",
+    "temporadaactiv": "temporada_activ",
+    "inicioventas": "inicio_ventas",
+    "finventas": "fin_ventas",
+    "iniciorebajas": "inicio_rebajas",
+    "finrebajas": "fin_rebajas",
+}
+
+_MARCAS_MAPPING: dict[str, str] = {
+    "regmarca": "reg_marca",
+    "clave": "clave",
+    "marcatratamien": "marca_tratamien",
+    "presupuesto": "presupuesto",
+    "descuentocompra": "descuento_compra",
+}
+
+
+# ---------------------------------------------------------------------------
+# SQL queries (explicit column lists — never SELECT *)
+# ---------------------------------------------------------------------------
+
+_SQL_ARTICULOS = (
+    "SELECT RegArticulo, Codigo, CCRefeJOFACM, Descripcion, CodigoBarra,"
+    " NumFamilia, NumDepartament, NumColor, NumTemporada, NumMarca, NumProveedor,"
+    " PrecioCoste, PrCosteNe, PIva, Anulado, FechaCreacion, FechaModifica,"
+    " Color, ClaveTemporada, Modelo, Sexo"
+    " FROM Articulos"
+)
+
+_SQL_FAMILIAS = (
+    "SELECT RegFamilia, Clave, FamiGrupMarc, Coeficiente1, Coeficiente2,"
+    " CuentaVentas, Presupuesto, Anulado, SerieTallas, ClaveSeccion"
+    " FROM FamiGrupMarc"
+)
+
+_SQL_DEPARTAMENTOS = (
+    "SELECT RegDepartament, Clave, DepaSeccFabr, JOIva, Presupuesto, Anulado"
+    " FROM DepaSeccFabr"
+)
+
+_SQL_COLORES = "SELECT RegColor, Clave, Color FROM CCOPColores"
+
+_SQL_TEMPORADAS = (
+    "SELECT RegTemporada, Clave, TemporadaTipo, TemporadaActiv,"
+    " InicioVentas, FinVentas, InicioRebajas, FinRebajas"
+    " FROM CCOPTempTipo"
+)
+
+_SQL_MARCAS = (
+    "SELECT RegMarca, Clave, MarcaTratamien, Presupuesto, DescuentoCompra"
+    " FROM CCOPMarcTrat"
+)
+
+
+# ---------------------------------------------------------------------------
+# Public sync functions
+# ---------------------------------------------------------------------------
+
+
+def sync_articulos(conn_4d: Any, conn_pg: Any) -> int:
+    """Full-refresh ps_articulos from the 4D Articulos table.
+
+    Args:
+        conn_4d: An open p4d connection.
+        conn_pg: An open psycopg2 connection.
+
+    Returns:
+        Number of rows loaded into ps_articulos.
+    """
+    from etl.db.fourd import safe_fetch
+    from etl.db.postgres import truncate_and_insert
+
+    raw_rows = safe_fetch(conn_4d, _SQL_ARTICULOS)
+    pg_rows = [_map_row(r, _ARTICULOS_MAPPING) for r in raw_rows]
+    return truncate_and_insert(conn_pg, "ps_articulos", pg_rows)
+
+
+def sync_catalogos(conn_4d: Any, conn_pg: Any) -> dict[str, int]:
+    """Full-refresh all catalog dimension tables.
+
+    Syncs: ps_familias, ps_departamentos, ps_colores, ps_temporadas, ps_marcas.
+
+    Args:
+        conn_4d: An open p4d connection.
+        conn_pg: An open psycopg2 connection.
+
+    Returns:
+        Dict mapping each PostgreSQL table name to the number of rows loaded.
+    """
+    from etl.db.fourd import safe_fetch
+    from etl.db.postgres import truncate_and_insert
+
+    catalog_tables: list[tuple[str, str, dict[str, str]]] = [
+        ("ps_familias", _SQL_FAMILIAS, _FAMILIAS_MAPPING),
+        ("ps_departamentos", _SQL_DEPARTAMENTOS, _DEPARTAMENTOS_MAPPING),
+        ("ps_colores", _SQL_COLORES, _COLORES_MAPPING),
+        ("ps_temporadas", _SQL_TEMPORADAS, _TEMPORADAS_MAPPING),
+        ("ps_marcas", _SQL_MARCAS, _MARCAS_MAPPING),
+    ]
+
+    counts: dict[str, int] = {}
+    for pg_table, sql, mapping in catalog_tables:
+        raw_rows = safe_fetch(conn_4d, sql)
+        pg_rows = [_map_row(r, mapping) for r in raw_rows]
+        counts[pg_table] = truncate_and_insert(conn_pg, pg_table, pg_rows)
+
+    return counts

--- a/etl/tests/test_sync_articulos.py
+++ b/etl/tests/test_sync_articulos.py
@@ -1,0 +1,144 @@
+"""Integration tests for etl/sync/articulos.py.
+
+All tests require both a live 4D connection (P4D_HOST set) and a live
+PostgreSQL connection.  They are skipped automatically when either is
+unavailable so CI without external access passes cleanly.
+
+What is tested:
+- Row count in ps_articulos matches 4D source after sync.
+- No bytes values in ps_articulos (bytes-decoding regression guard).
+- ccrefejofacm is populated for at least 90 % of rows (referencia present).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Skip guards
+# ---------------------------------------------------------------------------
+
+
+def _p4d_available() -> bool:
+    return bool(os.environ.get("P4D_HOST", "").strip())
+
+
+def _postgres_available() -> bool:
+    if os.environ.get("POSTGRES_DSN", "").strip():
+        return True
+    return bool(
+        os.environ.get("POSTGRES_USER", "").strip()
+        and os.environ.get("POSTGRES_DB", "").strip()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def conn_4d():
+    """Yield a p4d connection; skip if P4D_HOST is not configured."""
+    if not _p4d_available():
+        pytest.skip("P4D_HOST not set — skipping 4D integration tests")
+
+    from etl.config import Config
+    from etl.db.fourd import get_connection
+
+    config = Config()
+    conn = get_connection(config)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture(scope="module")
+def conn_pg():
+    """Yield a psycopg2 connection; skip if PostgreSQL is not configured."""
+    if not _postgres_available():
+        pytest.skip("PostgreSQL configuration not available — skipping PostgreSQL tests")
+
+    from etl.config import Config
+    from etl.db import postgres
+
+    config = Config()
+    conn = postgres.get_connection(config)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture(scope="module")
+def synced_count(conn_4d, conn_pg):
+    """Run sync_articulos once and return the reported row count.
+
+    Module-scoped so the expensive full-refresh runs only once across all tests
+    in this module.
+    """
+    from etl.sync.articulos import sync_articulos
+
+    return sync_articulos(conn_4d, conn_pg)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSyncArticulos:
+    def test_sync_articulos_count(self, conn_4d, conn_pg, synced_count):
+        """Row count in ps_articulos should match the 4D source table."""
+        from etl.db.fourd import safe_fetch
+
+        rows = safe_fetch(conn_4d, "SELECT COUNT(*) AS cnt FROM Articulos")
+        source_count = int(rows[0]["cnt"])
+
+        with conn_pg.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM ps_articulos")
+            pg_count = cur.fetchone()[0]
+
+        assert synced_count == source_count
+        assert pg_count == source_count
+
+    def test_no_bytes_in_articulos(self, conn_pg, synced_count):  # noqa: ARG002
+        """No column in ps_articulos should contain raw bytes values.
+
+        After safe_fetch decoding, all text fields must be str (or None).
+        This guards against regressions where bytes sneak through to PostgreSQL.
+        """
+        with conn_pg.cursor() as cur:
+            cur.execute("SELECT * FROM ps_articulos LIMIT 500")
+            col_names = [desc[0] for desc in cur.description]
+            rows = cur.fetchall()
+
+        for row in rows:
+            for col_name, value in zip(col_names, row):
+                assert not isinstance(value, bytes), (
+                    f"Column '{col_name}' contains raw bytes: {value!r}"
+                )
+
+    def test_referencia_not_empty(self, conn_pg, synced_count):  # noqa: ARG002
+        """ccrefejofacm (Referencia) should be non-NULL for at least 90% of rows.
+
+        Referencia is the primary business identifier displayed on labels and
+        reports.  A high NULL rate would indicate a mapping error.
+        """
+        with conn_pg.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM ps_articulos")
+            total = cur.fetchone()[0]
+
+            cur.execute(
+                "SELECT COUNT(*) FROM ps_articulos"
+                " WHERE ccrefejofacm IS NOT NULL AND ccrefejofacm <> ''"
+            )
+            non_empty = cur.fetchone()[0]
+
+        if total == 0:
+            pytest.skip("ps_articulos is empty — skipping referencia check")
+
+        ratio = non_empty / total
+        assert ratio >= 0.90, (
+            f"Only {non_empty}/{total} ({ratio:.1%}) rows have a non-empty"
+            " ccrefejofacm.  Expected >= 90%."
+        )


### PR DESCRIPTION
## Summary

- Implements `etl/sync/articulos.py` with two public functions: `sync_articulos` (full-refresh `ps_articulos`) and `sync_catalogos` (full-refresh five catalog dimension tables: `ps_familias`, `ps_departamentos`, `ps_colores`, `ps_temporadas`, `ps_marcas`)
- Adds `etl/tests/test_sync_articulos.py` with three integration tests (skipped when P4D_HOST or PostgreSQL not available)
- Uses existing `safe_fetch` + `truncate_and_insert` helpers; float PKs converted to `Decimal` before insert to prevent NUMERIC precision loss on the `.99` suffix pattern

## Design decisions

- Full-refresh strategy for Articulos: all 41K records had `FechaModifica >= 2025-03-26` due to a batch update, making delta sync unreliable (per `docs/etl-sync-strategy.md`)
- Explicit column lists in SQL queries — Articulos has 379 columns with BLOB/PICTURE types that hang on `SELECT *`
- `_NUMERIC_FIELDS` set drives float→Decimal conversion; only PK/FK/amount columns are converted — text fields are left as-is

## Test plan

- [ ] `ruff check etl/sync/articulos.py etl/tests/test_sync_articulos.py` — passes (verified)
- [ ] `test_sync_articulos_count`: row count in `ps_articulos` matches 4D `COUNT(*)`
- [ ] `test_no_bytes_in_articulos`: no raw bytes values in any column after sync
- [ ] `test_referencia_not_empty`: `ccrefejofacm` is non-NULL/non-empty for ≥ 90% of rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)