### PR TITLE
[P4] ETL scheduler + main.py orchestration

### DIFF
--- a/etl/main.py
+++ b/etl/main.py
@@ -1,10 +1,280 @@
-"""ETL main entry point. Sync modules will be wired here by P4."""
+"""ETL main orchestrator.
+
+Wires all sync modules into a single nightly pipeline with:
+- Topological execution order (catalog → masters → stock → ventas → mayorista → compras)
+- Per-table error handling (one failure does not stop the rest)
+- Watermark management (get/set via etl_watermarks table)
+- Schema initialisation from etl/schema/init.sql on first run
+- CLI: --once for a single run, or scheduler mode (daily at ETL_CRON_HOUR)
+
+Usage:
+    python -m etl.main --once       # run full sync once and exit
+    python -m etl.main              # run scheduler (daily at ETL_CRON_HOUR, default 2)
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
 import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s %(message)s",
+    level=logging.INFO,
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+logger = logging.getLogger("etl")
+
+# ---------------------------------------------------------------------------
+# Schema initialisation
+# ---------------------------------------------------------------------------
+
+_SCHEMA_SQL_PATH = Path(__file__).parent / "schema" / "init.sql"
 
 
-def main():
-    print("ETL: sync modules not yet wired. Run individual sync modules directly.")
-    sys.exit(0)
+def _init_schema(conn_pg) -> None:
+    """Execute etl/schema/init.sql against PostgreSQL (idempotent — IF NOT EXISTS)."""
+    sql = _SCHEMA_SQL_PATH.read_text(encoding="utf-8")
+    with conn_pg.cursor() as cur:
+        cur.execute(sql)
+    conn_pg.commit()
+    logger.info("Schema initialised (init.sql applied)")
+
+
+# ---------------------------------------------------------------------------
+# Per-table sync runner
+# ---------------------------------------------------------------------------
+
+
+def _run_sync(name: str, sync_fn, conn_4d, conn_pg, uses_watermark: bool = False) -> int:
+    """Run a single sync function with timing, watermark management, and error handling.
+
+    Returns the number of rows synced (0 on error).  Errors are logged but do
+    not propagate — the caller continues with the next table.
+    """
+    from etl.db.postgres import get_watermark, set_watermark
+
+    start = time.time()
+    try:
+        if uses_watermark:
+            since = get_watermark(conn_pg, name)
+            rows = sync_fn(conn_4d, conn_pg, since)
+        else:
+            rows = sync_fn(conn_4d, conn_pg)
+        duration_ms = int((time.time() - start) * 1000)
+        set_watermark(conn_pg, name, datetime.now(timezone.utc), rows, "ok")
+        logger.info("%s rows=%d duration_ms=%d", name, rows, duration_ms)
+        return rows
+    except Exception as exc:
+        duration_ms = int((time.time() - start) * 1000)
+        try:
+            set_watermark(conn_pg, name, datetime.now(timezone.utc), 0, "error", str(exc))
+        except Exception as wm_exc:
+            logger.error("Failed to write error watermark for %s: %s", name, wm_exc)
+        logger.error("%s FAILED duration_ms=%d: %s", name, duration_ms, exc)
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# sync_catalogos returns dict[str, int] — sum the values for the watermark row count
+# ---------------------------------------------------------------------------
+
+
+def _run_sync_catalogos(conn_4d, conn_pg) -> int:
+    """Wrap sync_catalogos (returns dict) so _run_sync can treat it uniformly."""
+    from etl.sync.articulos import sync_catalogos
+
+    result = sync_catalogos(conn_4d, conn_pg)
+    if isinstance(result, dict):
+        return sum(result.values())
+    return int(result)
+
+
+# ---------------------------------------------------------------------------
+# Full sync pipeline
+# ---------------------------------------------------------------------------
+
+
+def run_full_sync(conn_4d, conn_pg) -> None:
+    """Execute all sync tasks in topological order.
+
+    Errors in individual tables are caught and logged; execution continues.
+    """
+    from etl.sync.articulos import sync_articulos
+    from etl.sync.compras import (
+        sync_albaranes,
+        sync_compras,
+        sync_facturas,
+        sync_facturas_compra,
+        sync_lineas_compras,
+    )
+    from etl.sync.maestros import (
+        sync_clientes,
+        sync_gc_comerciales,
+        sync_proveedores,
+        sync_tiendas,
+    )
+    from etl.sync.mayorista import (
+        sync_gc_albaranes,
+        sync_gc_facturas,
+        sync_gc_lin_albarane,
+        sync_gc_lin_facturas,
+        sync_gc_lin_pedidos,
+        sync_gc_pedidos,
+    )
+    from etl.sync.stock import sync_stock, sync_traspasos
+    from etl.sync.ventas import sync_lineas_ventas, sync_pagos_ventas, sync_ventas
+
+    logger.info("=== Full sync started ===")
+    pipeline_start = time.time()
+
+    # ------------------------------------------------------------------
+    # 1. Catalog (full refresh, no watermark)
+    # ------------------------------------------------------------------
+    _run_sync("articulos", sync_articulos, conn_4d, conn_pg, uses_watermark=False)
+    # sync_catalogos returns a dict — delegate through wrapper
+    _run_sync("catalogos", _run_sync_catalogos, conn_4d, conn_pg, uses_watermark=False)
+
+    # ------------------------------------------------------------------
+    # 2. Masters (full refresh, no watermark)
+    # ------------------------------------------------------------------
+    _run_sync("tiendas", sync_tiendas, conn_4d, conn_pg, uses_watermark=False)
+    _run_sync("clientes", sync_clientes, conn_4d, conn_pg, uses_watermark=False)
+    _run_sync("proveedores", sync_proveedores, conn_4d, conn_pg, uses_watermark=False)
+    _run_sync("gc_comerciales", sync_gc_comerciales, conn_4d, conn_pg, uses_watermark=False)
+
+    # ------------------------------------------------------------------
+    # 3. Stock (delta by FechaModifica)
+    # ------------------------------------------------------------------
+    _run_sync("stock", sync_stock, conn_4d, conn_pg, uses_watermark=True)
+    _run_sync("traspasos", sync_traspasos, conn_4d, conn_pg, uses_watermark=True)
+
+    # ------------------------------------------------------------------
+    # 4. Retail sales (delta by FechaModifica)
+    # ------------------------------------------------------------------
+    _run_sync("ventas", sync_ventas, conn_4d, conn_pg, uses_watermark=True)
+    _run_sync("lineas_ventas", sync_lineas_ventas, conn_4d, conn_pg, uses_watermark=True)
+    _run_sync("pagos_ventas", sync_pagos_ventas, conn_4d, conn_pg, uses_watermark=True)
+
+    # ------------------------------------------------------------------
+    # 5. Wholesale (delta by Modifica for headers; full for pedidos lines)
+    # ------------------------------------------------------------------
+    _run_sync("gc_albaranes", sync_gc_albaranes, conn_4d, conn_pg, uses_watermark=True)
+    _run_sync("gc_lin_albarane", sync_gc_lin_albarane, conn_4d, conn_pg, uses_watermark=True)
+    _run_sync("gc_facturas", sync_gc_facturas, conn_4d, conn_pg, uses_watermark=True)
+    _run_sync("gc_lin_facturas", sync_gc_lin_facturas, conn_4d, conn_pg, uses_watermark=True)
+    _run_sync("gc_pedidos", sync_gc_pedidos, conn_4d, conn_pg, uses_watermark=False)
+    _run_sync("gc_lin_pedidos", sync_gc_lin_pedidos, conn_4d, conn_pg, uses_watermark=False)
+
+    # ------------------------------------------------------------------
+    # 6. Purchasing (full refresh)
+    # ------------------------------------------------------------------
+    _run_sync("compras", sync_compras, conn_4d, conn_pg, uses_watermark=False)
+    _run_sync("lineas_compras", sync_lineas_compras, conn_4d, conn_pg, uses_watermark=False)
+    _run_sync("facturas", sync_facturas, conn_4d, conn_pg, uses_watermark=False)
+    _run_sync("albaranes", sync_albaranes, conn_4d, conn_pg, uses_watermark=False)
+    _run_sync("facturas_compra", sync_facturas_compra, conn_4d, conn_pg, uses_watermark=False)
+
+    total_ms = int((time.time() - pipeline_start) * 1000)
+    logger.info("=== Full sync completed in %d ms ===", total_ms)
+
+
+# ---------------------------------------------------------------------------
+# Connection test
+# ---------------------------------------------------------------------------
+
+
+def _test_connections(config) -> tuple:
+    """Attempt to connect to both 4D and PostgreSQL.  Exit(1) on failure.
+
+    Returns (conn_4d, conn_pg) on success.
+    """
+    from etl.db import fourd, postgres
+
+    conn_4d = None
+    conn_pg = None
+
+    logger.info("Testing 4D connection to %s:%d ...", config.p4d_host, config.p4d_port)
+    try:
+        conn_4d = fourd.get_connection(config)
+        logger.info("4D connection OK")
+    except Exception as exc:
+        logger.error("Cannot connect to 4D: %s", exc)
+        sys.exit(1)
+
+    logger.info("Testing PostgreSQL connection ...")
+    try:
+        conn_pg = postgres.get_connection(config)
+        logger.info("PostgreSQL connection OK")
+    except Exception as exc:
+        logger.error("Cannot connect to PostgreSQL: %s", exc)
+        if conn_4d is not None:
+            conn_4d.close()
+        sys.exit(1)
+
+    return conn_4d, conn_pg
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="PowerShop ETL orchestrator")
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run a single full sync and exit (default: run scheduler)",
+    )
+    args = parser.parse_args()
+
+    from etl.config import Config
+
+    try:
+        config = Config()
+    except ValueError as exc:
+        logger.error("Configuration error: %s", exc)
+        sys.exit(1)
+
+    cron_hour = int(os.environ.get("ETL_CRON_HOUR", "2"))
+
+    conn_4d, conn_pg = _test_connections(config)
+
+    try:
+        _init_schema(conn_pg)
+
+        if args.once:
+            run_full_sync(conn_4d, conn_pg)
+        else:
+            import schedule
+
+            logger.info("Scheduler mode: daily sync at %02d:00", cron_hour)
+
+            def _job() -> None:
+                run_full_sync(conn_4d, conn_pg)
+
+            schedule.every().day.at(f"{cron_hour:02d}:00").do(_job)
+
+            # Run immediately on first start so we do not wait until 02:00
+            logger.info("Running initial sync on startup ...")
+            _job()
+
+            while True:
+                schedule.run_pending()
+                time.sleep(60)
+    finally:
+        try:
+            conn_4d.close()
+        except Exception:
+            pass
+        try:
+            conn_pg.close()
+        except Exception:
+            pass
 
 
 if __name__ == "__main__":

--- a/etl/tests/test_scheduler.py
+++ b/etl/tests/test_scheduler.py
@@ -1,0 +1,214 @@
+"""Unit tests for etl/main.py orchestrator.
+
+No real database connections are needed — all sync functions and watermark
+helpers are mocked via unittest.mock.
+
+Test coverage:
+- test_sync_order          : All sync functions are called in the correct
+                             topological order (catalog → masters → stock →
+                             ventas → mayorista → compras).
+- test_error_continues     : A failure in one sync function does not prevent
+                             subsequent functions from running.
+- test_watermark_not_updated_on_error : When a sync function raises, set_watermark
+                             is called with status='error' and rows_synced=0.
+"""
+from __future__ import annotations
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+_WM_MODULE = "etl.db.postgres"
+
+# All sync targets that must be patched in every test, keyed by dotted path.
+_SYNC_TARGETS = [
+    "etl.sync.articulos.sync_articulos",
+    "etl.sync.articulos.sync_catalogos",
+    "etl.sync.maestros.sync_tiendas",
+    "etl.sync.maestros.sync_clientes",
+    "etl.sync.maestros.sync_proveedores",
+    "etl.sync.maestros.sync_gc_comerciales",
+    "etl.sync.stock.sync_stock",
+    "etl.sync.stock.sync_traspasos",
+    "etl.sync.ventas.sync_ventas",
+    "etl.sync.ventas.sync_lineas_ventas",
+    "etl.sync.ventas.sync_pagos_ventas",
+    "etl.sync.mayorista.sync_gc_albaranes",
+    "etl.sync.mayorista.sync_gc_lin_albarane",
+    "etl.sync.mayorista.sync_gc_facturas",
+    "etl.sync.mayorista.sync_gc_lin_facturas",
+    "etl.sync.mayorista.sync_gc_pedidos",
+    "etl.sync.mayorista.sync_gc_lin_pedidos",
+    "etl.sync.compras.sync_compras",
+    "etl.sync.compras.sync_lineas_compras",
+    "etl.sync.compras.sync_facturas",
+    "etl.sync.compras.sync_albaranes",
+    "etl.sync.compras.sync_facturas_compra",
+]
+
+# Short name derived from the dotted path (last segment).
+_SHORT_NAMES = [t.rsplit(".", 1)[-1] for t in _SYNC_TARGETS]
+
+
+def _make_conn():
+    return MagicMock()
+
+
+def _apply_patches(stack: ExitStack, side_effects: dict) -> dict:
+    """Enter all sync patches + watermark patches into *stack*.
+
+    *side_effects* maps short function name to a callable side_effect or a
+    return_value (int/dict).  Targets not in *side_effects* default to
+    ``return_value=0`` (except sync_catalogos which defaults to ``return_value={}``).
+
+    Returns a dict mapping short name → mock object.
+    """
+    mocks: dict[str, MagicMock] = {}
+    for target, name in zip(_SYNC_TARGETS, _SHORT_NAMES):
+        effect = side_effects.get(name)
+        if callable(effect) and not isinstance(effect, MagicMock):
+            m = stack.enter_context(patch(target, side_effect=effect))
+        elif isinstance(effect, MagicMock):
+            m = stack.enter_context(patch(target, effect))
+        else:
+            default = {} if name == "sync_catalogos" else 0
+            rv = side_effects.get(name, default)
+            m = stack.enter_context(patch(target, return_value=rv))
+        mocks[name] = m
+
+    mocks["get_watermark"] = stack.enter_context(
+        patch(f"{_WM_MODULE}.get_watermark", return_value=None)
+    )
+    mocks["set_watermark"] = stack.enter_context(
+        patch(f"{_WM_MODULE}.set_watermark")
+    )
+    return mocks
+
+
+# ---------------------------------------------------------------------------
+# Test: execution order
+# ---------------------------------------------------------------------------
+
+
+def test_sync_order():
+    """All sync functions are invoked in the required topological order."""
+    conn_4d = _make_conn()
+    conn_pg = _make_conn()
+    call_order: list[str] = []
+
+    def _tracker(name):
+        def _fn(*args, **kwargs):
+            call_order.append(name)
+            return {} if name == "sync_catalogos" else 0
+        return _fn
+
+    side_effects = {name: _tracker(name) for name in _SHORT_NAMES}
+
+    with ExitStack() as stack:
+        _apply_patches(stack, side_effects)
+        from etl.main import run_full_sync
+        run_full_sync(conn_4d, conn_pg)
+
+    expected_order = [
+        # Catalog
+        "sync_articulos",
+        "sync_catalogos",
+        # Masters
+        "sync_tiendas",
+        "sync_clientes",
+        "sync_proveedores",
+        "sync_gc_comerciales",
+        # Stock
+        "sync_stock",
+        "sync_traspasos",
+        # Retail sales
+        "sync_ventas",
+        "sync_lineas_ventas",
+        "sync_pagos_ventas",
+        # Wholesale
+        "sync_gc_albaranes",
+        "sync_gc_lin_albarane",
+        "sync_gc_facturas",
+        "sync_gc_lin_facturas",
+        "sync_gc_pedidos",
+        "sync_gc_lin_pedidos",
+        # Purchasing
+        "sync_compras",
+        "sync_lineas_compras",
+        "sync_facturas",
+        "sync_albaranes",
+        "sync_facturas_compra",
+    ]
+    assert call_order == expected_order
+
+
+# ---------------------------------------------------------------------------
+# Test: error in one table does not stop the rest
+# ---------------------------------------------------------------------------
+
+
+def test_error_continues():
+    """A failure in sync_ventas does not prevent subsequent tables from running."""
+    conn_4d = _make_conn()
+    conn_pg = _make_conn()
+    called: list[str] = []
+
+    def _tracker(name):
+        def _fn(*args, **kwargs):
+            called.append(name)
+            return {} if name == "sync_catalogos" else 0
+        return _fn
+
+    def _ventas_boom(*args, **kwargs):
+        called.append("sync_ventas")
+        raise RuntimeError("simulated ventas failure")
+
+    side_effects = {name: _tracker(name) for name in _SHORT_NAMES}
+    side_effects["sync_ventas"] = _ventas_boom
+
+    with ExitStack() as stack:
+        _apply_patches(stack, side_effects)
+        from etl.main import run_full_sync
+        run_full_sync(conn_4d, conn_pg)
+
+    # ventas failed, but everything after it should still have run
+    assert "sync_ventas" in called
+    assert "sync_lineas_ventas" in called
+    assert "sync_pagos_ventas" in called
+    assert "sync_gc_albaranes" in called
+    assert "sync_compras" in called
+    assert "sync_facturas_compra" in called
+
+
+# ---------------------------------------------------------------------------
+# Test: watermark written with status='error' on failure
+# ---------------------------------------------------------------------------
+
+
+def test_watermark_not_updated_on_error():
+    """When a sync function raises, set_watermark is called with status='error' and rows_synced=0."""
+    conn_4d = _make_conn()
+    conn_pg = _make_conn()
+
+    def _articulos_boom(*args, **kwargs):
+        raise ValueError("simulated articulos error")
+
+    side_effects = {"sync_articulos": _articulos_boom}
+
+    with ExitStack() as stack:
+        mocks = _apply_patches(stack, side_effects)
+        mock_set_wm = mocks["set_watermark"]
+        from etl.main import run_full_sync
+        run_full_sync(conn_4d, conn_pg)
+
+    # set_watermark(conn_pg, table_name, last_sync_at, rows_synced, status, error_msg)
+    # args[0]=conn_pg, args[1]=table_name, args[2]=last_sync_at,
+    # args[3]=rows_synced, args[4]=status, args[5]=error_msg
+    articulos_calls = [c for c in mock_set_wm.call_args_list if c.args[1] == "articulos"]
+    assert articulos_calls, "set_watermark was not called for 'articulos'"
+
+    error_call = articulos_calls[0]
+    args = error_call.args
+    assert args[3] == 0, f"Expected rows_synced=0, got {args[3]}"
+    assert args[4] == "error", f"Expected status='error', got {args[4]!r}"
+    assert len(args) > 5, "set_watermark was not called with error_msg"
+    assert "simulated articulos error" in args[5]


### PR DESCRIPTION
## Summary

- Replaces the `etl/main.py` stub with a complete orchestrator that wires all sync modules in correct topological order: catalog → masters → stock → retail sales → wholesale → purchasing
- Per-table error handling: a failure in any table is caught, logged, and the error watermark is recorded; execution continues with the next table
- Schema initialisation: `etl/schema/init.sql` is applied on every startup (idempotent `CREATE TABLE IF NOT EXISTS`)
- CLI: `--once` for a single run; default mode runs `schedule` daily at `ETL_CRON_HOUR` (default `2`) with an immediate sync on startup
- Connection tests at startup: exits with code 1 if either 4D or PostgreSQL is unreachable
- Adds `etl/tests/test_scheduler.py` with 3 unit tests (no real connections): execution order, error continuation, error-state watermark

Closes #28

## Test plan

- [x] `ruff check etl/main.py etl/tests/test_scheduler.py` — clean
- [x] `pytest etl/tests/test_scheduler.py -v` — 3/3 passed
- [ ] Integration: `python -m etl.main --once` with real connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)