### PR TITLE
[D3-B] DashboardRenderer component

### DIFF
--- a/dashboard/components/DashboardRenderer.tsx
+++ b/dashboard/components/DashboardRenderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import type { DashboardSpec, Widget } from "@/lib/schema";
 import type { WidgetData } from "./widgets/types";
 import {
@@ -18,6 +18,9 @@ import {
 // ---------------------------------------------------------------------------
 
 export interface DashboardRendererProps {
+  /** The dashboard specification to render. Callers may pass a new object
+   *  on each render -- the component uses a stable JSON key internally to
+   *  avoid unnecessary refetches. */
   spec: DashboardSpec;
 }
 
@@ -79,10 +82,13 @@ export function DashboardRenderer({ spec }: DashboardRendererProps) {
     new Map()
   );
   const abortRef = useRef<AbortController | null>(null);
-  // Track the spec that widgetStates corresponds to, so we show skeletons
+  // Stable key derived from spec content (not referential identity) so
+  // parent re-renders that recreate the same spec object don't trigger refetches.
+  const specKey = useMemo(() => JSON.stringify(spec), [spec]);
+  // Track the specKey that widgetStates corresponds to, so we show skeletons
   // (not stale data) when spec changes before the effect runs.
-  const renderedSpecRef = useRef<DashboardSpec>(spec);
-  const specChanged = renderedSpecRef.current !== spec;
+  const renderedKeyRef = useRef<string>(specKey);
+  const specChanged = renderedKeyRef.current !== specKey;
 
   const fetchAll = useCallback(async (widgets: Widget[]) => {
     // Abort any in-flight requests from a previous spec
@@ -145,14 +151,14 @@ export function DashboardRenderer({ spec }: DashboardRendererProps) {
   }, []);
 
   useEffect(() => {
-    renderedSpecRef.current = spec;
+    renderedKeyRef.current = specKey;
     if (spec.widgets.length > 0) {
       fetchAll(spec.widgets);
     }
     return () => {
       abortRef.current?.abort();
     };
-  }, [spec, fetchAll]);
+  }, [specKey, spec.widgets, fetchAll]);
 
   return (
     <div>
@@ -186,6 +192,9 @@ export function DashboardRenderer({ spec }: DashboardRendererProps) {
                 <div className="rounded-lg border border-red-300 bg-red-50 p-4">
                   <p className="text-sm font-medium text-red-800">
                     Error en widget
+                    {widget.type !== "kpi_row" && "title" in widget
+                      ? `: ${widget.title}`
+                      : ""}
                   </p>
                   <p className="mt-1 text-sm text-red-600">{state.error}</p>
                 </div>

--- a/dashboard/components/__tests__/DashboardRenderer.test.tsx
+++ b/dashboard/components/__tests__/DashboardRenderer.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import "../widgets/__tests__/setup";
 import { DashboardRenderer } from "../DashboardRenderer";
@@ -119,14 +119,19 @@ const multiWidgetSpec: DashboardSpec = {
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe("DashboardRenderer", () => {
   it("renders title and description", async () => {
-    globalThis.fetch = mockFetchSuccess({
+    vi.stubGlobal("fetch", mockFetchSuccess({
       columns: ["tienda", "total"],
       rows: [["Madrid", 100]],
-    });
+    }));
 
     render(<DashboardRenderer spec={barSpec} />);
 
@@ -137,10 +142,10 @@ describe("DashboardRenderer", () => {
   });
 
   it("renders title without description when omitted", async () => {
-    globalThis.fetch = mockFetchSuccess({
+    vi.stubGlobal("fetch", mockFetchSuccess({
       columns: ["value"],
       rows: [[42]],
-    });
+    }));
 
     render(<DashboardRenderer spec={kpiSpec} />);
 
@@ -149,7 +154,7 @@ describe("DashboardRenderer", () => {
 
   it("shows loading skeleton initially", () => {
     // Make fetch hang indefinitely so we stay in loading state
-    globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
 
     render(<DashboardRenderer spec={barSpec} />);
 
@@ -157,10 +162,10 @@ describe("DashboardRenderer", () => {
   });
 
   it("renders correct widget component for bar_chart", async () => {
-    globalThis.fetch = mockFetchSuccess({
+    vi.stubGlobal("fetch", mockFetchSuccess({
       columns: ["tienda", "total"],
       rows: [["Madrid", 100]],
-    });
+    }));
 
     render(<DashboardRenderer spec={barSpec} />);
 
@@ -171,7 +176,7 @@ describe("DashboardRenderer", () => {
 
   it("renders kpi_row with parallel fetches per item", async () => {
     let callCount = 0;
-    globalThis.fetch = vi.fn().mockImplementation(() => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(() => {
       callCount++;
       return Promise.resolve({
         ok: true,
@@ -181,7 +186,7 @@ describe("DashboardRenderer", () => {
             rows: [[callCount === 1 ? 5000 : 123]],
           }),
       } as unknown as Response);
-    });
+    }));
 
     render(<DashboardRenderer spec={kpiSpec} />);
 
@@ -191,13 +196,13 @@ describe("DashboardRenderer", () => {
     });
 
     // Should have called fetch for each KPI item
-    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 
   it("shows error message on query failure without breaking other widgets", async () => {
     // First call fails, second succeeds
     let callIdx = 0;
-    globalThis.fetch = vi.fn().mockImplementation(() => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(() => {
       callIdx++;
       if (callIdx === 1) {
         return Promise.resolve({
@@ -214,7 +219,7 @@ describe("DashboardRenderer", () => {
             rows: [["A", 1]],
           }),
       } as unknown as Response);
-    });
+    }));
 
     const twoWidgetSpec: DashboardSpec = {
       title: "Mixed",
@@ -238,8 +243,8 @@ describe("DashboardRenderer", () => {
     render(<DashboardRenderer spec={twoWidgetSpec} />);
 
     await waitFor(() => {
-      // Error widget shows error message
-      expect(screen.getByText("Error en widget")).toBeInTheDocument();
+      // Error widget shows error message with widget title
+      expect(screen.getByText("Error en widget: Broken")).toBeInTheDocument();
       expect(screen.getByText("Query timeout")).toBeInTheDocument();
       // Working widget still renders
       expect(screen.getByText("Working")).toBeInTheDocument();
@@ -262,20 +267,20 @@ describe("DashboardRenderer", () => {
     const hackedSpec = { ...emptySpec, widgets: [] } as unknown as DashboardSpec;
 
     // Should not call fetch at all
-    globalThis.fetch = vi.fn();
+    vi.stubGlobal("fetch", vi.fn());
 
     render(<DashboardRenderer spec={hackedSpec} />);
 
     expect(screen.getByText("Vacio")).toBeInTheDocument();
-    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
     expect(screen.queryByTestId("widget-skeleton")).not.toBeInTheDocument();
   });
 
   it("renders all widget types correctly", async () => {
-    globalThis.fetch = mockFetchSuccess({
+    vi.stubGlobal("fetch", mockFetchSuccess({
       columns: ["x", "y"],
       rows: [["A", 42]],
-    });
+    }));
 
     render(<DashboardRenderer spec={multiWidgetSpec} />);
 
@@ -290,16 +295,20 @@ describe("DashboardRenderer", () => {
   });
 
   it("refetches when spec changes", async () => {
-    globalThis.fetch = mockFetchSuccess({
+    const fetchMock = mockFetchSuccess({
       columns: ["tienda", "total"],
       rows: [["Madrid", 100]],
     });
+    vi.stubGlobal("fetch", fetchMock);
 
     const { rerender } = render(<DashboardRenderer spec={barSpec} />);
 
     await waitFor(() => {
       expect(screen.getByText("Ventas por Tienda")).toBeInTheDocument();
     });
+
+    // Record call count after first spec's fetches
+    const callsAfterFirst = fetchMock.mock.calls.length;
 
     const newSpec: DashboardSpec = {
       title: "Nuevo Panel",
@@ -319,5 +328,13 @@ describe("DashboardRenderer", () => {
       expect(screen.getByText("Nuevo Panel")).toBeInTheDocument();
       expect(screen.getByText("Nuevo Numero")).toBeInTheDocument();
     });
+
+    // Verify additional fetch calls were made for the new spec
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    // The last call should contain the new widget's SQL
+    const lastCallBody = JSON.parse(
+      fetchMock.mock.calls[fetchMock.mock.calls.length - 1][1].body
+    );
+    expect(lastCallBody.sql).toBe("SELECT 99");
   });
 });


### PR DESCRIPTION
## Summary
- Create `DashboardRenderer.tsx` — accepts a `DashboardSpec`, executes all widget SQL queries in parallel via `/api/query`, and renders a responsive Tailwind grid
- KPI rows fetch each item independently; charts/tables use single queries
- Per-widget states: loading skeleton, error boundary (red border), and success rendering via type-appropriate widget components
- Full-width layout for `kpi_row` and `table`, 2-column grid for charts on desktop
- 9 tests covering: title/description rendering, loading skeletons, all widget types, error isolation, empty widgets, KPI parallel fetches, spec change re-fetch

## Test plan
- [x] `cd dashboard && npx vitest run` — all 223 tests pass (9 new DashboardRenderer tests)
- [x] Verified loading skeleton shows while fetch is pending
- [x] Verified error in one widget does not break other widgets
- [x] Verified kpi_row makes parallel fetch calls (one per item)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)