### PR TITLE
[D2-B] API: Dashboard modification endpoint

### DIFF
--- a/dashboard/app/api/dashboard/modify/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/modify/__tests__/route.test.ts
@@ -140,8 +140,8 @@ describe("POST /api/dashboard/modify", () => {
 
     expect(res.status).toBe(500);
     const json = await res.json();
-    expect(json.error).toMatch(/LLM error/i);
-    expect(json.error).toMatch(/rate limit/i);
+    expect(json.error).toBe("Failed to modify dashboard");
+    expect(json.code).toBe("LLM_MODIFY_FAILED");
   });
 
   it("returns 400 when LLM returns invalid JSON", async () => {
@@ -197,6 +197,14 @@ describe("POST /api/dashboard/modify", () => {
     expect(res.status).toBe(400);
     const json = await res.json();
     expect(json.error).toMatch(/must be a JSON object/i);
+  });
+
+  it("returns 400 with validation error when spec is null", async () => {
+    const res = await POST(makeRequest({ spec: null, prompt: "Cambiar algo" }));
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/invalid dashboard spec/i);
   });
 
   it("does not expose raw LLM output in error responses", async () => {

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -9,7 +9,7 @@
  */
 import { NextResponse } from "next/server";
 import { modifyDashboard } from "@/lib/llm";
-import { validateSpec, DashboardSpecSchema } from "@/lib/schema";
+import { validateSpec, DashboardSpecSchema, type DashboardSpec } from "@/lib/schema";
 
 /**
  * Extract JSON from a string that may be wrapped in markdown code blocks.
@@ -45,7 +45,7 @@ export async function POST(request: Request) {
   const { spec, prompt } = body as Record<string, unknown>;
 
   // --- Validate required fields ---------------------------------------------
-  if (!spec) {
+  if (spec === undefined) {
     return NextResponse.json(
       { error: "Missing required field: spec" },
       { status: 400 },
@@ -79,9 +79,9 @@ export async function POST(request: Request) {
       prompt.trim(),
     );
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown LLM error";
+    console.error("Failed to modify dashboard via LLM", err);
     return NextResponse.json(
-      { error: `LLM error: ${message}` },
+      { error: "Failed to modify dashboard", code: "LLM_MODIFY_FAILED" },
       { status: 500 },
     );
   }
@@ -98,7 +98,7 @@ export async function POST(request: Request) {
     );
   }
 
-  let updatedSpec;
+  let updatedSpec: DashboardSpec;
   try {
     updatedSpec = validateSpec(parsed);
   } catch {


### PR DESCRIPTION
## Summary
- Add `POST /api/dashboard/modify` endpoint that accepts `{spec, prompt}`, calls `modifyDashboard()` from `lib/llm.ts`, validates both input and output specs with Zod, and handles markdown code block stripping from LLM responses
- Returns 400 for missing fields, invalid spec, or invalid LLM response; returns 500 with generic error for LLM failures (details logged server-side)
- 15 tests covering all success and error paths (all 76 dashboard tests pass)

## Test plan
- [x] Valid modification returns updated spec (200)
- [x] Markdown code blocks stripped from LLM response
- [x] Missing spec returns 400
- [x] Missing/empty prompt returns 400
- [x] Invalid incoming spec returns 400
- [x] LLM error returns 500 with generic message
- [x] Invalid JSON from LLM returns 400
- [x] Valid JSON but invalid spec from LLM returns 400
- [x] Correct arguments passed to modifyDashboard()
- [x] Malformed JSON body returns 400
- [x] Array body returns 400
- [x] String body returns 400
- [x] Null spec goes to Zod validation (not "missing" error)
- [x] Raw LLM output not exposed in error responses
- [x] Internal error details not exposed to clients

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)