### PR TITLE
[D3-A] Widget components: KPI, Bar, Line, Area, Donut, Table, Number

### DIFF
--- a/dashboard/app/demo/page.tsx
+++ b/dashboard/app/demo/page.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import {
+  KpiRow,
+  BarChartWidget,
+  LineChartWidget,
+  AreaChartWidget,
+  DonutChartWidget,
+  TableWidget,
+  NumberWidget,
+} from "@/components/widgets";
+import type {
+  KpiRowWidget,
+  BarChartWidget as BarChartSpec,
+  LineChartWidget as LineChartSpec,
+  AreaChartWidget as AreaChartSpec,
+  DonutChartWidget as DonutChartSpec,
+  TableWidget as TableSpec,
+  NumberWidget as NumberSpec,
+} from "@/lib/schema";
+import type { WidgetData } from "@/components/widgets";
+
+// ---------------------------------------------------------------------------
+// Sample data
+// ---------------------------------------------------------------------------
+
+const kpiWidget: KpiRowWidget = {
+  type: "kpi_row",
+  items: [
+    { label: "Ventas Netas", sql: "", format: "currency", prefix: "\u20ac" },
+    { label: "Tickets", sql: "", format: "number" },
+    { label: "Ticket Medio", sql: "", format: "currency", prefix: "\u20ac" },
+    { label: "Margen", sql: "", format: "percent" },
+  ],
+};
+
+const kpiData = new Map<number, { value: string | number }>([
+  [0, { value: 125340.5 }],
+  [1, { value: 4521 }],
+  [2, { value: 27.72 }],
+  [3, { value: 34.8 }],
+]);
+
+const barWidget: BarChartSpec = {
+  type: "bar_chart",
+  title: "Ventas por Tienda",
+  sql: "",
+  x: "tienda",
+  y: "ventas",
+};
+
+const barData: WidgetData = {
+  columns: ["tienda", "ventas"],
+  rows: [
+    ["Madrid Centro", 45200],
+    ["Barcelona", 38900],
+    ["Valencia", 22100],
+    ["Sevilla", 18500],
+    ["Bilbao", 15300],
+  ],
+};
+
+const lineWidget: LineChartSpec = {
+  type: "line_chart",
+  title: "Tendencia Semanal de Ventas",
+  sql: "",
+  x: "semana",
+  y: "ventas",
+};
+
+const lineData: WidgetData = {
+  columns: ["semana", "ventas"],
+  rows: [
+    ["Sem 1", 18500],
+    ["Sem 2", 22300],
+    ["Sem 3", 19800],
+    ["Sem 4", 25100],
+    ["Sem 5", 28400],
+    ["Sem 6", 31200],
+  ],
+};
+
+const areaWidget: AreaChartSpec = {
+  type: "area_chart",
+  title: "Evolucion Mensual de Ingresos",
+  sql: "",
+  x: "mes",
+  y: "ingresos",
+};
+
+const areaData: WidgetData = {
+  columns: ["mes", "ingresos"],
+  rows: [
+    ["Ene", 95000],
+    ["Feb", 102000],
+    ["Mar", 118000],
+    ["Abr", 125000],
+    ["May", 110000],
+    ["Jun", 135000],
+  ],
+};
+
+const donutWidget: DonutChartSpec = {
+  type: "donut_chart",
+  title: "Mix por Familia",
+  sql: "",
+  x: "familia",
+  y: "porcentaje",
+};
+
+const donutData: WidgetData = {
+  columns: ["familia", "porcentaje"],
+  rows: [
+    ["Camisetas", 35],
+    ["Pantalones", 25],
+    ["Calzado", 20],
+    ["Accesorios", 12],
+    ["Otros", 8],
+  ],
+};
+
+const tableWidget: TableSpec = {
+  type: "table",
+  title: "Top 10 Articulos por Ventas",
+  sql: "",
+};
+
+const tableData: WidgetData = {
+  columns: ["Referencia", "Descripcion", "Unidades", "Importe"],
+  rows: [
+    ["CAM-001", "Camiseta basica blanca", 245, 4900],
+    ["PAN-012", "Pantalon vaquero slim", 189, 9450],
+    ["CAL-005", "Zapatilla deportiva", 156, 11700],
+    ["CAM-003", "Camiseta estampada", 134, 3350],
+    ["ACC-008", "Cinturon cuero", 121, 2420],
+    ["PAN-007", "Pantalon chino beige", 98, 3920],
+    ["CAM-015", "Polo manga corta", 87, 2610],
+    ["CAL-002", "Bota casual", 76, 6840],
+    ["ACC-001", "Gafas de sol", 72, 2880],
+    ["CAM-009", "Sudadera con capucha", 65, 3250],
+  ],
+};
+
+const numberWidget: NumberSpec = {
+  type: "number",
+  title: "Total Ventas del Mes",
+  sql: "",
+  format: "currency",
+  prefix: "\u20ac",
+};
+
+const numberData: WidgetData = {
+  columns: ["total"],
+  rows: [[253891.45]],
+};
+
+// Empty state widget for demo
+const emptyBarWidget: BarChartSpec = {
+  type: "bar_chart",
+  title: "Grafico sin datos (estado vacio)",
+  sql: "",
+  x: "x",
+  y: "y",
+};
+
+// ---------------------------------------------------------------------------
+// Demo page
+// ---------------------------------------------------------------------------
+
+export default function DemoPage() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">
+          Demo de Widgets
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Todos los tipos de widget con datos de ejemplo.
+        </p>
+      </div>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-gray-700">
+          KPI Row
+        </h2>
+        <KpiRow widget={kpiWidget} data={kpiData} />
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-gray-700">
+          Number (numero grande)
+        </h2>
+        <div className="max-w-sm">
+          <NumberWidget widget={numberWidget} data={numberData} />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-gray-700">
+          Bar Chart
+        </h2>
+        <BarChartWidget widget={barWidget} data={barData} />
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-gray-700">
+          Line Chart
+        </h2>
+        <LineChartWidget widget={lineWidget} data={lineData} />
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-gray-700">
+          Area Chart
+        </h2>
+        <AreaChartWidget widget={areaWidget} data={areaData} />
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-gray-700">
+          Donut Chart
+        </h2>
+        <div className="max-w-md">
+          <DonutChartWidget widget={donutWidget} data={donutData} />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-gray-700">
+          Table (con ordenacion)
+        </h2>
+        <TableWidget widget={tableWidget} data={tableData} />
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-gray-700">
+          Estado vacio
+        </h2>
+        <BarChartWidget widget={emptyBarWidget} data={null} />
+      </section>
+    </div>
+  );
+}

--- a/dashboard/app/demo/page.tsx
+++ b/dashboard/app/demo/page.tsx
@@ -34,12 +34,12 @@ const kpiWidget: KpiRowWidget = {
   ],
 };
 
