### PR TITLE
[D2-A] API: Dashboard generation endpoint

### DIFF
--- a/dashboard/app/api/dashboard/generate/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/generate/__tests__/route.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// --- Mock the LLM module ---
+vi.mock("@/lib/llm", () => ({
+  generateDashboard: vi.fn(),
+}));
+
+// --- Mock the schema module (pass-through by default) ---
+vi.mock("@/lib/schema", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/schema")>(
+    "@/lib/schema",
+  );
+  return { ...actual };
+});
+
+import { POST } from "../route";
+import { generateDashboard } from "@/lib/llm";
+
+const mockGenerate = vi.mocked(generateDashboard);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/dashboard/generate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_SPEC = {
+  title: "Ventas Marzo 2026",
+  widgets: [
+    {
+      type: "kpi_row" as const,
+      items: [
+        {
+          label: "Ventas Netas",
+          sql: "SELECT SUM(total_si) FROM ps_ventas",
+          format: "currency" as const,
+          prefix: "€",
+        },
+      ],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/dashboard/generate", () => {
+  beforeEach(() => {
+    mockGenerate.mockReset();
+  });
+
+  // --- Happy path ---
+
+  it("returns a valid dashboard spec on success", async () => {
+    mockGenerate.mockResolvedValue(JSON.stringify(VALID_SPEC));
+
+    const res = await POST(makeRequest({ prompt: "Ventas del mes" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.title).toBe("Ventas Marzo 2026");
+    expect(json.widgets).toHaveLength(1);
+    expect(json.widgets[0].type).toBe("kpi_row");
+  });
+
+  it("strips markdown code fences from LLM response", async () => {
+    const wrapped = "```json\n" + JSON.stringify(VALID_SPEC) + "\n```";
+    mockGenerate.mockResolvedValue(wrapped);
+
+    const res = await POST(makeRequest({ prompt: "Ventas del mes" }));
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.title).toBe("Ventas Marzo 2026");
+  });
+
+  it("strips bare code fences (no json tag) from LLM response", async () => {
+    const wrapped = "```\n" + JSON.stringify(VALID_SPEC) + "\n```";
+    mockGenerate.mockResolvedValue(wrapped);
+
+    const res = await POST(makeRequest({ prompt: "Ventas del mes" }));
+    expect(res.status).toBe(200);
+  });
+
+  // --- Input validation ---
+
+  it("returns 400 for empty prompt", async () => {
+    const res = await POST(makeRequest({ prompt: "" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain("empty");
+  });
+
+  it("returns 400 for whitespace-only prompt", async () => {
+    const res = await POST(makeRequest({ prompt: "   " }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for missing prompt field", async () => {
+    const res = await POST(makeRequest({ query: "test" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain("prompt");
+  });
+
+  it("returns 400 for non-string prompt", async () => {
+    const res = await POST(makeRequest({ prompt: 123 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new Request("http://localhost/api/dashboard/generate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("Invalid JSON");
+  });
+
+  // --- LLM errors ---
+
+  it("returns 500 when LLM throws a generic error", async () => {
+    mockGenerate.mockRejectedValue(new Error("Connection timeout"));
+
+    const res = await POST(makeRequest({ prompt: "Ventas del mes" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain("Connection timeout");
+  });
+
+  it("returns 429 when LLM throws a rate limit error", async () => {
+    mockGenerate.mockRejectedValue(new Error("rate limit exceeded (429)"));
+
+    const res = await POST(makeRequest({ prompt: "Ventas del mes" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 500 when LLM throws a non-Error value", async () => {
+    mockGenerate.mockRejectedValue("unexpected string error");
+
+    const res = await POST(makeRequest({ prompt: "Ventas del mes" }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toContain("Unknown LLM error");
+  });
+
+  // --- Invalid LLM output ---
+
+  it("returns 400 when LLM returns non-JSON text", async () => {
+    mockGenerate.mockResolvedValue(
+      "I'm sorry, I cannot generate that dashboard.",
+    );
+
+    const res = await POST(makeRequest({ prompt: "Ventas del mes" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain("invalid JSON");
+  });
+
+  it("returns 400 when LLM returns JSON that fails schema validation", async () => {
+    const invalidSpec = { title: "Test" }; // missing widgets
+    mockGenerate.mockResolvedValue(JSON.stringify(invalidSpec));
+
+    const res = await POST(makeRequest({ prompt: "Ventas del mes" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain("invalid dashboard spec");
+    expect(json.details).toBeDefined();
+  });
+
+  it("returns 400 when LLM returns JSON with invalid widget types", async () => {
+    const badWidgets = {
+      title: "Test",
+      widgets: [{ type: "pie_chart", title: "Bad", sql: "SELECT 1" }],
+    };
+    mockGenerate.mockResolvedValue(JSON.stringify(badWidgets));
+
+    const res = await POST(makeRequest({ prompt: "Ventas del mes" }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/dashboard/app/api/dashboard/generate/route.ts
+++ b/dashboard/app/api/dashboard/generate/route.ts
@@ -1,0 +1,118 @@
+/**
+ * POST /api/dashboard/generate
+ *
+ * Accepts a user prompt (Spanish) and returns an AI-generated dashboard spec.
+ *
+ * Request body: { prompt: string }
+ * Success response (200): DashboardSpec JSON
+ * Error responses: 400 (invalid input / invalid spec), 500 (LLM error)
+ */
+
+import { NextResponse } from "next/server";
+import { generateDashboard } from "@/lib/llm";
+import { validateSpec } from "@/lib/schema";
+import { ZodError } from "zod";
+
+/**
+ * Extract JSON from an LLM response that may be wrapped in markdown code blocks.
+ *
+ * LLMs sometimes return:
+ *   ```json
+ *   { ... }
+ *   ```
+ * This strips the fences and returns the inner content.
+ */
+function extractJson(raw: string): string {
+  const trimmed = raw.trim();
+
+  // Match ```json ... ``` or ``` ... ```
+  const fenceMatch = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```$/);
+  if (fenceMatch) {
+    return fenceMatch[1].trim();
+  }
+
+  return trimmed;
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  // --- Parse request body ---
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON in request body" },
+      { status: 400 },
+    );
+  }
+
+  // --- Validate prompt ---
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !("prompt" in body) ||
+    typeof (body as Record<string, unknown>).prompt !== "string"
+  ) {
+    return NextResponse.json(
+      { error: "Request body must include a 'prompt' string" },
+      { status: 400 },
+    );
+  }
+
+  const prompt = ((body as Record<string, unknown>).prompt as string).trim();
+  if (prompt.length === 0) {
+    return NextResponse.json(
+      { error: "Prompt must not be empty" },
+      { status: 400 },
+    );
+  }
+
+  // --- Call LLM ---
+  let rawResponse: string;
+  try {
+    rawResponse = await generateDashboard(prompt);
+  } catch (err: unknown) {
+    const message =
+      err instanceof Error ? err.message : "Unknown LLM error";
+
+    // Surface rate-limit and timeout errors with context
+    const status =
+      message.includes("rate limit") || message.includes("429") ? 429 : 500;
+
+    return NextResponse.json(
+      { error: `LLM error: ${message}` },
+      { status },
+    );
+  }
+
+  // --- Parse JSON from LLM output ---
+  const jsonStr = extractJson(rawResponse);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch {
+    return NextResponse.json(
+      {
+        error: "LLM returned invalid JSON",
+        details: jsonStr.slice(0, 500),
+      },
+      { status: 400 },
+    );
+  }
+
+  // --- Validate against DashboardSpec schema ---
+  try {
+    const spec = validateSpec(parsed);
+    return NextResponse.json(spec, { status: 200 });
+  } catch (err: unknown) {
+    const details =
+      err instanceof ZodError
+        ? err.issues.map((e) => `${e.path.join(".")}: ${e.message}`)
+        : ["Unknown validation error"];
+
+    return NextResponse.json(
+      { error: "LLM returned an invalid dashboard spec", details },
+      { status: 400 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add `POST /api/dashboard/generate` endpoint that accepts `{prompt: string}` and returns an AI-generated `DashboardSpec`
- Parses LLM response JSON, stripping markdown code fences (`\`\`\`json ... \`\`\``) when present
- Validates against `DashboardSpecSchema` (Zod), returns proper HTTP error codes: 400 (invalid input/spec), 429 (rate limit), 500 (LLM error)
- 14 unit tests covering happy path, code fence stripping, input validation edge cases, LLM errors, and schema validation failures

## Test plan
- [x] `cd dashboard && npx vitest run` — all 75 tests pass (14 new + 61 existing)
- [ ] Manual test with real LLM: `curl -X POST http://localhost:4000/api/dashboard/generate -H 'Content-Type: application/json' -d '{"prompt":"Ventas del mes"}'`

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)