### PR TITLE
[deploy] Docker Hub image publishing: release + beta channels

### DIFF
--- a/.github/workflows/beta-docker.yml
+++ b/.github/workflows/beta-docker.yml
@@ -1,0 +1,30 @@
+# Build and push powershop-etl:beta when merging into main.
+# Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN
+name: Beta Docker Image
+
+on:
+  push:
+    branches: [main, master]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push beta
+        uses: docker/build-push-action@v5
+        with:
+          context: ./etl
+          file: ./etl/Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/powershop-etl:beta

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,36 @@
+# Build and push powershop-etl image when a release is created.
+# Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN
+name: Release Docker Image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract release version
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./etl
+          file: ./etl/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/powershop-etl:${{ steps.version.outputs.VERSION }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/powershop-etl:latest


### PR DESCRIPTION
## Summary

- Adds two GitHub Actions workflows for publishing the `powershop-etl` Docker image to Docker Hub.
- **Beta channel** (`beta-docker.yml`): triggered on every push to `main`/`master`, publishes `<user>/powershop-etl:beta`. Gives users an always-fresh image that tracks the main branch.
- **Release channel** (`release-docker.yml`): triggered when a GitHub Release is published, publishes both `<user>/powershop-etl:<version>` (e.g. `v1.2.0`) and `<user>/powershop-etl:latest`. Follows the same dual-tag pattern used in alvarolobato/iptv-proxy.

Both workflows use the repo secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (already configured).

Part of epic #54, implements issue #56.

## Test plan

- [ ] Verify workflow YAML is syntactically valid (done locally with Ruby YAML parser).
- [ ] After merge, confirm GitHub Actions triggers the beta workflow and the image appears on Docker Hub as `<user>/powershop-etl:beta`.
- [ ] Create a test GitHub Release and confirm `<version>` and `latest` tags appear on Docker Hub.
- [ ] Confirm no plaintext credentials are present in any committed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)