-const kpiData = new Map<number, { value: string | number }>([
-  [0, { value: 125340.5 }],
-  [1, { value: 4521 }],
-  [2, { value: 27.72 }],
-  [3, { value: 34.8 }],
-]);
+const kpiData: (WidgetData | null)[] = [
+  { columns: ["value"], rows: [[125340.5]] },
+  { columns: ["value"], rows: [[4521]] },
+  { columns: ["value"], rows: [[27.72]] },
+  { columns: ["value"], rows: [[34.8]] },
+];
 
 const barWidget: BarChartSpec = {
   type: "bar_chart",

--- a/dashboard/components/widgets/AreaChartWidget.tsx
+++ b/dashboard/components/widgets/AreaChartWidget.tsx
@@ -3,7 +3,7 @@
 import { Card, AreaChart } from "@tremor/react";
 import type { AreaChartWidget as AreaChartWidgetSpec } from "@/lib/schema";
 import type { WidgetData } from "./types";
-import { EMPTY_MESSAGE } from "./types";
+import { EMPTY_MESSAGE, resolveXY } from "./types";
 
 interface AreaChartWidgetProps {
   widget: AreaChartWidgetSpec;
@@ -22,14 +22,22 @@ export function AreaChartWidget({ widget, data }: AreaChartWidgetProps) {
     );
   }
 
-  const xCol = widget.x ?? data.columns[0];
-  const yCol = widget.y ?? data.columns[1];
-  const xIdx = data.columns.indexOf(xCol);
-  const yIdx = data.columns.indexOf(yCol);
+  const resolved = resolveXY(data, widget.x, widget.y);
+  if (!resolved) {
+    return (
+      <Card className="p-4">
+        <h3 className="text-sm font-medium text-gray-500">{widget.title}</h3>
+        <p className="mt-4 text-center text-sm text-gray-400">
+          {EMPTY_MESSAGE}
+        </p>
+      </Card>
+    );
+  }
 
+  const { xIdx, yIdx, xCol, yCol } = resolved;
   const chartData = data.rows.map((row) => ({
-    [xCol]: String(row[xIdx >= 0 ? xIdx : 0]),
-    [yCol]: Number(row[yIdx >= 0 ? yIdx : 1]),
+    [xCol]: String(row[xIdx]),
+    [yCol]: Number(row[yIdx]),
   }));
 
   return (

--- a/dashboard/components/widgets/AreaChartWidget.tsx
+++ b/dashboard/components/widgets/AreaChartWidget.tsx
@@ -3,7 +3,7 @@
 import { Card, AreaChart } from "@tremor/react";
 import type { AreaChartWidget as AreaChartWidgetSpec } from "@/lib/schema";
 import type { WidgetData } from "./types";
-import { EMPTY_MESSAGE, resolveXY } from "./types";
+import { EMPTY_MESSAGE, resolveXY, safeNumber } from "./types";
 
 interface AreaChartWidgetProps {
   widget: AreaChartWidgetSpec;
@@ -35,10 +35,12 @@ export function AreaChartWidget({ widget, data }: AreaChartWidgetProps) {
   }
 
   const { xIdx, yIdx, xCol, yCol } = resolved;
-  const chartData = data.rows.map((row) => ({
-    [xCol]: String(row[xIdx]),
-    [yCol]: Number(row[yIdx]),
-  }));
+  const chartData = data.rows
+    .filter((row) => safeNumber(row[yIdx]) !== null)
+    .map((row) => ({
+      [xCol]: String(row[xIdx]),
+      [yCol]: safeNumber(row[yIdx])!,
+    }));
 
   return (
     <Card className="p-4">

--- a/dashboard/components/widgets/AreaChartWidget.tsx
+++ b/dashboard/components/widgets/AreaChartWidget.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Card, AreaChart } from "@tremor/react";
+import type { AreaChartWidget as AreaChartWidgetSpec } from "@/lib/schema";
+import type { WidgetData } from "./types";
+import { EMPTY_MESSAGE } from "./types";
+
+interface AreaChartWidgetProps {
+  widget: AreaChartWidgetSpec;
+  data: WidgetData | null;
+}
+
+export function AreaChartWidget({ widget, data }: AreaChartWidgetProps) {
+  if (!data || data.rows.length === 0) {
+    return (
+      <Card className="p-4">
+        <h3 className="text-sm font-medium text-gray-500">{widget.title}</h3>
+        <p className="mt-4 text-center text-sm text-gray-400">
+          {EMPTY_MESSAGE}
+        </p>
+      </Card>
+    );
+  }
+
+  const xCol = widget.x ?? data.columns[0];
+  const yCol = widget.y ?? data.columns[1];
+  const xIdx = data.columns.indexOf(xCol);
+  const yIdx = data.columns.indexOf(yCol);
+
+  const chartData = data.rows.map((row) => ({
+    [xCol]: String(row[xIdx >= 0 ? xIdx : 0]),
+    [yCol]: Number(row[yIdx >= 0 ? yIdx : 1]),
+  }));
+
+  return (
+    <Card className="p-4">
+      <h3 className="mb-4 text-sm font-medium text-gray-500">{widget.title}</h3>
+      <AreaChart
+        data={chartData}
+        index={xCol}
+        categories={[yCol]}
+        yAxisWidth={60}
+      />
+    </Card>
+  );
+}

--- a/dashboard/components/widgets/BarChartWidget.tsx
+++ b/dashboard/components/widgets/BarChartWidget.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Card, BarChart } from "@tremor/react";
+import type { BarChartWidget as BarChartWidgetSpec } from "@/lib/schema";
+import type { WidgetData } from "./types";
+import { EMPTY_MESSAGE } from "./types";
+
+interface BarChartWidgetProps {
+  widget: BarChartWidgetSpec;
+  data: WidgetData | null;
+}
+
+export function BarChartWidget({ widget, data }: BarChartWidgetProps) {
+  if (!data || data.rows.length === 0) {
+    return (
+      <Card className="p-4">
+        <h3 className="text-sm font-medium text-gray-500">{widget.title}</h3>
+        <p className="mt-4 text-center text-sm text-gray-400">
+          {EMPTY_MESSAGE}
+        </p>
+      </Card>
+    );
+  }
+
+  const xIdx = data.columns.indexOf(widget.x);
+  const yIdx = data.columns.indexOf(widget.y);
+
+  const chartData = data.rows.map((row) => ({
+    [widget.x]: row[xIdx >= 0 ? xIdx : 0],
+    [widget.y]: Number(row[yIdx >= 0 ? yIdx : 1]),
+  }));
+
+  return (
+    <Card className="p-4">
+      <h3 className="mb-4 text-sm font-medium text-gray-500">{widget.title}</h3>
+      <BarChart
+        data={chartData}
+        index={widget.x}
+        categories={[widget.y]}
+        yAxisWidth={60}
+        showLegend={false}
+      />
+    </Card>
+  );
+}

--- a/dashboard/components/widgets/BarChartWidget.tsx
+++ b/dashboard/components/widgets/BarChartWidget.tsx
@@ -3,7 +3,7 @@
 import { Card, BarChart } from "@tremor/react";
 import type { BarChartWidget as BarChartWidgetSpec } from "@/lib/schema";
 import type { WidgetData } from "./types";
-import { EMPTY_MESSAGE, resolveXY } from "./types";
+import { EMPTY_MESSAGE, resolveXY, safeNumber } from "./types";
 
 interface BarChartWidgetProps {
   widget: BarChartWidgetSpec;
@@ -35,10 +35,12 @@ export function BarChartWidget({ widget, data }: BarChartWidgetProps) {
   }
 
   const { xIdx, yIdx, xCol, yCol } = resolved;
-  const chartData = data.rows.map((row) => ({
-    [xCol]: row[xIdx],
-    [yCol]: Number(row[yIdx]),
-  }));
+  const chartData = data.rows
+    .filter((row) => safeNumber(row[yIdx]) !== null)
+    .map((row) => ({
+      [xCol]: row[xIdx],
+      [yCol]: safeNumber(row[yIdx])!,
+    }));
 
   return (
     <Card className="p-4">

--- a/dashboard/components/widgets/BarChartWidget.tsx
+++ b/dashboard/components/widgets/BarChartWidget.tsx
@@ -3,7 +3,7 @@
 import { Card, BarChart } from "@tremor/react";
 import type { BarChartWidget as BarChartWidgetSpec } from "@/lib/schema";
 import type { WidgetData } from "./types";
-import { EMPTY_MESSAGE } from "./types";
+import { EMPTY_MESSAGE, resolveXY } from "./types";
 
 interface BarChartWidgetProps {
   widget: BarChartWidgetSpec;
@@ -22,12 +22,22 @@ export function BarChartWidget({ widget, data }: BarChartWidgetProps) {
     );
   }
 
-  const xIdx = data.columns.indexOf(widget.x);
-  const yIdx = data.columns.indexOf(widget.y);
+  const resolved = resolveXY(data, widget.x, widget.y);
+  if (!resolved) {
+    return (
+      <Card className="p-4">
+        <h3 className="text-sm font-medium text-gray-500">{widget.title}</h3>
+        <p className="mt-4 text-center text-sm text-gray-400">
+          {EMPTY_MESSAGE}
+        </p>
+      </Card>
+    );
+  }
 
+  const { xIdx, yIdx, xCol, yCol } = resolved;
   const chartData = data.rows.map((row) => ({
-    [widget.x]: row[xIdx >= 0 ? xIdx : 0],
-    [widget.y]: Number(row[yIdx >= 0 ? yIdx : 1]),
+    [xCol]: row[xIdx],
+    [yCol]: Number(row[yIdx]),
   }));
 
   return (
@@ -35,8 +45,8 @@ export function BarChartWidget({ widget, data }: BarChartWidgetProps) {
       <h3 className="mb-4 text-sm font-medium text-gray-500">{widget.title}</h3>
       <BarChart
         data={chartData}
-        index={widget.x}
-        categories={[widget.y]}
+        index={xCol}
+        categories={[yCol]}
         yAxisWidth={60}
         showLegend={false}
       />

--- a/dashboard/components/widgets/DonutChartWidget.tsx
+++ b/dashboard/components/widgets/DonutChartWidget.tsx
@@ -3,7 +3,7 @@
 import { Card, DonutChart } from "@tremor/react";
 import type { DonutChartWidget as DonutChartWidgetSpec } from "@/lib/schema";
 import type { WidgetData } from "./types";
-import { EMPTY_MESSAGE, resolveXY } from "./types";
+import { EMPTY_MESSAGE, resolveXY, safeNumber } from "./types";
 
 interface DonutChartWidgetProps {
   widget: DonutChartWidgetSpec;
@@ -35,10 +35,12 @@ export function DonutChartWidget({ widget, data }: DonutChartWidgetProps) {
   }
 
   const { xIdx, yIdx } = resolved;
-  const chartData = data.rows.map((row) => ({
-    name: String(row[xIdx]),
-    value: Number(row[yIdx]),
-  }));
+  const chartData = data.rows
+    .filter((row) => row[xIdx] != null && row[xIdx] !== "" && safeNumber(row[yIdx]) !== null)
+    .map((row) => ({
+      name: String(row[xIdx]),
+      value: safeNumber(row[yIdx])!,
+    }));
 
   return (
     <Card className="p-4">

--- a/dashboard/components/widgets/DonutChartWidget.tsx
+++ b/dashboard/components/widgets/DonutChartWidget.tsx
@@ -3,7 +3,7 @@
 import { Card, DonutChart } from "@tremor/react";
 import type { DonutChartWidget as DonutChartWidgetSpec } from "@/lib/schema";
 import type { WidgetData } from "./types";
-import { EMPTY_MESSAGE } from "./types";
+import { EMPTY_MESSAGE, resolveXY } from "./types";
 
 interface DonutChartWidgetProps {
   widget: DonutChartWidgetSpec;
@@ -22,14 +22,22 @@ export function DonutChartWidget({ widget, data }: DonutChartWidgetProps) {
     );
   }
 
-  const xCol = widget.x ?? data.columns[0];
-  const yCol = widget.y ?? data.columns[1];
-  const xIdx = data.columns.indexOf(xCol);
-  const yIdx = data.columns.indexOf(yCol);
+  const resolved = resolveXY(data, widget.x, widget.y);
+  if (!resolved) {
+    return (
+      <Card className="p-4">
+        <h3 className="text-sm font-medium text-gray-500">{widget.title}</h3>
+        <p className="mt-4 text-center text-sm text-gray-400">
+          {EMPTY_MESSAGE}
+        </p>
+      </Card>
+    );
+  }
 
+  const { xIdx, yIdx } = resolved;
   const chartData = data.rows.map((row) => ({
-    name: String(row[xIdx >= 0 ? xIdx : 0]),
-    value: Number(row[yIdx >= 0 ? yIdx : 1]),
+    name: String(row[xIdx]),
+    value: Number(row[yIdx]),
   }));
 
   return (

--- a/dashboard/components/widgets/DonutChartWidget.tsx
+++ b/dashboard/components/widgets/DonutChartWidget.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Card, DonutChart } from "@tremor/react";
+import type { DonutChartWidget as DonutChartWidgetSpec } from "@/lib/schema";
+import type { WidgetData } from "./types";
+import { EMPTY_MESSAGE } from "./types";
+
+interface DonutChartWidgetProps {
+  widget: DonutChartWidgetSpec;
+  data: WidgetData | null;
+}
+
+export function DonutChartWidget({ widget, data }: DonutChartWidgetProps) {
+  if (!data || data.rows.length === 0) {
+    return (
+      <Card className="p-4">
+        <h3 className="text-sm font-medium text-gray-500">{widget.title}</h3>
+        <p className="mt-4 text-center text-sm text-gray-400">
+          {EMPTY_MESSAGE}
+        </p>
+      </Card>
+    );
+  }
+
+  const xCol = widget.x ?? data.columns[0];
+  const yCol = widget.y ?? data.columns[1];
+  const xIdx = data.columns.indexOf(xCol);
+  const yIdx = data.columns.indexOf(yCol);
+
+  const chartData = data.rows.map((row) => ({
+    name: String(row[xIdx >= 0 ? xIdx : 0]),
+    value: Number(row[yIdx >= 0 ? yIdx : 1]),
+  }));
+
+  return (
+    <Card className="p-4">
+      <h3 className="mb-4 text-sm font-medium text-gray-500">{widget.title}</h3>
+      <DonutChart
+        data={chartData}
+        category="value"
+        index="name"
+        showLabel
+        showAnimation
+      />
+    </Card>
+  );
+}

--- a/dashboard/components/widgets/KpiRow.tsx
+++ b/dashboard/components/widgets/KpiRow.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Card } from "@tremor/react";
+import type { KpiRowWidget } from "@/lib/schema";
+import { formatValue } from "./format";
+
+interface KpiRowProps {
+  widget: KpiRowWidget;
+  /** Map from item index to its query result value. */
+  data: Map<number, { value: string | number }>;
+}
+
+export function KpiRow({ widget, data }: KpiRowProps) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {widget.items.map((item, idx) => {
+        const entry = data.get(idx);
+        const displayValue =
+          entry !== undefined
+            ? formatValue(entry.value, item.format, item.prefix)
+            : "—";
+
+        return (
+          <Card key={idx} className="p-4">
+            <p className="text-sm text-gray-500">{item.label}</p>
+            <p className="mt-1 text-2xl font-semibold text-gray-900">
+              {displayValue}
+            </p>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/components/widgets/KpiRow.tsx
+++ b/dashboard/components/widgets/KpiRow.tsx
@@ -2,23 +2,27 @@
 
 import { Card } from "@tremor/react";
 import type { KpiRowWidget } from "@/lib/schema";
+import type { WidgetData } from "./types";
 import { formatValue } from "./format";
 
 interface KpiRowProps {
   widget: KpiRowWidget;
-  /** Map from item index to its query result value. */
-  data: Map<number, { value: string | number }>;
+  /**
+   * Array of query results, one per KPI item (by index).
+   * Each WidgetData should have a single row with a single value.
+   * A null entry means the query has not been executed or returned no data.
+   */
+  data: (WidgetData | null)[];
 }
 
 export function KpiRow({ widget, data }: KpiRowProps) {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {widget.items.map((item, idx) => {
-        const entry = data.get(idx);
-        const displayValue =
-          entry !== undefined
-            ? formatValue(entry.value, item.format, item.prefix)
-            : "—";
+        const entry = data[idx];
+        const rawValue =
+          entry && entry.rows.length > 0 ? entry.rows[0][0] : null;
+        const displayValue = formatValue(rawValue, item.format, item.prefix);
 
         return (
           <Card key={idx} className="p-4">

--- a/dashboard/components/widgets/LineChartWidget.tsx
+++ b/dashboard/components/widgets/LineChartWidget.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Card, LineChart } from "@tremor/react";
+import type { LineChartWidget as LineChartWidgetSpec } from "@/lib/schema";
+import type { WidgetData } from "./types";
+import { EMPTY_MESSAGE } from "./types";
+
+interface LineChartWidgetProps {
+  widget: LineChartWidgetSpec;
+  data: WidgetData | null;
+}
+
+export function LineChartWidget({ widget, data }: LineChartWidgetProps) {
+  if (!data || data.rows.length === 0) {
+    return (
+      <Card className="p-4">
+        <h3 className="text-sm font-medium text-gray-500">{widget.title}</h3>
+        <p className="mt-4 text-center text-sm text-gray-400">
+          {EMPTY_MESSAGE}
+        </p>
+      </Card>
+    );
+  }
+
+  const xCol = widget.x ?? data.columns[0];
+  const yCol = widget.y ?? data.columns[1];
+  const xIdx = data.columns.indexOf(xCol);
+  const yIdx = data.columns.indexOf(yCol);
+
+  const chartData = data.rows.map((row) => ({
+    [xCol]: String(row[xIdx >= 0 ? xIdx : 0]),
+    [yCol]: Number(row[yIdx >= 0 ? yIdx : 1]),
+  }));
+
+  return (
+    <Card className="p-4">
+      <h3 className="mb-4 text-sm font-medium text-gray-500">{widget.title}</h3>
+      <LineChart
+        data={chartData}
+        index={xCol}
+        categories={[yCol]}
+        yAxisWidth={60}
+      />
+    </Card>
+  );
+}

--- a/dashboard/components/widgets/LineChartWidget.tsx
+++ b/dashboard/components/widgets/LineChartWidget.tsx
@@ -3,7 +3,7 @@
 import { Card, LineChart } from "@tremor/react";
 import type { LineChartWidget as LineChartWidgetSpec } from "@/lib/schema";
 import type { WidgetData } from "./types";
-import { EMPTY_MESSAGE, resolveXY } from "./types";
+import { EMPTY_MESSAGE, resolveXY, safeNumber } from "./types";
 
 interface LineChartWidgetProps {
   widget: LineChartWidgetSpec;
@@ -35,10 +35,12 @@ export function LineChartWidget({ widget, data }: LineChartWidgetProps) {
   }
 
   const { xIdx, yIdx, xCol, yCol } = resolved;
-  const chartData = data.rows.map((row) => ({
-    [xCol]: String(row[xIdx]),
-    [yCol]: Number(row[yIdx]),
-  }));
+  const chartData = data.rows
+    .filter((row) => safeNumber(row[yIdx]) !== null)
+    .map((row) => ({
+      [xCol]: String(row[xIdx]),
+      [yCol]: safeNumber(row[yIdx])!,
+    }));
 
   return (
     <Card className="p-4">

--- a/dashboard/components/widgets/LineChartWidget.tsx
+++ b/dashboard/components/widgets/LineChartWidget.tsx
@@ -3,7 +3,7 @@
 import { Card, LineChart } from "@tremor/react";
 import type { LineChartWidget as LineChartWidgetSpec } from "@/lib/schema";
 import type { WidgetData } from "./types";
-import { EMPTY_MESSAGE } from "./types";
+import { EMPTY_MESSAGE, resolveXY } from "./types";
 
 interface LineChartWidgetProps {
   widget: LineChartWidgetSpec;
@@ -22,14 +22,22 @@ export function LineChartWidget({ widget, data }: LineChartWidgetProps) {
     );
   }
 
-  const xCol = widget.x ?? data.columns[0];
-  const yCol = widget.y ?? data.columns[1];
-  const xIdx = data.columns.indexOf(xCol);
-  const yIdx = data.columns.indexOf(yCol);
+  const resolved = resolveXY(data, widget.x, widget.y);
+  if (!resolved) {
+    return (
+      <Card className="p-4">
+        <h3 className="text-sm font-medium text-gray-500">{widget.title}</h3>
+        <p className="mt-4 text-center text-sm text-gray-400">
+          {EMPTY_MESSAGE}
+        </p>
+      </Card>
+    );
+  }
 
+  const { xIdx, yIdx, xCol, yCol } = resolved;
   const chartData = data.rows.map((row) => ({
-    [xCol]: String(row[xIdx >= 0 ? xIdx : 0]),
-    [yCol]: Number(row[yIdx >= 0 ? yIdx : 1]),
+    [xCol]: String(row[xIdx]),
+    [yCol]: Number(row[yIdx]),
   }));
 
   return (

--- a/dashboard/components/widgets/NumberWidget.tsx
+++ b/dashboard/components/widgets/NumberWidget.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Card } from "@tremor/react";
+import type { NumberWidget as NumberWidgetSpec } from "@/lib/schema";
+import type { WidgetData } from "./types";
+import { EMPTY_MESSAGE } from "./types";
+import { formatValue } from "./format";
+
+interface NumberWidgetProps {
+  widget: NumberWidgetSpec;
+  data: WidgetData | null;
+}
+
+export function NumberWidget({ widget, data }: NumberWidgetProps) {
+  if (!data || data.rows.length === 0) {
+    return (
+      <Card className="p-4">
+        <h3 className="text-sm font-medium text-gray-500">{widget.title}</h3>
+        <p className="mt-4 text-center text-sm text-gray-400">
+          {EMPTY_MESSAGE}
+        </p>
+      </Card>
+    );
+  }
+
+  const rawValue = data.rows[0][0];
+  const displayValue = formatValue(rawValue, widget.format, widget.prefix);
+
+  return (
+    <Card className="p-4">
+      <p className="text-sm text-gray-500">{widget.title}</p>
+      <p className="mt-2 text-4xl font-semibold text-gray-900">
+        {displayValue}
+      </p>
+    </Card>
+  );
+}

--- a/dashboard/components/widgets/TableWidget.tsx
+++ b/dashboard/components/widgets/TableWidget.tsx
@@ -13,6 +13,9 @@ interface TableWidgetProps {
 
 type SortDir = "asc" | "desc";
 
+/** Shared formatter to avoid per-cell allocations. */
+const cellFormatter = new Intl.NumberFormat("es-ES", { useGrouping: true });
+
 function isNullish(v: unknown): boolean {
   return v === null || v === undefined || v === "";
 }
@@ -79,15 +82,27 @@ export function TableWidget({ widget, data }: TableWidgetProps) {
               {data.columns.map((col, idx) => (
                 <th
                   key={`${idx}-${col}`}
-                  onClick={() => handleSort(idx)}
-                  className="cursor-pointer px-3 py-2 text-left font-medium text-gray-600 hover:text-gray-900"
+                  className="px-3 py-2 text-left font-medium text-gray-600"
+                  aria-sort={
+                    sortCol === idx
+                      ? sortDir === "asc"
+                        ? "ascending"
+                        : "descending"
+                      : "none"
+                  }
                 >
-                  {col}
-                  {sortCol === idx && (
-                    <span className="ml-1">
-                      {sortDir === "asc" ? "\u2191" : "\u2193"}
-                    </span>
-                  )}
+                  <button
+                    type="button"
+                    onClick={() => handleSort(idx)}
+                    className="inline-flex items-center hover:text-gray-900"
+                  >
+                    {col}
+                    {sortCol === idx && (
+                      <span className="ml-1">
+                        {sortDir === "asc" ? "\u2191" : "\u2193"}
+                      </span>
+                    )}
+                  </button>
                 </th>
               ))}
             </tr>
@@ -110,15 +125,15 @@ export function TableWidget({ widget, data }: TableWidgetProps) {
 }
 
 function formatCell(value: unknown): string {
-  if (value === null || value === undefined) return "\u2014";
+  if (value === null || value === undefined || value === "") return "\u2014";
   if (typeof value === "number") {
-    return new Intl.NumberFormat("es-ES", { useGrouping: true }).format(value);
+    return cellFormatter.format(value);
   }
   // Handle numeric strings from PostgreSQL NUMERIC columns
-  if (typeof value === "string" && value !== "") {
+  if (typeof value === "string") {
     const num = Number(value);
     if (Number.isFinite(num)) {
-      return new Intl.NumberFormat("es-ES", { useGrouping: true }).format(num);
+      return cellFormatter.format(num);
     }
   }
   return String(value);

--- a/dashboard/components/widgets/TableWidget.tsx
+++ b/dashboard/components/widgets/TableWidget.tsx
@@ -13,6 +13,10 @@ interface TableWidgetProps {
 
 type SortDir = "asc" | "desc";
 
+function isNullish(v: unknown): boolean {
+  return v === null || v === undefined || v === "";
+}
+
 export function TableWidget({ widget, data }: TableWidgetProps) {
   const [sortCol, setSortCol] = useState<number | null>(null);
   const [sortDir, setSortDir] = useState<SortDir>("asc");
@@ -23,15 +27,21 @@ export function TableWidget({ widget, data }: TableWidgetProps) {
     rows.sort((a, b) => {
       const va = a[sortCol];
       const vb = b[sortCol];
+
+      // Nullish values always sort last regardless of direction
+      if (isNullish(va) && isNullish(vb)) return 0;
+      if (isNullish(va)) return 1;
+      if (isNullish(vb)) return -1;
+
       const na = Number(va);
       const nb = Number(vb);
-      // Numeric comparison when both are numbers
-      if (!Number.isNaN(na) && !Number.isNaN(nb)) {
+      // Numeric comparison when both are finite numbers
+      if (Number.isFinite(na) && Number.isFinite(nb)) {
         return sortDir === "asc" ? na - nb : nb - na;
       }
       // String comparison
-      const sa = String(va ?? "");
-      const sb = String(vb ?? "");
+      const sa = String(va);
+      const sb = String(vb);
       return sortDir === "asc"
         ? sa.localeCompare(sb, "es")
         : sb.localeCompare(sa, "es");
@@ -68,7 +78,7 @@ export function TableWidget({ widget, data }: TableWidgetProps) {
             <tr className="border-b border-gray-200">
               {data.columns.map((col, idx) => (
                 <th
-                  key={col}
+                  key={`${idx}-${col}`}
                   onClick={() => handleSort(idx)}
                   className="cursor-pointer px-3 py-2 text-left font-medium text-gray-600 hover:text-gray-900"
                 >
@@ -100,9 +110,16 @@ export function TableWidget({ widget, data }: TableWidgetProps) {
 }
 
 function formatCell(value: unknown): string {
-  if (value === null || value === undefined) return "—";
+  if (value === null || value === undefined) return "\u2014";
   if (typeof value === "number") {
-    return new Intl.NumberFormat("es-ES").format(value);
+    return new Intl.NumberFormat("es-ES", { useGrouping: true }).format(value);
+  }
+  // Handle numeric strings from PostgreSQL NUMERIC columns
+  if (typeof value === "string" && value !== "") {
+    const num = Number(value);
+    if (Number.isFinite(num)) {
+      return new Intl.NumberFormat("es-ES", { useGrouping: true }).format(num);
+    }
   }
   return String(value);
 }

--- a/dashboard/components/widgets/TableWidget.tsx
+++ b/dashboard/components/widgets/TableWidget.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Card } from "@tremor/react";
+import type { TableWidget as TableWidgetSpec } from "@/lib/schema";
+import type { WidgetData } from "./types";
+import { EMPTY_MESSAGE } from "./types";
+
+interface TableWidgetProps {
+  widget: TableWidgetSpec;
+  data: WidgetData | null;
+}
+
+type SortDir = "asc" | "desc";
+
+export function TableWidget({ widget, data }: TableWidgetProps) {
+  const [sortCol, setSortCol] = useState<number | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  const sortedRows = useMemo(() => {
+    if (!data || sortCol === null) return data?.rows ?? [];
+    const rows = [...data.rows];
+    rows.sort((a, b) => {
+      const va = a[sortCol];
+      const vb = b[sortCol];
+      const na = Number(va);
+      const nb = Number(vb);
+      // Numeric comparison when both are numbers
+      if (!Number.isNaN(na) && !Number.isNaN(nb)) {
+        return sortDir === "asc" ? na - nb : nb - na;
+      }
+      // String comparison
+      const sa = String(va ?? "");
+      const sb = String(vb ?? "");
+      return sortDir === "asc"
+        ? sa.localeCompare(sb, "es")
+        : sb.localeCompare(sa, "es");
+    });
+    return rows;
+  }, [data, sortCol, sortDir]);
+
+  function handleSort(colIdx: number) {
+    if (sortCol === colIdx) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortCol(colIdx);
+      setSortDir("asc");
+    }
+  }
+
+  if (!data || data.rows.length === 0) {
+    return (
+      <Card className="p-4">
+        <h3 className="text-sm font-medium text-gray-500">{widget.title}</h3>
+        <p className="mt-4 text-center text-sm text-gray-400">
+          {EMPTY_MESSAGE}
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-4">
+      <h3 className="mb-4 text-sm font-medium text-gray-500">{widget.title}</h3>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-200">
+              {data.columns.map((col, idx) => (
+                <th
+                  key={col}
+                  onClick={() => handleSort(idx)}
+                  className="cursor-pointer px-3 py-2 text-left font-medium text-gray-600 hover:text-gray-900"
+                >
+                  {col}
+                  {sortCol === idx && (
+                    <span className="ml-1">
+                      {sortDir === "asc" ? "\u2191" : "\u2193"}
+                    </span>
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sortedRows.map((row, rIdx) => (
+              <tr key={rIdx} className="border-b border-gray-100 hover:bg-gray-50">
+                {row.map((cell, cIdx) => (
+                  <td key={cIdx} className="px-3 py-2 text-gray-700">
+                    {formatCell(cell)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "number") {
+    return new Intl.NumberFormat("es-ES").format(value);
+  }
+  return String(value);
+}

--- a/dashboard/components/widgets/__tests__/format.test.ts
+++ b/dashboard/components/widgets/__tests__/format.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { formatValue } from "../format";
+
+describe("formatValue", () => {
+  it("formats currency with prefix in European style", () => {
+    expect(formatValue(1234.56, "currency", "\u20ac")).toBe("\u20ac1.234,56");
+  });
+
+  it("formats currency without prefix", () => {
+    expect(formatValue(1234.56, "currency")).toBe("1.234,56");
+  });
+
+  it("formats large currency values", () => {
+    expect(formatValue(125340.5, "currency", "\u20ac")).toBe("\u20ac125.340,50");
+  });
+
+  it("formats integer numbers with dot separator", () => {
+    expect(formatValue(4521, "number")).toBe("4.521");
+  });
+
+  it("formats small numbers without separator", () => {
+    expect(formatValue(42, "number")).toBe("42");
+  });
+
+  it("formats percent with one decimal", () => {
+    expect(formatValue(34.8, "percent")).toBe("34,8%");
+  });
+
+  it("returns dash for NaN input", () => {
+    expect(formatValue("not-a-number", "currency")).toBe("\u2014");
+  });
+
+  it("handles string numeric values", () => {
+    expect(formatValue("1234", "number")).toBe("1.234");
+  });
+
+  it("handles zero", () => {
+    expect(formatValue(0, "currency", "\u20ac")).toBe("\u20ac0,00");
+  });
+
+  it("handles negative values", () => {
+    const result = formatValue(-500.5, "currency", "\u20ac");
+    expect(result).toContain("500,50");
+  });
+});

--- a/dashboard/components/widgets/__tests__/format.test.ts
+++ b/dashboard/components/widgets/__tests__/format.test.ts
@@ -30,6 +30,18 @@ describe("formatValue", () => {
     expect(formatValue("not-a-number", "currency")).toBe("\u2014");
   });
 
+  it("returns dash for null", () => {
+    expect(formatValue(null, "currency")).toBe("\u2014");
+  });
+
+  it("returns dash for undefined", () => {
+    expect(formatValue(undefined, "number")).toBe("\u2014");
+  });
+
+  it("returns dash for empty string", () => {
+    expect(formatValue("", "percent")).toBe("\u2014");
+  });
+
   it("handles string numeric values", () => {
     expect(formatValue("1234", "number")).toBe("1.234");
   });

--- a/dashboard/components/widgets/__tests__/setup.ts
+++ b/dashboard/components/widgets/__tests__/setup.ts
@@ -1,0 +1,14 @@
+/**
+ * JSDOM setup for widget component tests.
+ * Polyfills missing browser APIs that Tremor/recharts depend on.
+ */
+import "@testing-library/jest-dom/vitest";
+
+// recharts ResponsiveContainer requires ResizeObserver
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;

--- a/dashboard/components/widgets/__tests__/widgets.test.tsx
+++ b/dashboard/components/widgets/__tests__/widgets.test.tsx
@@ -36,10 +36,10 @@ describe("KpiRow", () => {
   };
 
   it("renders labels and formatted values", () => {
-    const data = new Map<number, { value: string | number }>([
-      [0, { value: 1234.5 }],
-      [1, { value: 42 }],
-    ]);
+    const data: (WidgetData | null)[] = [
+      { columns: ["value"], rows: [[1234.5]] },
+      { columns: ["value"], rows: [[42]] },
+    ];
     render(<KpiRow widget={widget} data={data} />);
     expect(screen.getByText("Ventas")).toBeInTheDocument();
     expect(screen.getByText("Tickets")).toBeInTheDocument();
@@ -48,7 +48,7 @@ describe("KpiRow", () => {
   });
 
   it("shows dash when data is missing for an item", () => {
-    const data = new Map<number, { value: string | number }>();
+    const data: (WidgetData | null)[] = [null, null];
     render(<KpiRow widget={widget} data={data} />);
     const dashes = screen.getAllByText("\u2014");
     expect(dashes).toHaveLength(2);
@@ -110,6 +110,15 @@ describe("BarChartWidget", () => {
 
   it("shows empty message for empty rows", () => {
     const data: WidgetData = { columns: ["tienda", "ventas"], rows: [] };
+    render(<BarChartWidget widget={widget} data={data} />);
+    expect(screen.getByText("Sin datos")).toBeInTheDocument();
+  });
+
+  it("shows empty message when column names do not match", () => {
+    const data: WidgetData = {
+      columns: ["wrong_x", "wrong_y"],
+      rows: [["A", 1]],
+    };
     render(<BarChartWidget widget={widget} data={data} />);
     expect(screen.getByText("Sin datos")).toBeInTheDocument();
   });
@@ -238,5 +247,23 @@ describe("TableWidget", () => {
     };
     render(<TableWidget widget={widget} data={data} />);
     expect(screen.getByText("12.500")).toBeInTheDocument();
+  });
+
+  it("formats string numeric cells from PostgreSQL", () => {
+    const data: WidgetData = {
+      columns: ["Importe"],
+      rows: [["12500.5"]],
+    };
+    render(<TableWidget widget={widget} data={data} />);
+    expect(screen.getByText("12.500,5")).toBeInTheDocument();
+  });
+
+  it("shows dash for null cells", () => {
+    const data: WidgetData = {
+      columns: ["Valor"],
+      rows: [[null]],
+    };
+    render(<TableWidget widget={widget} data={data} />);
+    expect(screen.getByText("\u2014")).toBeInTheDocument();
   });
 });

--- a/dashboard/components/widgets/__tests__/widgets.test.tsx
+++ b/dashboard/components/widgets/__tests__/widgets.test.tsx
@@ -1,0 +1,242 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "./setup";
+import {
+  KpiRow,
+  BarChartWidget,
+  LineChartWidget,
+  AreaChartWidget,
+  DonutChartWidget,
+  TableWidget,
+  NumberWidget,
+} from "../index";
+import type {
+  KpiRowWidget,
+  BarChartWidget as BarChartSpec,
+  LineChartWidget as LineChartSpec,
+  AreaChartWidget as AreaChartSpec,
+  DonutChartWidget as DonutChartSpec,
+  TableWidget as TableSpec,
+  NumberWidget as NumberSpec,
+} from "@/lib/schema";
+import type { WidgetData } from "../types";
+
+// ---------------------------------------------------------------------------
+// KpiRow
+// ---------------------------------------------------------------------------
+
+describe("KpiRow", () => {
+  const widget: KpiRowWidget = {
+    type: "kpi_row",
+    items: [
+      { label: "Ventas", sql: "", format: "currency", prefix: "\u20ac" },
+      { label: "Tickets", sql: "", format: "number" },
+    ],
+  };
+
+  it("renders labels and formatted values", () => {
+    const data = new Map<number, { value: string | number }>([
+      [0, { value: 1234.5 }],
+      [1, { value: 42 }],
+    ]);
+    render(<KpiRow widget={widget} data={data} />);
+    expect(screen.getByText("Ventas")).toBeInTheDocument();
+    expect(screen.getByText("Tickets")).toBeInTheDocument();
+    expect(screen.getByText("\u20ac1.234,50")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("shows dash when data is missing for an item", () => {
+    const data = new Map<number, { value: string | number }>();
+    render(<KpiRow widget={widget} data={data} />);
+    const dashes = screen.getAllByText("\u2014");
+    expect(dashes).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NumberWidget
+// ---------------------------------------------------------------------------
+
+describe("NumberWidget", () => {
+  const widget: NumberSpec = {
+    type: "number",
+    title: "Total Ventas",
+    sql: "",
+    format: "currency",
+    prefix: "\u20ac",
+  };
+
+  it("renders the formatted value", () => {
+    const data: WidgetData = { columns: ["total"], rows: [[5000]] };
+    render(<NumberWidget widget={widget} data={data} />);
+    expect(screen.getByText("Total Ventas")).toBeInTheDocument();
+    expect(screen.getByText("\u20ac5.000,00")).toBeInTheDocument();
+  });
+
+  it("shows empty message when no data", () => {
+    render(<NumberWidget widget={widget} data={null} />);
+    expect(screen.getByText("Sin datos")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BarChartWidget
+// ---------------------------------------------------------------------------
+
+describe("BarChartWidget", () => {
+  const widget: BarChartSpec = {
+    type: "bar_chart",
+    title: "Ventas por Tienda",
+    sql: "",
+    x: "tienda",
+    y: "ventas",
+  };
+
+  it("renders the title", () => {
+    const data: WidgetData = {
+      columns: ["tienda", "ventas"],
+      rows: [["Madrid", 100]],
+    };
+    render(<BarChartWidget widget={widget} data={data} />);
+    expect(screen.getByText("Ventas por Tienda")).toBeInTheDocument();
+  });
+
+  it("shows empty message for null data", () => {
+    render(<BarChartWidget widget={widget} data={null} />);
+    expect(screen.getByText("Sin datos")).toBeInTheDocument();
+  });
+
+  it("shows empty message for empty rows", () => {
+    const data: WidgetData = { columns: ["tienda", "ventas"], rows: [] };
+    render(<BarChartWidget widget={widget} data={data} />);
+    expect(screen.getByText("Sin datos")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LineChartWidget
+// ---------------------------------------------------------------------------
+
+describe("LineChartWidget", () => {
+  const widget: LineChartSpec = {
+    type: "line_chart",
+    title: "Tendencia",
+    sql: "",
+    x: "semana",
+    y: "ventas",
+  };
+
+  it("renders the title with data", () => {
+    const data: WidgetData = {
+      columns: ["semana", "ventas"],
+      rows: [["S1", 100], ["S2", 200]],
+    };
+    render(<LineChartWidget widget={widget} data={data} />);
+    expect(screen.getByText("Tendencia")).toBeInTheDocument();
+  });
+
+  it("shows empty message for null data", () => {
+    render(<LineChartWidget widget={widget} data={null} />);
+    expect(screen.getByText("Sin datos")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AreaChartWidget
+// ---------------------------------------------------------------------------
+
+describe("AreaChartWidget", () => {
+  const widget: AreaChartSpec = {
+    type: "area_chart",
+    title: "Ingresos",
+    sql: "",
+    x: "mes",
+    y: "total",
+  };
+
+  it("renders the title with data", () => {
+    const data: WidgetData = {
+      columns: ["mes", "total"],
+      rows: [["Ene", 50], ["Feb", 80]],
+    };
+    render(<AreaChartWidget widget={widget} data={data} />);
+    expect(screen.getByText("Ingresos")).toBeInTheDocument();
+  });
+
+  it("shows empty message for null data", () => {
+    render(<AreaChartWidget widget={widget} data={null} />);
+    expect(screen.getByText("Sin datos")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DonutChartWidget
+// ---------------------------------------------------------------------------
+
+describe("DonutChartWidget", () => {
+  const widget: DonutChartSpec = {
+    type: "donut_chart",
+    title: "Mix Familias",
+    sql: "",
+    x: "familia",
+    y: "pct",
+  };
+
+  it("renders the title with data", () => {
+    const data: WidgetData = {
+      columns: ["familia", "pct"],
+      rows: [["A", 60], ["B", 40]],
+    };
+    render(<DonutChartWidget widget={widget} data={data} />);
+    expect(screen.getByText("Mix Familias")).toBeInTheDocument();
+  });
+
+  it("shows empty message for null data", () => {
+    render(<DonutChartWidget widget={widget} data={null} />);
+    expect(screen.getByText("Sin datos")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TableWidget
+// ---------------------------------------------------------------------------
+
+describe("TableWidget", () => {
+  const widget: TableSpec = {
+    type: "table",
+    title: "Top Articulos",
+    sql: "",
+  };
+
+  it("renders column headers and rows", () => {
+    const data: WidgetData = {
+      columns: ["Ref", "Descripcion", "Unidades"],
+      rows: [
+        ["A1", "Camiseta", 10],
+        ["A2", "Pantalon", 5],
+      ],
+    };
+    render(<TableWidget widget={widget} data={data} />);
+    expect(screen.getByText("Top Articulos")).toBeInTheDocument();
+    expect(screen.getByText("Ref")).toBeInTheDocument();
+    expect(screen.getByText("Descripcion")).toBeInTheDocument();
+    expect(screen.getByText("Camiseta")).toBeInTheDocument();
+    expect(screen.getByText("Pantalon")).toBeInTheDocument();
+  });
+
+  it("shows empty message for null data", () => {
+    render(<TableWidget widget={widget} data={null} />);
+    expect(screen.getByText("Sin datos")).toBeInTheDocument();
+  });
+
+  it("formats numeric cells with European style", () => {
+    const data: WidgetData = {
+      columns: ["Importe"],
+      rows: [[12500]],
+    };
+    render(<TableWidget widget={widget} data={data} />);
+    expect(screen.getByText("12.500")).toBeInTheDocument();
+  });
+});

--- a/dashboard/components/widgets/format.ts
+++ b/dashboard/components/widgets/format.ts
@@ -24,15 +24,17 @@ const percentFormatter = new Intl.NumberFormat("es-ES", {
 
 /**
  * Format a numeric value according to the given KPI format.
- * Returns a string like "1.234,56 €", "1.234", or "12,3%".
+ * Returns a string like "€1.234,56", "1.234", or "12,3%".
+ * Returns "—" for null, undefined, empty strings, and non-numeric values.
  */
 export function formatValue(
   value: unknown,
   format: KpiFormat,
   prefix?: string,
 ): string {
+  if (value === null || value === undefined || value === "") return "\u2014";
   const num = typeof value === "number" ? value : Number(value);
-  if (Number.isNaN(num)) return "—";
+  if (Number.isNaN(num)) return "\u2014";
 
   switch (format) {
     case "currency": {

--- a/dashboard/components/widgets/format.ts
+++ b/dashboard/components/widgets/format.ts
@@ -1,0 +1,49 @@
+/**
+ * European number formatting utilities for Spanish business context.
+ * Uses dot for thousands separator, comma for decimal separator.
+ */
+import type { KpiFormat } from "@/lib/schema";
+
+const euroFormatter = new Intl.NumberFormat("es-ES", {
+  useGrouping: true,
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const integerFormatter = new Intl.NumberFormat("es-ES", {
+  useGrouping: true,
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
+const percentFormatter = new Intl.NumberFormat("es-ES", {
+  useGrouping: true,
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+/**
+ * Format a numeric value according to the given KPI format.
+ * Returns a string like "1.234,56 €", "1.234", or "12,3%".
+ */
+export function formatValue(
+  value: unknown,
+  format: KpiFormat,
+  prefix?: string,
+): string {
+  const num = typeof value === "number" ? value : Number(value);
+  if (Number.isNaN(num)) return "—";
+
+  switch (format) {
+    case "currency": {
+      const formatted = euroFormatter.format(num);
+      return prefix ? `${prefix}${formatted}` : formatted;
+    }
+    case "percent":
+      return `${percentFormatter.format(num)}%`;
+    case "number":
+      return integerFormatter.format(num);
+    default:
+      return String(num);
+  }
+}

--- a/dashboard/components/widgets/index.ts
+++ b/dashboard/components/widgets/index.ts
@@ -1,0 +1,9 @@
+export { KpiRow } from "./KpiRow";
+export { BarChartWidget } from "./BarChartWidget";
+export { LineChartWidget } from "./LineChartWidget";
+export { AreaChartWidget } from "./AreaChartWidget";
+export { DonutChartWidget } from "./DonutChartWidget";
+export { TableWidget } from "./TableWidget";
+export { NumberWidget } from "./NumberWidget";
+export { formatValue } from "./format";
+export type { WidgetData } from "./types";

--- a/dashboard/components/widgets/types.ts
+++ b/dashboard/components/widgets/types.ts
@@ -33,3 +33,13 @@ export function resolveXY(
 
   return { xIdx, yIdx, xCol, yCol };
 }
+
+/**
+ * Safely coerce a value to number, returning null for nullish/non-finite.
+ * This prevents null/undefined/"" from silently becoming 0 in charts.
+ */
+export function safeNumber(v: unknown): number | null {
+  if (v === null || v === undefined || v === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}

--- a/dashboard/components/widgets/types.ts
+++ b/dashboard/components/widgets/types.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared types for widget components.
+ */
+
+/** Query result format returned by the /api/query endpoint. */
+export interface WidgetData {
+  columns: string[];
+  rows: unknown[][];
+}
+
+/** Standard empty-state message. */
+export const EMPTY_MESSAGE = "Sin datos";

--- a/dashboard/components/widgets/types.ts
+++ b/dashboard/components/widgets/types.ts
@@ -10,3 +10,26 @@ export interface WidgetData {
 
 /** Standard empty-state message. */
 export const EMPTY_MESSAGE = "Sin datos";
+
+/**
+ * Resolve column indices for x/y axes from a WidgetData.
+ * Returns null if the required columns cannot be found or data has
+ * fewer than 2 columns when falling back to defaults.
+ */
+export function resolveXY(
+  data: WidgetData,
+  xHint: string | undefined,
+  yHint: string | undefined,
+): { xIdx: number; yIdx: number; xCol: string; yCol: string } | null {
+  const xCol = xHint ?? data.columns[0];
+  const yCol = yHint ?? data.columns[1];
+  if (!xCol || !yCol) return null;
+
+  const xIdx = data.columns.indexOf(xCol);
+  const yIdx = data.columns.indexOf(yCol);
+
+  // If explicitly named columns are not found, treat as misconfigured
+  if (xIdx < 0 || yIdx < 0) return null;
+
+  return { xIdx, yIdx, xCol, yCol };
+}

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -18,13 +18,17 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^20.19.39",
         "@types/pg": "^8.20.0",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
+        "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.4.21",
         "eslint": "^8.57.1",
         "eslint-config-next": "^14.2.29",
+        "jsdom": "^29.0.1",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
@@ -33,6 +37,13 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -47,6 +58,94 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.5.tgz",
+      "integrity": "sha512-8cMAA1bE66Mb/tfmkhcfJLjEPgyT7SSy6lW6id5XL113ai1ky76d/1L27sGnXCMsLfq66DInAU3OzuahB4lu9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.6.tgz",
+      "integrity": "sha512-Tgmk6EQM0nc9xvp7sEHRVavbknhb/vGKht+04yAT3t5KQwZ02CSobCtcFgaHH04ZrjD1BhEKNA8tRhzFV20gkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -54,6 +153,159 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -151,6 +403,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1033,6 +1303,93 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tremor/react": {
       "version": "3.18.7",
       "resolved": "https://registry.npmjs.org/@tremor/react/-/react-3.18.7.tgz",
@@ -1137,6 +1494,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1841,6 +2206,39 @@
         "win32"
       ]
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitejs/plugin-react/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -2357,6 +2755,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2668,6 +3076,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2815,6 +3244,20 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -2897,6 +3340,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -2946,6 +3396,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2982,6 +3443,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3028,6 +3497,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -4234,6 +4716,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4269,6 +4764,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -4604,6 +5109,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4827,6 +5339,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/json-buffer": {
@@ -5252,6 +5815,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5271,6 +5845,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5294,6 +5875,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -5778,6 +6369,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6210,6 +6814,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6399,6 +7041,20 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -6441,6 +7097,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -6648,6 +7314,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7121,6 +7800,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7205,6 +7897,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tabbable": {
       "version": "6.4.0",
@@ -7392,6 +8091,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7403,6 +8122,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7579,6 +8324,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -7888,6 +8643,54 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8127,6 +8930,23 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -24,13 +24,17 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^20.19.39",
     "@types/pg": "^8.20.0",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
+    "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.21",
     "eslint": "^8.57.1",
     "eslint-config-next": "^14.2.29",
+    "jsdom": "^29.0.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 import path from "path";
 
 export default defineConfig({
+  plugins: [react()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "."),
@@ -10,6 +12,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["**/__tests__/**/*.test.ts"],
+    include: ["**/__tests__/**/*.test.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## Summary
- Add 7 Tremor-based React widget components (`dashboard/components/widgets/`) that render each dashboard spec widget type: KpiRow, BarChart, LineChart, AreaChart, DonutChart, Table, and Number
- European number formatting (es-ES: dot for thousands, comma for decimals) for all numeric displays
- Demo page at `/demo` showing all widget types with hardcoded sample data
- Component tests with jsdom + @testing-library/react (all 208 tests pass, `next build` succeeds)

## Test plan
- [x] `cd dashboard && npx vitest run` -- all 208 tests pass (including 26 new widget tests)
- [x] `cd dashboard && npx next build` -- compiles successfully, demo page statically generated
- [ ] Visual verification: run `npm run dev` and visit http://localhost:4000/demo

Closes #77

Generated with [Claude Code](https://claude.com/claude-code)