### PR TITLE
[P5] WrenAI MDL: complete semantic model

### DIFF
--- a/wren/mdl/model.json
+++ b/wren/mdl/model.json
@@ -1,0 +1,1912 @@
+{
+  "catalog": "powershop",
+  "schema": "public",
+  "dataSource": "POSTGRES",
+  "models": [
+    {
+      "name": "Producto",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_articulos"
+      },
+      "primaryKey": "reg_articulo",
+      "columns": [
+        {
+          "name": "reg_articulo",
+          "type": "NUMERIC",
+          "expression": "reg_articulo",
+          "properties": {"description": "ID interno del artículo (clave primaria)"}
+        },
+        {
+          "name": "codigo",
+          "type": "VARCHAR",
+          "expression": "codigo",
+          "properties": {"description": "Código de artículo"}
+        },
+        {
+          "name": "ccrefejofacm",
+          "type": "VARCHAR",
+          "expression": "ccrefejofacm",
+          "properties": {"description": "Referencia comercial — identificador principal de negocio (e.g. V26212484). Prefijo M = mayorista, sin M = retail"}
+        },
+        {
+          "name": "descripcion",
+          "type": "VARCHAR",
+          "expression": "descripcion",
+          "properties": {"description": "Descripción del artículo"}
+        },
+        {
+          "name": "codigo_barra",
+          "type": "VARCHAR",
+          "expression": "codigo_barra",
+          "properties": {"description": "Código de barras EAN"}
+        },
+        {
+          "name": "num_familia",
+          "type": "NUMERIC",
+          "expression": "num_familia",
+          "properties": {"description": "FK → Familia (reg_familia)"}
+        },
+        {
+          "name": "num_departament",
+          "type": "NUMERIC",
+          "expression": "num_departament",
+          "properties": {"description": "FK → Departamento (reg_departament)"}
+        },
+        {
+          "name": "num_color",
+          "type": "NUMERIC",
+          "expression": "num_color",
+          "properties": {"description": "FK → Color (reg_color)"}
+        },
+        {
+          "name": "num_temporada",
+          "type": "NUMERIC",
+          "expression": "num_temporada",
+          "properties": {"description": "FK → Temporada (reg_temporada)"}
+        },
+        {
+          "name": "num_marca",
+          "type": "NUMERIC",
+          "expression": "num_marca",
+          "properties": {"description": "FK → Marca (reg_marca)"}
+        },
+        {
+          "name": "num_proveedor",
+          "type": "NUMERIC",
+          "expression": "num_proveedor",
+          "properties": {"description": "FK → Proveedor (reg_proveedor)"}
+        },
+        {
+          "name": "precio_coste",
+          "type": "NUMERIC",
+          "expression": "precio_coste",
+          "properties": {"description": "Precio de coste del artículo"}
+        },
+        {
+          "name": "pr_coste_ne",
+          "type": "NUMERIC",
+          "expression": "pr_coste_ne",
+          "properties": {"description": "Precio de coste neto sin IVA"}
+        },
+        {
+          "name": "p_iva",
+          "type": "NUMERIC",
+          "expression": "p_iva",
+          "properties": {"description": "Porcentaje de IVA aplicable"}
+        },
+        {
+          "name": "anulado",
+          "type": "BOOLEAN",
+          "expression": "anulado",
+          "properties": {"description": "Indica si el artículo está anulado/inactivo"}
+        },
+        {
+          "name": "fecha_creacion",
+          "type": "DATE",
+          "expression": "fecha_creacion",
+          "properties": {"description": "Fecha de creación del artículo"}
+        },
+        {
+          "name": "fecha_modifica",
+          "type": "DATE",
+          "expression": "fecha_modifica",
+          "properties": {"description": "Fecha de última modificación"}
+        },
+        {
+          "name": "color",
+          "type": "VARCHAR",
+          "expression": "color",
+          "properties": {"description": "Descripción de color (campo textual)"}
+        },
+        {
+          "name": "clave_temporada",
+          "type": "VARCHAR",
+          "expression": "clave_temporada",
+          "properties": {"description": "Clave de temporada (campo textual)"}
+        },
+        {
+          "name": "modelo",
+          "type": "VARCHAR",
+          "expression": "modelo",
+          "properties": {"description": "Modelo del artículo"}
+        },
+        {
+          "name": "sexo",
+          "type": "VARCHAR",
+          "expression": "sexo",
+          "properties": {"description": "Género al que va destinado el artículo"}
+        },
+        {
+          "name": "es_mayorista",
+          "type": "BOOLEAN",
+          "isCalculated": true,
+          "expression": "LEFT(ccrefejofacm, 1) = 'M'",
+          "properties": {"description": "true si la referencia comercial empieza por M (línea mayorista)"}
+        }
+      ],
+      "properties": {"description": "Catálogo de productos y artículos"}
+    },
+    {
+      "name": "Familia",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_familias"
+      },
+      "primaryKey": "reg_familia",
+      "columns": [
+        {
+          "name": "reg_familia",
+          "type": "NUMERIC",
+          "expression": "reg_familia",
+          "properties": {"description": "ID interno de la familia (clave primaria)"}
+        },
+        {
+          "name": "clave",
+          "type": "VARCHAR",
+          "expression": "clave",
+          "properties": {"description": "Clave / nombre de la familia"}
+        },
+        {
+          "name": "fami_grup_marc",
+          "type": "VARCHAR",
+          "expression": "fami_grup_marc",
+          "properties": {"description": "Grupo de marca asociado a la familia"}
+        },
+        {
+          "name": "coeficiente1",
+          "type": "NUMERIC",
+          "expression": "coeficiente1",
+          "properties": {"description": "Coeficiente de margen 1"}
+        },
+        {
+          "name": "coeficiente2",
+          "type": "NUMERIC",
+          "expression": "coeficiente2",
+          "properties": {"description": "Coeficiente de margen 2"}
+        },
+        {
+          "name": "cuenta_ventas",
+          "type": "VARCHAR",
+          "expression": "cuenta_ventas",
+          "properties": {"description": "Cuenta contable de ventas"}
+        },
+        {
+          "name": "presupuesto",
+          "type": "NUMERIC",
+          "expression": "presupuesto",
+          "properties": {"description": "Presupuesto de ventas de la familia"}
+        },
+        {
+          "name": "anulado",
+          "type": "BOOLEAN",
+          "expression": "anulado",
+          "properties": {"description": "Indica si la familia está anulada"}
+        },
+        {
+          "name": "serie_tallas",
+          "type": "VARCHAR",
+          "expression": "serie_tallas",
+          "properties": {"description": "Serie de tallas asociada a la familia"}
+        },
+        {
+          "name": "clave_seccion",
+          "type": "VARCHAR",
+          "expression": "clave_seccion",
+          "properties": {"description": "Clave de sección"}
+        }
+      ],
+      "properties": {"description": "Familias de productos (nivel de clasificación intermedio)"}
+    },
+    {
+      "name": "Color",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_colores"
+      },
+      "primaryKey": "reg_color",
+      "columns": [
+        {
+          "name": "reg_color",
+          "type": "NUMERIC",
+          "expression": "reg_color",
+          "properties": {"description": "ID interno del color (clave primaria)"}
+        },
+        {
+          "name": "clave",
+          "type": "VARCHAR",
+          "expression": "clave",
+          "properties": {"description": "Clave / código del color"}
+        },
+        {
+          "name": "color",
+          "type": "VARCHAR",
+          "expression": "color",
+          "properties": {"description": "Nombre descriptivo del color"}
+        }
+      ],
+      "properties": {"description": "Catálogo de colores de artículos"}
+    },
+    {
+      "name": "Temporada",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_temporadas"
+      },
+      "primaryKey": "reg_temporada",
+      "columns": [
+        {
+          "name": "reg_temporada",
+          "type": "NUMERIC",
+          "expression": "reg_temporada",
+          "properties": {"description": "ID interno de la temporada (clave primaria)"}
+        },
+        {
+          "name": "clave",
+          "type": "VARCHAR",
+          "expression": "clave",
+          "properties": {"description": "Clave / nombre de la temporada (e.g. PV2025, OI2024)"}
+        },
+        {
+          "name": "temporada_tipo",
+          "type": "VARCHAR",
+          "expression": "temporada_tipo",
+          "properties": {"description": "Tipo de temporada (primavera-verano, otoño-invierno, etc.)"}
+        },
+        {
+          "name": "temporada_activ",
+          "type": "BOOLEAN",
+          "expression": "temporada_activ",
+          "properties": {"description": "Indica si la temporada está activa"}
+        },
+        {
+          "name": "inicio_ventas",
+          "type": "DATE",
+          "expression": "inicio_ventas",
+          "properties": {"description": "Fecha de inicio del período de ventas"}
+        },
+        {
+          "name": "fin_ventas",
+          "type": "DATE",
+          "expression": "fin_ventas",
+          "properties": {"description": "Fecha de fin del período de ventas"}
+        },
+        {
+          "name": "inicio_rebajas",
+          "type": "DATE",
+          "expression": "inicio_rebajas",
+          "properties": {"description": "Fecha de inicio del período de rebajas"}
+        },
+        {
+          "name": "fin_rebajas",
+          "type": "DATE",
+          "expression": "fin_rebajas",
+          "properties": {"description": "Fecha de fin del período de rebajas"}
+        }
+      ],
+      "properties": {"description": "Temporadas comerciales de la colección"}
+    },
+    {
+      "name": "Departamento",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_departamentos"
+      },
+      "primaryKey": "reg_departament",
+      "columns": [
+        {
+          "name": "reg_departament",
+          "type": "NUMERIC",
+          "expression": "reg_departament",
+          "properties": {"description": "ID interno del departamento (clave primaria)"}
+        },
+        {
+          "name": "clave",
+          "type": "VARCHAR",
+          "expression": "clave",
+          "properties": {"description": "Clave / nombre del departamento"}
+        },
+        {
+          "name": "depa_secc_fabr",
+          "type": "VARCHAR",
+          "expression": "depa_secc_fabr",
+          "properties": {"description": "Sección de fabricación del departamento"}
+        },
+        {
+          "name": "jo_iva",
+          "type": "NUMERIC",
+          "expression": "jo_iva",
+          "properties": {"description": "Tipo de IVA por defecto del departamento"}
+        },
+        {
+          "name": "presupuesto",
+          "type": "NUMERIC",
+          "expression": "presupuesto",
+          "properties": {"description": "Presupuesto de ventas del departamento"}
+        },
+        {
+          "name": "anulado",
+          "type": "BOOLEAN",
+          "expression": "anulado",
+          "properties": {"description": "Indica si el departamento está anulado"}
+        }
+      ],
+      "properties": {"description": "Departamentos de producto (nivel superior de clasificación)"}
+    },
+    {
+      "name": "Marca",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_marcas"
+      },
+      "primaryKey": "reg_marca",
+      "columns": [
+        {
+          "name": "reg_marca",
+          "type": "NUMERIC",
+          "expression": "reg_marca",
+          "properties": {"description": "ID interno de la marca (clave primaria)"}
+        },
+        {
+          "name": "clave",
+          "type": "VARCHAR",
+          "expression": "clave",
+          "properties": {"description": "Clave / nombre de la marca"}
+        },
+        {
+          "name": "marca_tratamien",
+          "type": "VARCHAR",
+          "expression": "marca_tratamien",
+          "properties": {"description": "Tratamiento o categoría de la marca"}
+        },
+        {
+          "name": "presupuesto",
+          "type": "NUMERIC",
+          "expression": "presupuesto",
+          "properties": {"description": "Presupuesto de ventas de la marca"}
+        },
+        {
+          "name": "descuento_compra",
+          "type": "NUMERIC",
+          "expression": "descuento_compra",
+          "properties": {"description": "Descuento de compra habitual de la marca (%)"}
+        }
+      ],
+      "properties": {"description": "Marcas de los artículos"}
+    },
+    {
+      "name": "Tienda",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_tiendas"
+      },
+      "primaryKey": "codigo",
+      "columns": [
+        {
+          "name": "reg_tienda",
+          "type": "NUMERIC",
+          "expression": "reg_tienda",
+          "properties": {"description": "ID interno de la tienda"}
+        },
+        {
+          "name": "codigo",
+          "type": "VARCHAR",
+          "expression": "codigo",
+          "properties": {"description": "Código de tienda (TEXT) — código 99 = almacén central, 97 = tienda online"}
+        },
+        {
+          "name": "fecha_modifica",
+          "type": "DATE",
+          "expression": "fecha_modifica",
+          "properties": {"description": "Fecha de última modificación del registro de tienda"}
+        }
+      ],
+      "properties": {"description": "Tiendas y puntos de venta. Código 99 = almacén central, 97 = tienda online"}
+    },
+    {
+      "name": "Cliente",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_clientes"
+      },
+      "primaryKey": "reg_cliente",
+      "columns": [
+        {
+          "name": "reg_cliente",
+          "type": "NUMERIC",
+          "expression": "reg_cliente",
+          "properties": {"description": "ID interno del cliente (clave primaria)"}
+        },
+        {
+          "name": "num_cliente",
+          "type": "NUMERIC",
+          "expression": "num_cliente",
+          "properties": {"description": "Número de cliente — num_cliente = 0 son ventas anónimas de caja"}
+        },
+        {
+          "name": "nombre",
+          "type": "VARCHAR",
+          "expression": "nombre",
+          "properties": {"description": "Nombre del cliente"}
+        },
+        {
+          "name": "nif",
+          "type": "VARCHAR",
+          "expression": "nif",
+          "properties": {"description": "NIF / CIF del cliente"}
+        },
+        {
+          "name": "email",
+          "type": "VARCHAR",
+          "expression": "email",
+          "properties": {"description": "Dirección de correo electrónico del cliente"}
+        },
+        {
+          "name": "codigo_postal",
+          "type": "VARCHAR",
+          "expression": "codigo_postal",
+          "properties": {"description": "Código postal del cliente"}
+        },
+        {
+          "name": "poblacion",
+          "type": "VARCHAR",
+          "expression": "poblacion",
+          "properties": {"description": "Población / ciudad del cliente"}
+        },
+        {
+          "name": "pais",
+          "type": "VARCHAR",
+          "expression": "pais",
+          "properties": {"description": "País del cliente"}
+        },
+        {
+          "name": "fecha_creacion",
+          "type": "DATE",
+          "expression": "fecha_creacion",
+          "properties": {"description": "Fecha de alta del cliente"}
+        },
+        {
+          "name": "fecha_modifica",
+          "type": "DATE",
+          "expression": "fecha_modifica",
+          "properties": {"description": "Fecha de última modificación del cliente"}
+        },
+        {
+          "name": "ultima_compra_f",
+          "type": "DATE",
+          "expression": "ultima_compra_f",
+          "properties": {"description": "Fecha de la última compra del cliente"}
+        }
+      ],
+      "properties": {"description": "Clientes. num_cliente = 0 son ventas anónimas de caja (sin identificar)"}
+    },
+    {
+      "name": "Proveedor",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_proveedores"
+      },
+      "primaryKey": "reg_proveedor",
+      "columns": [
+        {
+          "name": "reg_proveedor",
+          "type": "NUMERIC",
+          "expression": "reg_proveedor",
+          "properties": {"description": "ID interno del proveedor (clave primaria)"}
+        },
+        {
+          "name": "nombre",
+          "type": "VARCHAR",
+          "expression": "nombre",
+          "properties": {"description": "Nombre del proveedor"}
+        },
+        {
+          "name": "nif",
+          "type": "VARCHAR",
+          "expression": "nif",
+          "properties": {"description": "NIF / CIF del proveedor"}
+        },
+        {
+          "name": "pais",
+          "type": "VARCHAR",
+          "expression": "pais",
+          "properties": {"description": "País del proveedor"}
+        },
+        {
+          "name": "f_modifica",
+          "type": "DATE",
+          "expression": "f_modifica",
+          "properties": {"description": "Fecha de última modificación del proveedor"}
+        }
+      ],
+      "properties": {"description": "Proveedores de mercancía"}
+    },
+    {
+      "name": "Comercial",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_gc_comerciales"
+      },
+      "primaryKey": "reg_comercial",
+      "columns": [
+        {
+          "name": "reg_comercial",
+          "type": "NUMERIC",
+          "expression": "reg_comercial",
+          "properties": {"description": "ID interno del comercial (clave primaria)"}
+        },
+        {
+          "name": "comercial",
+          "type": "VARCHAR",
+          "expression": "comercial",
+          "properties": {"description": "Nombre del agente comercial"}
+        },
+        {
+          "name": "cif",
+          "type": "VARCHAR",
+          "expression": "cif",
+          "properties": {"description": "CIF / NIF del comercial"}
+        },
+        {
+          "name": "zona_comercial",
+          "type": "VARCHAR",
+          "expression": "zona_comercial",
+          "properties": {"description": "Zona geográfica asignada al comercial"}
+        },
+        {
+          "name": "comision1",
+          "type": "NUMERIC",
+          "expression": "comision1",
+          "properties": {"description": "Comisión base (%)"}
+        },
+        {
+          "name": "comision2",
+          "type": "NUMERIC",
+          "expression": "comision2",
+          "properties": {"description": "Comisión adicional (%)"}
+        },
+        {
+          "name": "email",
+          "type": "VARCHAR",
+          "expression": "email",
+          "properties": {"description": "Correo electrónico del comercial"}
+        },
+        {
+          "name": "movil",
+          "type": "VARCHAR",
+          "expression": "movil",
+          "properties": {"description": "Teléfono móvil del comercial"}
+        }
+      ],
+      "properties": {"description": "Agentes comerciales de mayorista (Gestión Comercial)"}
+    },
+    {
+      "name": "Venta",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_ventas"
+      },
+      "primaryKey": "reg_ventas",
+      "columns": [
+        {
+          "name": "reg_ventas",
+          "type": "NUMERIC",
+          "expression": "reg_ventas",
+          "properties": {"description": "ID interno de la venta / ticket (clave primaria)"}
+        },
+        {
+          "name": "n_documento",
+          "type": "NUMERIC",
+          "expression": "n_documento",
+          "properties": {"description": "Número de documento fiscal"}
+        },
+        {
+          "name": "serie_v",
+          "type": "INTEGER",
+          "expression": "serie_v",
+          "properties": {"description": "Serie de la venta (numeración por tienda)"}
+        },
+        {
+          "name": "tienda",
+          "type": "VARCHAR",
+          "expression": "tienda",
+          "properties": {"description": "Código de tienda donde se realizó la venta"}
+        },
+        {
+          "name": "fecha_creacion",
+          "type": "DATE",
+          "expression": "fecha_creacion",
+          "properties": {"description": "Fecha de la venta"}
+        },
+        {
+          "name": "fecha_modifica",
+          "type": "DATE",
+          "expression": "fecha_modifica",
+          "properties": {"description": "Fecha de última modificación del ticket"}
+        },
+        {
+          "name": "total_si",
+          "type": "NUMERIC",
+          "expression": "total_si",
+          "properties": {"description": "Importe sin IVA — SIEMPRE usar este campo para análisis económico"}
+        },
+        {
+          "name": "total",
+          "type": "NUMERIC",
+          "expression": "total",
+          "properties": {"description": "Importe CON IVA — NO usar para análisis comparativo entre regiones"}
+        },
+        {
+          "name": "num_cliente",
+          "type": "NUMERIC",
+          "expression": "num_cliente",
+          "properties": {"description": "FK → Cliente (num_cliente). Valor 0 = venta anónima de caja"}
+        },
+        {
+          "name": "codigo_cajero",
+          "type": "VARCHAR",
+          "expression": "codigo_cajero",
+          "properties": {"description": "Código del cajero que realizó la venta"}
+        },
+        {
+          "name": "cajero_nombre",
+          "type": "VARCHAR",
+          "expression": "cajero_nombre",
+          "properties": {"description": "Nombre del cajero"}
+        },
+        {
+          "name": "tipo_venta",
+          "type": "VARCHAR",
+          "expression": "tipo_venta",
+          "properties": {"description": "Tipo de venta (contado, crédito, etc.)"}
+        },
+        {
+          "name": "tipo_documento",
+          "type": "VARCHAR",
+          "expression": "tipo_documento",
+          "properties": {"description": "Tipo de documento (ticket, factura, abono, etc.)"}
+        },
+        {
+          "name": "forma",
+          "type": "VARCHAR",
+          "expression": "forma",
+          "properties": {"description": "Forma de pago principal"}
+        },
+        {
+          "name": "entrada",
+          "type": "BOOLEAN",
+          "expression": "entrada",
+          "properties": {"description": "Indica si el ticket es una entrada (devolución o depósito)"}
+        },
+        {
+          "name": "pendiente",
+          "type": "BOOLEAN",
+          "expression": "pendiente",
+          "properties": {"description": "Indica si el ticket está pendiente de cobro"}
+        },
+        {
+          "name": "pedido_web",
+          "type": "VARCHAR",
+          "expression": "pedido_web",
+          "properties": {"description": "Número de pedido web (ventas online)"}
+        }
+      ],
+      "properties": {"description": "Cabeceras de venta retail (tickets de caja). Una venta = un ticket"}
+    },
+    {
+      "name": "LineaVenta",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_lineas_ventas"
+      },
+      "primaryKey": "reg_lineas",
+      "columns": [
+        {
+          "name": "reg_lineas",
+          "type": "NUMERIC",
+          "expression": "reg_lineas",
+          "properties": {"description": "ID interno de la línea de venta (clave primaria)"}
+        },
+        {
+          "name": "num_ventas",
+          "type": "NUMERIC",
+          "expression": "num_ventas",
+          "properties": {"description": "FK → Venta (reg_ventas)"}
+        },
+        {
+          "name": "n_documento",
+          "type": "NUMERIC",
+          "expression": "n_documento",
+          "properties": {"description": "Número de documento fiscal del ticket"}
+        },
+        {
+          "name": "mes",
+          "type": "INTEGER",
+          "expression": "mes",
+          "properties": {"description": "Mes de la venta (1-12)"}
+        },
+        {
+          "name": "tienda",
+          "type": "VARCHAR",
+          "expression": "tienda",
+          "properties": {"description": "Código de tienda de la línea"}
+        },
+        {
+          "name": "codigo",
+          "type": "VARCHAR",
+          "expression": "codigo",
+          "properties": {"description": "Código del artículo vendido (FK → Producto.codigo)"}
+        },
+        {
+          "name": "descripcion",
+          "type": "VARCHAR",
+          "expression": "descripcion",
+          "properties": {"description": "Descripción del artículo en el momento de la venta"}
+        },
+        {
+          "name": "unidades",
+          "type": "NUMERIC",
+          "expression": "unidades",
+          "properties": {"description": "Unidades vendidas (negativo = devolución)"}
+        },
+        {
+          "name": "precio_neto_si",
+          "type": "NUMERIC",
+          "expression": "precio_neto_si",
+          "properties": {"description": "Precio unitario neto sin IVA"}
+        },
+        {
+          "name": "total_si",
+          "type": "NUMERIC",
+          "expression": "total_si",
+          "properties": {"description": "Importe total de la línea sin IVA"}
+        },
+        {
+          "name": "precio_coste_ci",
+          "type": "NUMERIC",
+          "expression": "precio_coste_ci",
+          "properties": {"description": "Precio de coste con IVA"}
+        },
+        {
+          "name": "total_coste_si",
+          "type": "NUMERIC",
+          "expression": "total_coste_si",
+          "properties": {"description": "Coste total de la línea sin IVA"}
+        },
+        {
+          "name": "fecha_creacion",
+          "type": "DATE",
+          "expression": "fecha_creacion",
+          "properties": {"description": "Fecha de creación de la línea"}
+        },
+        {
+          "name": "fecha_modifica",
+          "type": "DATE",
+          "expression": "fecha_modifica",
+          "properties": {"description": "Fecha de última modificación"}
+        }
+      ],
+      "properties": {"description": "Líneas de venta retail — una línea por artículo vendido"}
+    },
+    {
+      "name": "PagoVenta",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_pagos_ventas"
+      },
+      "primaryKey": "reg_pagos",
+      "columns": [
+        {
+          "name": "reg_pagos",
+          "type": "NUMERIC",
+          "expression": "reg_pagos",
+          "properties": {"description": "ID interno del pago (clave primaria)"}
+        },
+        {
+          "name": "num_ventas",
+          "type": "NUMERIC",
+          "expression": "num_ventas",
+          "properties": {"description": "FK → Venta (reg_ventas)"}
+        },
+        {
+          "name": "forma",
+          "type": "VARCHAR",
+          "expression": "forma",
+          "properties": {"description": "Forma de pago (efectivo, tarjeta, etc.)"}
+        },
+        {
+          "name": "codigo_forma",
+          "type": "VARCHAR",
+          "expression": "codigo_forma",
+          "properties": {"description": "Código interno de la forma de pago"}
+        },
+        {
+          "name": "importe_cob",
+          "type": "NUMERIC",
+          "expression": "importe_cob",
+          "properties": {"description": "Importe cobrado — usar este campo para análisis de medios de pago"}
+        },
+        {
+          "name": "fecha_creacion",
+          "type": "DATE",
+          "expression": "fecha_creacion",
+          "properties": {"description": "Fecha del cobro"}
+        },
+        {
+          "name": "fecha_modifica",
+          "type": "DATE",
+          "expression": "fecha_modifica",
+          "properties": {"description": "Fecha de última modificación"}
+        },
+        {
+          "name": "tienda",
+          "type": "VARCHAR",
+          "expression": "tienda",
+          "properties": {"description": "Código de tienda donde se realizó el cobro"}
+        },
+        {
+          "name": "entrada",
+          "type": "BOOLEAN",
+          "expression": "entrada",
+          "properties": {"description": "Indica si es una devolución de pago"}
+        }
+      ],
+      "properties": {"description": "Pagos y cobros asociados a ventas retail — un ticket puede tener varios métodos de pago"}
+    },
+    {
+      "name": "StockTienda",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_stock_tienda"
+      },
+      "primaryKey": "tienda_codigo",
+      "columns": [
+        {
+          "name": "codigo",
+          "type": "VARCHAR",
+          "expression": "codigo",
+          "properties": {"description": "Código del artículo (FK → Producto.codigo)"}
+        },
+        {
+          "name": "tienda_codigo",
+          "type": "VARCHAR",
+          "expression": "tienda_codigo",
+          "properties": {"description": "Clave compuesta tienda/artículo en formato store_code/article_code (e.g. '104/169')"}
+        },
+        {
+          "name": "tienda",
+          "type": "VARCHAR",
+          "expression": "tienda",
+          "properties": {"description": "Código de tienda (FK → Tienda.codigo)"}
+        },
+        {
+          "name": "talla",
+          "type": "VARCHAR",
+          "expression": "talla",
+          "properties": {"description": "Talla del artículo"}
+        },
+        {
+          "name": "stock",
+          "type": "INTEGER",
+          "expression": "stock",
+          "properties": {"description": "Unidades en stock físico"}
+        },
+        {
+          "name": "cc_stock",
+          "type": "NUMERIC",
+          "expression": "cc_stock",
+          "properties": {"description": "Stock en almacén central (CCStock)"}
+        },
+        {
+          "name": "st_stock",
+          "type": "NUMERIC",
+          "expression": "st_stock",
+          "properties": {"description": "Stock en tiendas (Exportaciones)"}
+        },
+        {
+          "name": "fecha_modifica",
+          "type": "DATE",
+          "expression": "fecha_modifica",
+          "properties": {"description": "Fecha de última modificación del registro de stock"}
+        }
+      ],
+      "properties": {"description": "Stock por artículo, tienda y talla. Normalizado de las tablas CCStock y Exportaciones (ancho → largo)"}
+    },
+    {
+      "name": "Traspaso",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_traspasos"
+      },
+      "primaryKey": "reg_traspaso",
+      "columns": [
+        {
+          "name": "reg_traspaso",
+          "type": "NUMERIC",
+          "expression": "reg_traspaso",
+          "properties": {"description": "ID interno del traspaso (clave primaria)"}
+        },
+        {
+          "name": "codigo",
+          "type": "VARCHAR",
+          "expression": "codigo",
+          "properties": {"description": "Código del artículo traspasado"}
+        },
+        {
+          "name": "descripcion",
+          "type": "VARCHAR",
+          "expression": "descripcion",
+          "properties": {"description": "Descripción del artículo"}
+        },
+        {
+          "name": "talla",
+          "type": "VARCHAR",
+          "expression": "talla",
+          "properties": {"description": "Talla del artículo traspasado"}
+        },
+        {
+          "name": "unidades_s",
+          "type": "NUMERIC",
+          "expression": "unidades_s",
+          "properties": {"description": "Unidades enviadas desde la tienda de salida"}
+        },
+        {
+          "name": "unidades_e",
+          "type": "NUMERIC",
+          "expression": "unidades_e",
+          "properties": {"description": "Unidades recibidas en la tienda de entrada"}
+        },
+        {
+          "name": "tienda_salida",
+          "type": "VARCHAR",
+          "expression": "tienda_salida",
+          "properties": {"description": "Código de la tienda de origen del traspaso"}
+        },
+        {
+          "name": "tienda_entrada",
+          "type": "VARCHAR",
+          "expression": "tienda_entrada",
+          "properties": {"description": "Código de la tienda de destino del traspaso"}
+        },
+        {
+          "name": "fecha_s",
+          "type": "DATE",
+          "expression": "fecha_s",
+          "properties": {"description": "Fecha de salida del traspaso"}
+        },
+        {
+          "name": "fecha_e",
+          "type": "DATE",
+          "expression": "fecha_e",
+          "properties": {"description": "Fecha de entrada / recepción del traspaso"}
+        },
+        {
+          "name": "tipo",
+          "type": "VARCHAR",
+          "expression": "tipo",
+          "properties": {"description": "Tipo de traspaso (interno, devolución a almacén, etc.)"}
+        },
+        {
+          "name": "concepto",
+          "type": "VARCHAR",
+          "expression": "concepto",
+          "properties": {"description": "Concepto del movimiento de traspaso"}
+        },
+        {
+          "name": "entrada",
+          "type": "BOOLEAN",
+          "expression": "entrada",
+          "properties": {"description": "Indica si el registro corresponde a la parte de entrada"}
+        }
+      ],
+      "properties": {"description": "Movimientos de traspaso de mercancía entre tiendas y almacén"}
+    },
+    {
+      "name": "AlbaranMayorista",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_gc_albaranes"
+      },
+      "primaryKey": "reg_albaran",
+      "columns": [
+        {
+          "name": "reg_albaran",
+          "type": "NUMERIC",
+          "expression": "reg_albaran",
+          "properties": {"description": "ID interno del albarán mayorista (clave primaria)"}
+        },
+        {
+          "name": "n_albaran",
+          "type": "NUMERIC",
+          "expression": "n_albaran",
+          "properties": {"description": "Número de albarán (usado como FK desde líneas)"}
+        },
+        {
+          "name": "num_cliente",
+          "type": "NUMERIC",
+          "expression": "num_cliente",
+          "properties": {"description": "FK → Cliente (reg_cliente)"}
+        },
+        {
+          "name": "fecha_envio",
+          "type": "DATE",
+          "expression": "fecha_envio",
+          "properties": {"description": "Fecha de envío del albarán"}
+        },
+        {
+          "name": "fecha_valor",
+          "type": "DATE",
+          "expression": "fecha_valor",
+          "properties": {"description": "Fecha valor del albarán"}
+        },
+        {
+          "name": "modifica",
+          "type": "DATE",
+          "expression": "modifica",
+          "properties": {"description": "Fecha de última modificación"}
+        },
+        {
+          "name": "base1",
+          "type": "NUMERIC",
+          "expression": "base1",
+          "properties": {"description": "Base imponible al tipo impositivo 1"}
+        },
+        {
+          "name": "base2",
+          "type": "NUMERIC",
+          "expression": "base2",
+          "properties": {"description": "Base imponible al tipo impositivo 2"}
+        },
+        {
+          "name": "base3",
+          "type": "NUMERIC",
+          "expression": "base3",
+          "properties": {"description": "Base imponible al tipo impositivo 3"}
+        },
+        {
+          "name": "importe_neto",
+          "type": "NUMERIC",
+          "isCalculated": true,
+          "expression": "base1 + base2 + base3",
+          "properties": {"description": "Importe neto total del albarán = base1 + base2 + base3"}
+        },
+        {
+          "name": "entregadas",
+          "type": "NUMERIC",
+          "expression": "entregadas",
+          "properties": {"description": "Unidades entregadas en el albarán"}
+        },
+        {
+          "name": "transportista",
+          "type": "VARCHAR",
+          "expression": "transportista",
+          "properties": {"description": "Nombre o código del transportista"}
+        },
+        {
+          "name": "num_comercial",
+          "type": "NUMERIC",
+          "expression": "num_comercial",
+          "properties": {"description": "FK → Comercial (reg_comercial)"}
+        },
+        {
+          "name": "temporada",
+          "type": "VARCHAR",
+          "expression": "temporada",
+          "properties": {"description": "Clave de temporada del albarán"}
+        }
+      ],
+      "properties": {"description": "Albaranes mayoristas (Gestión Comercial). Importe neto = base1 + base2 + base3"}
+    },
+    {
+      "name": "LineaAlbaranMayorista",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_gc_lin_albarane"
+      },
+      "primaryKey": "reg_linea",
+      "columns": [
+        {
+          "name": "reg_linea",
+          "type": "NUMERIC",
+          "expression": "reg_linea",
+          "properties": {"description": "ID interno de la línea de albarán (clave primaria)"}
+        },
+        {
+          "name": "n_albaran",
+          "type": "NUMERIC",
+          "expression": "n_albaran",
+          "properties": {"description": "FK → AlbaranMayorista (n_albaran)"}
+        },
+        {
+          "name": "num_albaran",
+          "type": "NUMERIC",
+          "expression": "num_albaran",
+          "properties": {"description": "Número de albarán (campo alternativo)"}
+        },
+        {
+          "name": "codigo",
+          "type": "VARCHAR",
+          "expression": "codigo",
+          "properties": {"description": "Código del artículo"}
+        },
+        {
+          "name": "articulo",
+          "type": "VARCHAR",
+          "expression": "articulo",
+          "properties": {"description": "Referencia del artículo"}
+        },
+        {
+          "name": "descripcion",
+          "type": "VARCHAR",
+          "expression": "descripcion",
+          "properties": {"description": "Descripción del artículo"}
+        },
+        {
+          "name": "color",
+          "type": "VARCHAR",
+          "expression": "color",
+          "properties": {"description": "Color del artículo"}
+        },
+        {
+          "name": "fecha_albaran",
+          "type": "DATE",
+          "expression": "fecha_albaran",
+          "properties": {"description": "Fecha del albarán"}
+        },
+        {
+          "name": "unidades",
+          "type": "NUMERIC",
+          "expression": "unidades",
+          "properties": {"description": "Unidades del artículo en la línea"}
+        },
+        {
+          "name": "precio_neto",
+          "type": "NUMERIC",
+          "expression": "precio_neto",
+          "properties": {"description": "Precio neto unitario sin IVA"}
+        },
+        {
+          "name": "total",
+          "type": "NUMERIC",
+          "expression": "total",
+          "properties": {"description": "Total de la línea de albarán"}
+        },
+        {
+          "name": "num_cliente",
+          "type": "NUMERIC",
+          "expression": "num_cliente",
+          "properties": {"description": "Número de cliente de la línea"}
+        },
+        {
+          "name": "num_familia",
+          "type": "NUMERIC",
+          "expression": "num_familia",
+          "properties": {"description": "FK → Familia (reg_familia)"}
+        },
+        {
+          "name": "num_departament",
+          "type": "NUMERIC",
+          "expression": "num_departament",
+          "properties": {"description": "FK → Departamento (reg_departament)"}
+        },
+        {
+          "name": "num_temporada",
+          "type": "NUMERIC",
+          "expression": "num_temporada",
+          "properties": {"description": "FK → Temporada (reg_temporada)"}
+        },
+        {
+          "name": "num_marca",
+          "type": "NUMERIC",
+          "expression": "num_marca",
+          "properties": {"description": "FK → Marca (reg_marca)"}
+        },
+        {
+          "name": "num_color",
+          "type": "NUMERIC",
+          "expression": "num_color",
+          "properties": {"description": "FK → Color (reg_color)"}
+        },
+        {
+          "name": "num_comercial",
+          "type": "NUMERIC",
+          "expression": "num_comercial",
+          "properties": {"description": "FK → Comercial (reg_comercial)"}
+        },
+        {
+          "name": "mes",
+          "type": "INTEGER",
+          "expression": "mes",
+          "properties": {"description": "Mes de la línea de albarán (1-12)"}
+        }
+      ],
+      "properties": {"description": "Líneas de albaranes mayoristas"}
+    },
+    {
+      "name": "FacturaMayorista",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_gc_facturas"
+      },
+      "primaryKey": "reg_factura",
+      "columns": [
+        {
+          "name": "reg_factura",
+          "type": "NUMERIC",
+          "expression": "reg_factura",
+          "properties": {"description": "ID interno de la factura mayorista (clave primaria)"}
+        },
+        {
+          "name": "n_factura",
+          "type": "NUMERIC",
+          "expression": "n_factura",
+          "properties": {"description": "Número de factura (usado como FK desde líneas)"}
+        },
+        {
+          "name": "fecha_factura",
+          "type": "DATE",
+          "expression": "fecha_factura",
+          "properties": {"description": "Fecha de la factura mayorista"}
+        },
+        {
+          "name": "modifica",
+          "type": "DATE",
+          "expression": "modifica",
+          "properties": {"description": "Fecha de última modificación"}
+        },
+        {
+          "name": "base1",
+          "type": "NUMERIC",
+          "expression": "base1",
+          "properties": {"description": "Base imponible al tipo impositivo 1"}
+        },
+        {
+          "name": "base2",
+          "type": "NUMERIC",
+          "expression": "base2",
+          "properties": {"description": "Base imponible al tipo impositivo 2"}
+        },
+        {
+          "name": "base3",
+          "type": "NUMERIC",
+          "expression": "base3",
+          "properties": {"description": "Base imponible al tipo impositivo 3"}
+        },
+        {
+          "name": "num_cliente",
+          "type": "NUMERIC",
+          "expression": "num_cliente",
+          "properties": {"description": "FK → Cliente (reg_cliente)"}
+        },
+        {
+          "name": "num_comercial",
+          "type": "NUMERIC",
+          "expression": "num_comercial",
+          "properties": {"description": "FK → Comercial (reg_comercial)"}
+        },
+        {
+          "name": "abono",
+          "type": "BOOLEAN",
+          "expression": "abono",
+          "properties": {"description": "Indica si es una factura de abono (nota de crédito)"}
+        },
+        {
+          "name": "total_factura",
+          "type": "NUMERIC",
+          "expression": "total_factura",
+          "properties": {"description": "Total de la factura (con IVA)"}
+        }
+      ],
+      "properties": {"description": "Facturas mayoristas (Gestión Comercial)"}
+    },
+    {
+      "name": "LineaFacturaMayorista",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_gc_lin_facturas"
+      },
+      "primaryKey": "reg_linea",
+      "columns": [
+        {
+          "name": "reg_linea",
+          "type": "NUMERIC",
+          "expression": "reg_linea",
+          "properties": {"description": "ID interno de la línea de factura (clave primaria)"}
+        },
+        {
+          "name": "num_factura",
+          "type": "NUMERIC",
+          "expression": "num_factura",
+          "properties": {"description": "FK → FacturaMayorista (n_factura). Nota: nomenclatura asimétrica respecto al PK"}
+        },
+        {
+          "name": "codigo",
+          "type": "VARCHAR",
+          "expression": "codigo",
+          "properties": {"description": "Código del artículo facturado"}
+        },
+        {
+          "name": "descripcion",
+          "type": "VARCHAR",
+          "expression": "descripcion",
+          "properties": {"description": "Descripción del artículo"}
+        },
+        {
+          "name": "unidades",
+          "type": "NUMERIC",
+          "expression": "unidades",
+          "properties": {"description": "Unidades facturadas"}
+        },
+        {
+          "name": "precio_neto",
+          "type": "NUMERIC",
+          "expression": "precio_neto",
+          "properties": {"description": "Precio neto unitario sin IVA"}
+        },
+        {
+          "name": "total",
+          "type": "NUMERIC",
+          "expression": "total",
+          "properties": {"description": "Total de la línea de factura"}
+        },
+        {
+          "name": "total_coste",
+          "type": "NUMERIC",
+          "expression": "total_coste",
+          "properties": {"description": "Coste total de la línea"}
+        },
+        {
+          "name": "p_iva",
+          "type": "NUMERIC",
+          "expression": "p_iva",
+          "properties": {"description": "Porcentaje de IVA aplicado"}
+        },
+        {
+          "name": "fecha_factura",
+          "type": "DATE",
+          "expression": "fecha_factura",
+          "properties": {"description": "Fecha de la factura"}
+        },
+        {
+          "name": "num_cliente",
+          "type": "NUMERIC",
+          "expression": "num_cliente",
+          "properties": {"description": "Número de cliente de la línea"}
+        },
+        {
+          "name": "num_familia",
+          "type": "NUMERIC",
+          "expression": "num_familia",
+          "properties": {"description": "FK → Familia (reg_familia)"}
+        },
+        {
+          "name": "num_departament",
+          "type": "NUMERIC",
+          "expression": "num_departament",
+          "properties": {"description": "FK → Departamento (reg_departament)"}
+        },
+        {
+          "name": "num_marca",
+          "type": "NUMERIC",
+          "expression": "num_marca",
+          "properties": {"description": "FK → Marca (reg_marca)"}
+        },
+        {
+          "name": "num_color",
+          "type": "NUMERIC",
+          "expression": "num_color",
+          "properties": {"description": "FK → Color (reg_color)"}
+        },
+        {
+          "name": "num_comercial",
+          "type": "NUMERIC",
+          "expression": "num_comercial",
+          "properties": {"description": "FK → Comercial (reg_comercial)"}
+        },
+        {
+          "name": "mes",
+          "type": "INTEGER",
+          "expression": "mes",
+          "properties": {"description": "Mes de la línea de factura (1-12)"}
+        }
+      ],
+      "properties": {"description": "Líneas de facturas mayoristas"}
+    },
+    {
+      "name": "PedidoMayorista",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_gc_pedidos"
+      },
+      "primaryKey": "reg_pedido",
+      "columns": [
+        {
+          "name": "reg_pedido",
+          "type": "NUMERIC",
+          "expression": "reg_pedido",
+          "properties": {"description": "ID interno del pedido mayorista (clave primaria)"}
+        },
+        {
+          "name": "n_pedido",
+          "type": "NUMERIC",
+          "expression": "n_pedido",
+          "properties": {"description": "Número de pedido mayorista"}
+        },
+        {
+          "name": "fecha_pedido",
+          "type": "DATE",
+          "expression": "fecha_pedido",
+          "properties": {"description": "Fecha del pedido"}
+        },
+        {
+          "name": "modifica",
+          "type": "DATE",
+          "expression": "modifica",
+          "properties": {"description": "Fecha de última modificación"}
+        },
+        {
+          "name": "num_cliente",
+          "type": "NUMERIC",
+          "expression": "num_cliente",
+          "properties": {"description": "FK → Cliente (reg_cliente)"}
+        },
+        {
+          "name": "comercial",
+          "type": "VARCHAR",
+          "expression": "comercial",
+          "properties": {"description": "Nombre del comercial asignado al pedido"}
+        },
+        {
+          "name": "total_pedido",
+          "type": "NUMERIC",
+          "expression": "total_pedido",
+          "properties": {"description": "Importe total del pedido"}
+        },
+        {
+          "name": "unidades",
+          "type": "NUMERIC",
+          "expression": "unidades",
+          "properties": {"description": "Total de unidades del pedido"}
+        },
+        {
+          "name": "entregadas",
+          "type": "NUMERIC",
+          "expression": "entregadas",
+          "properties": {"description": "Unidades ya entregadas del pedido"}
+        },
+        {
+          "name": "pendientes",
+          "type": "NUMERIC",
+          "expression": "pendientes",
+          "properties": {"description": "Unidades pendientes de entrega"}
+        },
+        {
+          "name": "temporada",
+          "type": "VARCHAR",
+          "expression": "temporada",
+          "properties": {"description": "Clave de temporada del pedido"}
+        },
+        {
+          "name": "pedido_cerrado",
+          "type": "BOOLEAN",
+          "expression": "pedido_cerrado",
+          "properties": {"description": "Indica si el pedido está cerrado / completado"}
+        },
+        {
+          "name": "abono",
+          "type": "BOOLEAN",
+          "expression": "abono",
+          "properties": {"description": "Indica si es un pedido de abono / devolución"}
+        }
+      ],
+      "properties": {"description": "Pedidos mayoristas (Gestión Comercial)"}
+    },
+    {
+      "name": "PedidoCompra",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_compras"
+      },
+      "primaryKey": "reg_pedido",
+      "columns": [
+        {
+          "name": "reg_pedido",
+          "type": "NUMERIC",
+          "expression": "reg_pedido",
+          "properties": {"description": "ID interno del pedido de compra (clave primaria)"}
+        },
+        {
+          "name": "fecha_pedido",
+          "type": "DATE",
+          "expression": "fecha_pedido",
+          "properties": {"description": "Fecha del pedido de compra a proveedor"}
+        },
+        {
+          "name": "fecha_recibido",
+          "type": "DATE",
+          "expression": "fecha_recibido",
+          "properties": {"description": "Fecha de recepción de la mercancía"}
+        },
+        {
+          "name": "modificada",
+          "type": "DATE",
+          "expression": "modificada",
+          "properties": {"description": "Fecha de última modificación"}
+        },
+        {
+          "name": "num_proveedor",
+          "type": "NUMERIC",
+          "expression": "num_proveedor",
+          "properties": {"description": "FK → Proveedor (reg_proveedor)"}
+        }
+      ],
+      "properties": {"description": "Pedidos de compra a proveedores"}
+    },
+    {
+      "name": "LineaPedidoCompra",
+      "tableReference": {
+        "catalog": "powershop",
+        "schema": "public",
+        "table": "ps_lineas_compras"
+      },
+      "primaryKey": "reg_linea_compra",
+      "columns": [
+        {
+          "name": "reg_linea_compra",
+          "type": "NUMERIC",
+          "expression": "reg_linea_compra",
+          "properties": {"description": "ID interno de la línea de compra (clave primaria)"}
+        },
+        {
+          "name": "num_pedido",
+          "type": "NUMERIC",
+          "expression": "num_pedido",
+          "properties": {"description": "FK → PedidoCompra (reg_pedido)"}
+        },
+        {
+          "name": "num_tienda",
+          "type": "NUMERIC",
+          "expression": "num_tienda",
+          "properties": {"description": "Número de tienda destino de la compra"}
+        },
+        {
+          "name": "fecha",
+          "type": "DATE",
+          "expression": "fecha",
+          "properties": {"description": "Fecha de la línea de compra"}
+        },
+        {
+          "name": "num_articulo",
+          "type": "NUMERIC",
+          "expression": "num_articulo",
+          "properties": {"description": "Número de artículo comprado"}
+        }
+      ],
+      "properties": {"description": "Líneas de pedidos de compra a proveedores (tabla CCLineasCompr en 4D)"}
+    }
+  ],
+  "relationships": [
+    {
+      "name": "LineaVenta_Venta",
+      "models": ["LineaVenta", "Venta"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "LineaVenta.num_ventas = Venta.reg_ventas",
+      "properties": {"description": "Cada línea de venta pertenece a un ticket de venta"}
+    },
+    {
+      "name": "PagoVenta_Venta",
+      "models": ["PagoVenta", "Venta"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "PagoVenta.num_ventas = Venta.reg_ventas",
+      "properties": {"description": "Cada pago está asociado a un ticket de venta"}
+    },
+    {
+      "name": "Venta_Tienda",
+      "models": ["Venta", "Tienda"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "Venta.tienda = Tienda.codigo",
+      "properties": {"description": "Cada venta se realiza en una tienda (join TEXT = TEXT)"}
+    },
+    {
+      "name": "Venta_Cliente",
+      "models": ["Venta", "Cliente"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "Venta.num_cliente = Cliente.num_cliente",
+      "properties": {"description": "Cada venta puede estar asociada a un cliente identificado"}
+    },
+    {
+      "name": "LineaVenta_Producto",
+      "models": ["LineaVenta", "Producto"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "LineaVenta.codigo = Producto.codigo",
+      "properties": {"description": "Cada línea de venta referencia un artículo del catálogo"}
+    },
+    {
+      "name": "Producto_Familia",
+      "models": ["Producto", "Familia"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "Producto.num_familia = Familia.reg_familia",
+      "properties": {"description": "Cada artículo pertenece a una familia"}
+    },
+    {
+      "name": "Producto_Departamento",
+      "models": ["Producto", "Departamento"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "Producto.num_departament = Departamento.reg_departament",
+      "properties": {"description": "Cada artículo pertenece a un departamento"}
+    },
+    {
+      "name": "Producto_Color",
+      "models": ["Producto", "Color"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "Producto.num_color = Color.reg_color",
+      "properties": {"description": "Cada artículo tiene un color del catálogo de colores"}
+    },
+    {
+      "name": "Producto_Temporada",
+      "models": ["Producto", "Temporada"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "Producto.num_temporada = Temporada.reg_temporada",
+      "properties": {"description": "Cada artículo pertenece a una temporada"}
+    },
+    {
+      "name": "Producto_Marca",
+      "models": ["Producto", "Marca"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "Producto.num_marca = Marca.reg_marca",
+      "properties": {"description": "Cada artículo pertenece a una marca"}
+    },
+    {
+      "name": "StockTienda_Producto",
+      "models": ["StockTienda", "Producto"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "StockTienda.codigo = Producto.codigo",
+      "properties": {"description": "Cada registro de stock referencia un artículo (join TEXT = TEXT)"}
+    },
+    {
+      "name": "StockTienda_Tienda",
+      "models": ["StockTienda", "Tienda"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "StockTienda.tienda = Tienda.codigo",
+      "properties": {"description": "Cada registro de stock pertenece a una tienda (join TEXT = TEXT)"}
+    },
+    {
+      "name": "LineaAlbaranMayorista_AlbaranMayorista",
+      "models": ["LineaAlbaranMayorista", "AlbaranMayorista"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "LineaAlbaranMayorista.n_albaran = AlbaranMayorista.n_albaran",
+      "properties": {"description": "Cada línea de albarán pertenece a un albarán mayorista"}
+    },
+    {
+      "name": "LineaFacturaMayorista_FacturaMayorista",
+      "models": ["LineaFacturaMayorista", "FacturaMayorista"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "LineaFacturaMayorista.num_factura = FacturaMayorista.n_factura",
+      "properties": {"description": "Cada línea de factura pertenece a una factura mayorista (FK asimétrico: num_factura → n_factura)"}
+    },
+    {
+      "name": "AlbaranMayorista_Cliente",
+      "models": ["AlbaranMayorista", "Cliente"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "AlbaranMayorista.num_cliente = Cliente.reg_cliente",
+      "properties": {"description": "Cada albarán mayorista está asociado a un cliente"}
+    },
+    {
+      "name": "AlbaranMayorista_Comercial",
+      "models": ["AlbaranMayorista", "Comercial"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "AlbaranMayorista.num_comercial = Comercial.reg_comercial",
+      "properties": {"description": "Cada albarán mayorista está gestionado por un comercial"}
+    },
+    {
+      "name": "FacturaMayorista_Cliente",
+      "models": ["FacturaMayorista", "Cliente"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "FacturaMayorista.num_cliente = Cliente.reg_cliente",
+      "properties": {"description": "Cada factura mayorista está asociada a un cliente"}
+    },
+    {
+      "name": "FacturaMayorista_Comercial",
+      "models": ["FacturaMayorista", "Comercial"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "FacturaMayorista.num_comercial = Comercial.reg_comercial",
+      "properties": {"description": "Cada factura mayorista está gestionada por un comercial"}
+    },
+    {
+      "name": "LineaPedidoCompra_PedidoCompra",
+      "models": ["LineaPedidoCompra", "PedidoCompra"],
+      "joinType": "MANY_TO_ONE",
+      "condition": "LineaPedidoCompra.num_pedido = PedidoCompra.reg_pedido",
+      "properties": {"description": "Cada línea de compra pertenece a un pedido de compra"}
+    }
+  ],
+  "metrics": [
+    {
+      "name": "VentasNetas",
+      "baseObject": "Venta",
+      "dimension": [
+        {
+          "name": "fecha_creacion",
+          "type": "DATE"
+        },
+        {
+          "name": "tienda",
+          "type": "VARCHAR"
+        }
+      ],
+      "measure": [
+        {
+          "name": "ventas_netas",
+          "type": "NUMERIC",
+          "expression": "SUM(total_si)",
+          "properties": {"description": "Suma de ventas sin IVA — usar siempre para análisis de ingresos"}
+        },
+        {
+          "name": "num_tickets",
+          "type": "INTEGER",
+          "expression": "COUNT(DISTINCT reg_ventas)",
+          "properties": {"description": "Número de tickets / transacciones"}
+        }
+      ],
+      "timeGrain": [
+        {
+          "name": "fecha_creacion",
+          "refColumn": "fecha_creacion",
+          "dateParts": ["YEAR", "QUARTER", "MONTH", "WEEK", "DAY"]
+        }
+      ],
+      "properties": {"description": "Métricas de ventas netas retail"}
+    },
+    {
+      "name": "LineasVentaMetricas",
+      "baseObject": "LineaVenta",
+      "dimension": [
+        {
+          "name": "fecha_creacion",
+          "type": "DATE"
+        },
+        {
+          "name": "tienda",
+          "type": "VARCHAR"
+        },
+        {
+          "name": "codigo",
+          "type": "VARCHAR"
+        }
+      ],
+      "measure": [
+        {
+          "name": "unidades_vendidas",
+          "type": "NUMERIC",
+          "expression": "SUM(unidades)",
+          "properties": {"description": "Total de unidades vendidas"}
+        },
+        {
+          "name": "margen_bruto_retail",
+          "type": "NUMERIC",
+          "expression": "SUM(total_si - total_coste_si)",
+          "properties": {"description": "Margen bruto retail = ventas netas - coste de ventas"}
+        }
+      ],
+      "timeGrain": [
+        {
+          "name": "fecha_creacion",
+          "refColumn": "fecha_creacion",
+          "dateParts": ["YEAR", "QUARTER", "MONTH", "WEEK", "DAY"]
+        }
+      ],
+      "properties": {"description": "Métricas de líneas de venta retail (unidades y margen)"}
+    },
+    {
+      "name": "FacturacionMayorista",
+      "baseObject": "FacturaMayorista",
+      "dimension": [
+        {
+          "name": "fecha_factura",
+          "type": "DATE"
+        }
+      ],
+      "measure": [
+        {
+          "name": "facturacion_mayorista",
+          "type": "NUMERIC",
+          "expression": "SUM(base1 + base2 + base3)",
+          "properties": {"description": "Facturación mayorista neta = suma de bases imponibles (base1+base2+base3)"}
+        }
+      ],
+      "timeGrain": [
+        {
+          "name": "fecha_factura",
+          "refColumn": "fecha_factura",
+          "dateParts": ["YEAR", "QUARTER", "MONTH", "WEEK", "DAY"]
+        }
+      ],
+      "properties": {"description": "Métricas de facturación mayorista"}
+    },
+    {
+      "name": "StockMetricas",
+      "baseObject": "StockTienda",
+      "dimension": [
+        {
+          "name": "tienda",
+          "type": "VARCHAR"
+        },
+        {
+          "name": "codigo",
+          "type": "VARCHAR"
+        },
+        {
+          "name": "talla",
+          "type": "VARCHAR"
+        }
+      ],
+      "measure": [
+        {
+          "name": "stock_total",
+          "type": "INTEGER",
+          "expression": "SUM(stock)",
+          "properties": {"description": "Stock total en unidades físicas por artículo/tienda/talla"}
+        }
+      ],
+      "properties": {"description": "Métricas de stock por tienda y artículo"}
+    }
+  ],
+  "views": [
+    {
+      "name": "VentasPorTiendaYMes",
+      "statement": "SELECT v.tienda, EXTRACT(YEAR FROM v.fecha_creacion) AS anio, EXTRACT(MONTH FROM v.fecha_creacion) AS mes, SUM(v.total_si) AS ventas_netas, COUNT(DISTINCT v.reg_ventas) AS num_tickets, SUM(v.total_si) / NULLIF(COUNT(DISTINCT v.reg_ventas), 0) AS ticket_medio FROM Venta v GROUP BY v.tienda, EXTRACT(YEAR FROM v.fecha_creacion), EXTRACT(MONTH FROM v.fecha_creacion)",
+      "properties": {"description": "Ventas netas, número de tickets y ticket medio por tienda y mes"}
+    },
+    {
+      "name": "StockPorProductoYTienda",
+      "statement": "SELECT s.codigo, p.ccrefejofacm AS referencia, p.descripcion, s.tienda, SUM(s.stock) AS stock_total FROM StockTienda s LEFT JOIN Producto p ON s.codigo = p.codigo GROUP BY s.codigo, p.ccrefejofacm, p.descripcion, s.tienda",
+      "properties": {"description": "Stock total por producto (con referencia comercial) y tienda"}
+    },
+    {
+      "name": "TicketMedioRetail",
+      "statement": "SELECT tienda, fecha_creacion, SUM(total_si) AS ventas_netas, COUNT(DISTINCT reg_ventas) AS num_tickets, SUM(total_si) / NULLIF(COUNT(DISTINCT reg_ventas), 0) AS ticket_medio FROM Venta GROUP BY tienda, fecha_creacion",
+      "properties": {"description": "Ticket medio diario por tienda (ventas netas / número de tickets)"}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Creates `wren/mdl/model.json`: a single WrenAI MDL JSON defining the complete semantic model for the PowerShop Analytics PostgreSQL mirror
- **22 models** covering all `ps_*` tables: catalog (Producto, Familia, Color, Temporada, Departamento, Marca), masters (Tienda, Cliente, Proveedor, Comercial), retail sales (Venta, LineaVenta, PagoVenta), stock (StockTienda, Traspaso), wholesale GC (AlbaranMayorista, LineaAlbaranMayorista, FacturaMayorista, LineaFacturaMayorista, PedidoMayorista), and purchasing (PedidoCompra, LineaPedidoCompra)
- **19 relationships** with correct join conditions and join types (all MANY_TO_ONE)
- **4 metrics**: VentasNetas, LineasVentaMetricas, FacturacionMayorista, StockMetricas
- **3 views**: VentasPorTiendaYMes, StockPorProductoYTienda, TicketMedioRetail
- All descriptions in Spanish
- Calculated fields: `Producto.es_mayorista` (LEFT(ccrefejofacm,1)='M') and `AlbaranMayorista.importe_neto` (base1+base2+base3)
- Critical business annotations: `total_si` marked as "SIEMPRE usar para análisis económico"; `total` marked as "NO usar para análisis comparativo"
- JSON validated with `python -m json.tool`

## Test plan

- [ ] `python -m json.tool wren/mdl/model.json` passes (done in CI)
- [ ] Model count = 22, relationship count = 19 (verified with Python assertions)
- [ ] All `ps_*` table names match `etl/schema/init.sql` column definitions
- [ ] Load MDL into a running WrenAI instance (`docker compose up`) and verify all models appear in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)