### PR TITLE
[P3-D] ETL sync: Compras

### DIFF
--- a/etl/sync/compras.py
+++ b/etl/sync/compras.py
@@ -109,11 +109,6 @@ _FACTURAS_COMPRA_MAPPING: dict[str, str] = {
 # SQL queries
 # ---------------------------------------------------------------------------
 
-_SQL_COMPRAS = (
-    "SELECT RegPedido, FechaPedido, FechaRecibido, Modificada, NumProveedor"
-    " FROM Compras"
-)
-
 _SQL_LINEAS_COMPRAS = (
     "SELECT RegLineaCompra, NumPedido, NumTienda, Fecha, NumArticulo"
     " FROM CCLineasCompr"
@@ -162,8 +157,6 @@ def sync_compras(conn_4d: Any, conn_pg: Any) -> int:
     cols_map = {k: v for k, v in cols_map.items() if k in queryable_lower}
 
     selected = [k for k in _COMPRAS_MAPPING if k in queryable_lower]
-    sql = "SELECT " + ", ".join(selected) + " FROM Compras"
-    # Use original casing from queryable list for safe column names
     orig_case = {c.lower(): c for c in queryable}
     sql = "SELECT " + ", ".join(orig_case[k] for k in selected) + " FROM Compras"
 
@@ -302,9 +295,15 @@ def sync_facturas_compra(conn_4d: Any, conn_pg: Any) -> int:
     selected = [k for k in _FACTURAS_COMPRA_MAPPING if k in queryable_lower]
 
     if not selected:
-        # No matching columns found — truncate and return 0
-        truncate_and_insert(conn_pg, "ps_facturas_compra", [], restart_identity=True)
-        return 0
+        # No matching columns found — fail fast to avoid silently wiping the
+        # target table on a schema/mapping mismatch.
+        expected = sorted(_FACTURAS_COMPRA_MAPPING.keys())
+        discovered = sorted(queryable)
+        raise RuntimeError(
+            "sync_facturas_compra: no expected columns found in source table "
+            "'FacturasCompra'. Expected at least one of: "
+            f"{expected}; discovered columns: {discovered}"
+        )
 
     sql = (
         "SELECT " + ", ".join(orig_case[k] for k in selected) + " FROM FacturasCompra"

--- a/etl/tests/test_sync_compras.py
+++ b/etl/tests/test_sync_compras.py
@@ -76,10 +76,22 @@ def synced_compras(conn_4d, conn_pg):
     Module-scoped so each full-refresh runs only once across all tests in this
     module.
     """
-    from etl.sync.compras import sync_compras, sync_lineas_compras
+    from etl.sync.compras import (
+        sync_albaranes,
+        sync_compras,
+        sync_facturas,
+        sync_facturas_compra,
+        sync_lineas_compras,
+    )
 
     compras_count = sync_compras(conn_4d, conn_pg)
     lineas_count = sync_lineas_compras(conn_4d, conn_pg)
+
+    # Exercise remaining sync functions to detect schema/mapping drift early.
+    sync_facturas(conn_4d, conn_pg)
+    sync_albaranes(conn_4d, conn_pg)
+    sync_facturas_compra(conn_4d, conn_pg)
+
     return compras_count, lineas_count
 
 


### PR DESCRIPTION
## Summary

- Implements `etl/sync/compras.py` with five full-refresh sync functions: `sync_compras`, `sync_lineas_compras`, `sync_facturas`, `sync_albaranes`, `sync_facturas_compra`
- Source table for purchase order lines is `CCLineasCompr` (not `LineasCompras` which does not exist)
- `sync_facturas_compra` uses `TRUNCATE ... RESTART IDENTITY` since `ps_facturas_compra` has a surrogate IDENTITY PK (no natural PK in 4D)
- PK/FK float values are converted to `decimal.Decimal` before PostgreSQL insert to prevent precision loss on `.99`-suffix values
- `sync_compras`, `sync_facturas`, `sync_albaranes` verify PK column existence via `_USER_COLUMNS` before querying and use `get_queryable_columns()` to skip type-0 columns

## Test plan

- [ ] `test_compras_count`: row count in `ps_compras` matches `COUNT(*) FROM Compras` (~2,700)
- [ ] `test_lineas_compras_count`: row count in `ps_lineas_compras` matches `COUNT(*) FROM CCLineasCompr` (~44,000)
- [ ] `test_lineas_fk`: no orphan `num_pedido` values in `ps_lineas_compras` (all exist in `ps_compras.reg_pedido`)
- [ ] All tests skip cleanly when `P4D_HOST` or PostgreSQL env vars are not set
- [ ] `ruff check` passes with no issues

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)