### PR TITLE
[infra] Bind mount volumes + WrenAI auto-config (#52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ docs/reports/*.html
 docs/reports/*.json
 docs/sample-data/
 
+# Persistent bind-mount data (Docker volumes — never commit)
+data/
+
 # Runtime/temp
 *.log
 tmp/

--- a/cli/commands/stack.sh
+++ b/cli/commands/stack.sh
@@ -24,6 +24,8 @@ Subcommands:
   logs [svc]      Show logs (follow); optional service name
   open            Open WrenAI UI in browser
   destroy         Stop containers and remove volumes (irreversible)
+  migrate         Migrate named volumes to bind-mount directories (one-time)
+  setup-wren      Auto-configure WrenAI: create PostgreSQL data source and deploy MDL
 EOF
 }
 
@@ -100,6 +102,16 @@ cmd_destroy() {
     fi
 }
 
+cmd_migrate() {
+    echo -e "${CYAN}Migrating named Docker volumes to bind-mount directories...${NC}"
+    "${REPO_ROOT}/scripts/migrate-volumes.sh"
+}
+
+cmd_setup_wren() {
+    echo -e "${CYAN}Configuring WrenAI data source and deploying MDL...${NC}"
+    "${REPO_ROOT}/scripts/wren-setup.sh" "$@"
+}
+
 SUBCMD="${1:-}"
 if [ -z "$SUBCMD" ] || [ "$SUBCMD" = "-h" ] || [ "$SUBCMD" = "--help" ]; then
     usage
@@ -108,13 +120,15 @@ fi
 shift
 
 case "$SUBCMD" in
-    up)      cmd_up ;;
-    down)    cmd_down ;;
-    restart) cmd_restart ;;
-    status)  cmd_status ;;
-    logs)    cmd_logs "${1:-}" ;;
-    open)    cmd_open ;;
-    destroy) cmd_destroy ;;
+    up)          cmd_up ;;
+    down)        cmd_down ;;
+    restart)     cmd_restart ;;
+    status)      cmd_status ;;
+    logs)        cmd_logs "${1:-}" ;;
+    open)        cmd_open ;;
+    destroy)     cmd_destroy ;;
+    migrate)     cmd_migrate ;;
+    setup-wren)  cmd_setup_wren "$@" ;;
     *)
         echo -e "${RED}ps stack: unknown subcommand '${SUBCMD}'${NC}" >&2
         usage >&2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,6 @@
 # Or copy .env.example and fill in manually:
 #   cp .env.example .env && $EDITOR .env
 
-volumes:
-  pgdata:
-  qdrant-data:
-  wren-data:
-
 networks:
   wren:
     driver: bridge
@@ -33,7 +28,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - ./data/postgres:/var/lib/postgresql/data
     networks:
       - wren
     healthcheck:
@@ -74,7 +69,7 @@ services:
     environment:
       DATA_PATH: /app/data
     volumes:
-      - wren-data:/app/data
+      - ./data/wren:/app/data
     command: /bin/sh /app/init.sh
     networks:
       - wren
@@ -90,7 +85,7 @@ services:
       - ${WREN_ENGINE_PORT:-8080}
       - ${WREN_ENGINE_SQL_PORT:-7432}
     volumes:
-      - wren-data:/usr/src/app/etc
+      - ./data/wren:/usr/src/app/etc
     networks:
       - wren
     depends_on:
@@ -142,7 +137,7 @@ services:
       WREN_AI_SERVICE_VERSION: ${WREN_AI_SERVICE_VERSION:-0.29.0}
     volumes:
       - ./wren-config.yaml:/app/config.yaml:ro
-      - wren-data:/app/data:ro
+      - ./data/wren:/app/data:ro
     networks:
       - wren
     depends_on:
@@ -181,7 +176,7 @@ services:
     ports:
       - "${HOST_PORT:-3000}:3000"
     volumes:
-      - wren-data:/app/data
+      - ./data/wren:/app/data
     networks:
       - wren
     depends_on:
@@ -198,6 +193,6 @@ services:
       - 6333
       - 6334
     volumes:
-      - qdrant-data:/qdrant/storage
+      - ./data/qdrant:/qdrant/storage
     networks:
       - wren

--- a/scripts/migrate-volumes.sh
+++ b/scripts/migrate-volumes.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# migrate-volumes.sh — Migrate Docker named volumes to bind-mount directories under ./data/
+#
+# Usage: ./scripts/migrate-volumes.sh
+#
+# This is a ONE-TIME migration script. Run it once after upgrading docker-compose.yml
+# from named volumes (pgdata / qdrant-data / wren-data) to bind mounts (./data/*).
+# After running, the old named volumes can be removed with `docker volume rm`.
+#
+# Safety: the script will NOT overwrite a non-empty destination directory.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()    { echo -e "${CYAN}[migrate]${NC} $*"; }
+success() { echo -e "${GREEN}[migrate]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[migrate]${NC} $*"; }
+error()   { echo -e "${RED}[migrate]${NC} $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# 1. Stop containers
+# ---------------------------------------------------------------------------
+info "Stopping containers..."
+docker compose -f "${REPO_ROOT}/docker-compose.yml" down
+
+# ---------------------------------------------------------------------------
+# 2. Create destination directories
+# ---------------------------------------------------------------------------
+info "Creating bind-mount directories..."
+mkdir -p "${REPO_ROOT}/data/postgres"
+mkdir -p "${REPO_ROOT}/data/qdrant"
+mkdir -p "${REPO_ROOT}/data/wren"
+
+# ---------------------------------------------------------------------------
+# Helper: find the exact volume name by suffix (e.g. pgdata)
+# Docker Compose prefixes volumes with the project name (usually the dir name,
+# lowercased, with hyphens).  We use `docker volume ls` to locate the exact name.
+# ---------------------------------------------------------------------------
+find_volume() {
+    local suffix="$1"
+    local vol
+    vol="$(docker volume ls --filter "name=${suffix}" --format '{{.Name}}' | head -1)"
+    echo "$vol"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: copy a named volume to a bind-mount directory
+# ---------------------------------------------------------------------------
+copy_volume() {
+    local vol_name="$1"
+    local dest_dir="$2"
+    local label="$3"
+
+    if [ -z "$vol_name" ]; then
+        warn "  No named volume found for '${label}' — skipping (nothing to migrate)."
+        return
+    fi
+
+    # Check destination is empty (do not overwrite existing data)
+    if [ -n "$(ls -A "${dest_dir}" 2>/dev/null)" ]; then
+        warn "  Destination '${dest_dir}' is not empty — skipping '${label}' to avoid overwrite."
+        warn "  If you want to re-run the migration, empty the directory first."
+        return
+    fi
+
+    info "  Migrating volume '${vol_name}' → '${dest_dir}'..."
+    docker run --rm \
+        -v "${vol_name}:/src:ro" \
+        -v "${dest_dir}:/dst" \
+        alpine sh -c "cp -a /src/. /dst/"
+    success "  Done: ${label}"
+}
+
+# ---------------------------------------------------------------------------
+# 3. Copy each volume
+# ---------------------------------------------------------------------------
+info "Discovering named volumes..."
+
+PGDATA_VOL="$(find_volume "pgdata")"
+QDRANT_VOL="$(find_volume "qdrant-data")"
+WREN_VOL="$(find_volume "wren-data")"
+
+echo ""
+info "Found volumes:"
+echo "  postgres  → ${PGDATA_VOL:-<not found>}"
+echo "  qdrant    → ${QDRANT_VOL:-<not found>}"
+echo "  wren      → ${WREN_VOL:-<not found>}"
+echo ""
+
+copy_volume "$PGDATA_VOL"  "${REPO_ROOT}/data/postgres" "postgres"
+copy_volume "$QDRANT_VOL"  "${REPO_ROOT}/data/qdrant"   "qdrant"
+copy_volume "$WREN_VOL"    "${REPO_ROOT}/data/wren"     "wren"
+
+# ---------------------------------------------------------------------------
+# 4. Done
+# ---------------------------------------------------------------------------
+echo ""
+success "Migration complete."
+echo ""
+echo "  Next steps:"
+echo "  1. Start the stack:  docker compose up -d"
+echo "  2. Verify services:  ps stack status"
+echo "  3. (Optional) Remove old named volumes once you're satisfied:"
+if [ -n "$PGDATA_VOL" ];  then echo "       docker volume rm ${PGDATA_VOL}";  fi
+if [ -n "$QDRANT_VOL" ];  then echo "       docker volume rm ${QDRANT_VOL}";  fi
+if [ -n "$WREN_VOL" ];    then echo "       docker volume rm ${WREN_VOL}";    fi
+echo ""

--- a/scripts/wren-setup.sh
+++ b/scripts/wren-setup.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# wren-setup.sh — Auto-configure WrenAI: create PostgreSQL data source and deploy MDL
+#
+# Usage: ./scripts/wren-setup.sh [--host <wren-ui-url>]
+#
+# Defaults:
+#   WREN_UI_URL  http://localhost:3000   (override via env or --host flag)
+#
+# This script:
+#   1. Waits for the wren-ui service to be ready.
+#   2. Saves the PostgreSQL data source via GraphQL mutation.
+#   3. Deploys/re-indexes the MDL via GraphQL mutation.
+#
+# Prerequisites:
+#   - curl (with JSON support)
+#   - The stack must be running: docker compose up -d
+#   - .env must be sourced or environment variables set
+#
+# GraphQL API used (wren-ui Next.js internal API at /api/graphql):
+#   mutation saveDataSource(input: DataSourceInput!)
+#   mutation deploy(force: Boolean)
+#
+# Note: This configures the *initial* data source in WrenAI.  If WrenAI already
+# has a data source configured (db.sqlite3 exists and has a project row), running
+# this script again will be a no-op (the mutation is idempotent for the same input).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Configuration (from environment / .env)
+# ---------------------------------------------------------------------------
+# Load .env if present in repo root (docker-compose pattern)
+if [ -f "${REPO_ROOT}/.env" ]; then
+    set -o allexport
+    # shellcheck disable=SC1091
+    source "${REPO_ROOT}/.env"
+    set +o allexport
+fi
+
+WREN_UI_URL="${WREN_UI_URL:-http://localhost:${HOST_PORT:-3000}}"
+POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-change_me_in_production}"
+POSTGRES_DB="${POSTGRES_DB:-powershop}"
+
+# Parse --host flag
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)
+            WREN_UI_URL="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            echo "Usage: $0 [--host <wren-ui-url>]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()    { echo -e "${CYAN}[wren-setup]${NC} $*"; }
+success() { echo -e "${GREEN}[wren-setup]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[wren-setup]${NC} $*"; }
+error()   { echo -e "${RED}[wren-setup]${NC} $*" >&2; }
+
+GRAPHQL_URL="${WREN_UI_URL}/api/graphql"
+
+# ---------------------------------------------------------------------------
+# Helper: send a GraphQL request
+# Returns the full JSON response body.
+# ---------------------------------------------------------------------------
+gql() {
+    local query="$1"
+    curl -s \
+        -X POST \
+        -H "Content-Type: application/json" \
+        --data "$query" \
+        "${GRAPHQL_URL}"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Wait for wren-ui to be ready
+# ---------------------------------------------------------------------------
+info "Waiting for WrenAI UI at ${WREN_UI_URL} ..."
+MAX_WAIT=120   # seconds
+ELAPSED=0
+INTERVAL=5
+
+until curl -s --max-time 3 "${WREN_UI_URL}" >/dev/null 2>&1; do
+    if [ $ELAPSED -ge $MAX_WAIT ]; then
+        error "WrenAI UI did not become ready within ${MAX_WAIT}s. Is the stack running?"
+        error "Run: docker compose up -d && docker compose ps"
+        exit 1
+    fi
+    info "  Not ready yet. Retrying in ${INTERVAL}s... (${ELAPSED}/${MAX_WAIT}s elapsed)"
+    sleep $INTERVAL
+    ELAPSED=$((ELAPSED + INTERVAL))
+done
+success "WrenAI UI is ready."
+
+# ---------------------------------------------------------------------------
+# 2. Save the PostgreSQL data source
+# ---------------------------------------------------------------------------
+info "Configuring PostgreSQL data source..."
+info "  host=${POSTGRES_HOST}  port=${POSTGRES_PORT}  db=${POSTGRES_DB}  user=${POSTGRES_USER}"
+
+SAVE_DS_PAYLOAD=$(cat <<EOF
+{
+  "query": "mutation SaveDataSource(\$input: DataSourceInput!) { saveDataSource(data: \$input) { type properties } }",
+  "variables": {
+    "input": {
+      "type": "POSTGRES",
+      "properties": {
+        "host": "${POSTGRES_HOST}",
+        "port": ${POSTGRES_PORT},
+        "database": "${POSTGRES_DB}",
+        "user": "${POSTGRES_USER}",
+        "password": "${POSTGRES_PASSWORD}"
+      }
+    }
+  }
+}
+EOF
+)
+
+SAVE_DS_RESP="$(gql "$SAVE_DS_PAYLOAD")"
+
+# Check for errors
+if echo "$SAVE_DS_RESP" | grep -q '"errors"'; then
+    # Check if it's a "data source already exists" style error (idempotent)
+    if echo "$SAVE_DS_RESP" | grep -qi "already"; then
+        warn "Data source already configured — skipping (idempotent)."
+    else
+        error "Failed to save data source. GraphQL response:"
+        echo "$SAVE_DS_RESP" >&2
+        exit 1
+    fi
+else
+    success "PostgreSQL data source saved."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Deploy / re-index MDL
+# ---------------------------------------------------------------------------
+info "Deploying MDL (force=true to reload)..."
+
+DEPLOY_PAYLOAD='{"query":"mutation Deploy { deploy(force: true) }"}'
+
+DEPLOY_RESP="$(gql "$DEPLOY_PAYLOAD")"
+
+if echo "$DEPLOY_RESP" | grep -q '"errors"'; then
+    error "MDL deploy returned an error. GraphQL response:"
+    echo "$DEPLOY_RESP" >&2
+    exit 1
+else
+    success "MDL deployed successfully."
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Done
+# ---------------------------------------------------------------------------
+echo ""
+success "WrenAI setup complete."
+echo ""
+echo "  Open the UI:  ${WREN_UI_URL}"
+echo ""
+echo "  If this is a fresh install you may still need to:"
+echo "    1. Go to the WrenAI UI and complete any onboarding wizard steps."
+echo "    2. Select the tables to include in the semantic model (ps_articulos, etc.)."
+echo "    3. Review and save the auto-generated MDL."
+echo ""


### PR DESCRIPTION
## Summary

- **Replaces named Docker volumes** (`pgdata`, `qdrant-data`, `wren-data`) with bind-mount directories under `./data/` for transparency, easy backups, and explicit persistence on the host filesystem.
- **Adds `scripts/migrate-volumes.sh`** — one-time migration script that copies data from old named volumes to the new bind-mount directories. Run once before restarting the stack.
- **Adds `scripts/wren-setup.sh`** — auto-configures WrenAI on first boot via its internal GraphQL API (`saveDataSource` + `deploy` mutations). Waits for wren-ui to be ready, creates the PostgreSQL data source, and deploys the MDL. Idempotent.
- **Extends CLI** with two new `ps stack` subcommands: `ps stack migrate` and `ps stack setup-wren`.
- **Adds `data/` to `.gitignore`** so bind-mount volumes are never committed.

## WrenAI API approach

WrenAI's OSS wren-ui exposes a Next.js GraphQL endpoint at `/api/graphql`. The relevant mutations used:
- `saveDataSource(data: DataSourceInput!)` — creates or updates the PostgreSQL connection
- `deploy(force: Boolean)` — redeploys/re-indexes the MDL

No external API key is required; the endpoint is internal to the stack.

## Test plan

- [ ] Fresh install: `docker compose up -d && ps stack setup-wren` — WrenAI should be reachable with PostgreSQL configured, no manual UI wizard needed.
- [ ] `ps stack migrate` on a stack with existing named volumes — data should be copied to `./data/` and the stack should start cleanly with bind mounts.
- [ ] `data/` directory is not tracked by git (`git status` shows it as ignored).
- [ ] `ps stack destroy` still works (removes `./data/` is a manual step, volumes are gone after `docker compose down -v`).
- [ ] `ps stack setup-wren --host http://localhost:3000` — custom host flag works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)