### PR TITLE
[D5-A] Dashboard templates: pre-built dashboards for common roles

### DIFF
--- a/dashboard/app/dashboard/new/page.tsx
+++ b/dashboard/app/dashboard/new/page.tsx
@@ -56,7 +56,7 @@ export default function NewDashboard() {
       }
 
       const spec: DashboardSpec = await genRes.json();
-      const name = spec.title || "Dashboard sin titulo";
+      const name = spec.title || "Dashboard sin título";
       await saveAndRedirect(name, spec.description || null, spec);
     } catch (err) {
       setError(

--- a/dashboard/app/dashboard/new/page.tsx
+++ b/dashboard/app/dashboard/new/page.tsx
@@ -3,12 +3,35 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import type { DashboardSpec } from "@/lib/schema";
+import { TEMPLATES, type DashboardTemplate } from "@/lib/templates";
 
 export default function NewDashboard() {
   const router = useRouter();
   const [prompt, setPrompt] = useState("");
   const [loading, setLoading] = useState(false);
+  const [loadingTemplate, setLoadingTemplate] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  /** Save a spec to the database and redirect to its view page. */
+  const saveAndRedirect = async (
+    name: string,
+    description: string | null,
+    spec: DashboardSpec,
+  ) => {
+    const saveRes = await fetch("/api/dashboards", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, description, spec }),
+    });
+
+    if (!saveRes.ok) {
+      const errBody = await saveRes.json().catch(() => null);
+      throw new Error(errBody?.error || "Error al guardar el dashboard");
+    }
+
+    const saved = await saveRes.json();
+    router.push(`/dashboard/${saved.id}`);
+  };
 
   const handleGenerate = async () => {
     const trimmed = prompt.trim();
@@ -33,28 +56,8 @@ export default function NewDashboard() {
       }
 
       const spec: DashboardSpec = await genRes.json();
-
-      // Auto-save with generated name
-      const name = spec.title || "Dashboard sin título";
-      const saveRes = await fetch("/api/dashboards", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name,
-          description: spec.description || null,
-          spec,
-        }),
-      });
-
-      if (!saveRes.ok) {
-        const errBody = await saveRes.json().catch(() => null);
-        throw new Error(
-          errBody?.error || "Error al guardar el dashboard",
-        );
-      }
-
-      const saved = await saveRes.json();
-      router.push(`/dashboard/${saved.id}`);
+      const name = spec.title || "Dashboard sin titulo";
+      await saveAndRedirect(name, spec.description || null, spec);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Error inesperado",
@@ -64,20 +67,44 @@ export default function NewDashboard() {
     }
   };
 
+  const handleUseTemplate = async (template: DashboardTemplate) => {
+    if (loading || loadingTemplate) return;
+
+    setLoadingTemplate(template.slug);
+    setError(null);
+
+    try {
+      await saveAndRedirect(
+        template.spec.title,
+        template.description,
+        template.spec,
+      );
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Error inesperado",
+      );
+    } finally {
+      setLoadingTemplate(null);
+    }
+  };
+
+  const isDisabled = loading || loadingTemplate !== null;
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Nuevo Dashboard</h1>
         <p className="mt-1 text-sm text-gray-500">
-          Describe el cuadro de mando que deseas crear
+          Describe el cuadro de mando que deseas crear, o selecciona una plantilla
         </p>
       </div>
 
+      {/* Free-form prompt */}
       <div className="max-w-2xl space-y-4">
         <textarea
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
-          disabled={loading}
+          disabled={isDisabled}
           placeholder="Describe el dashboard que necesitas..."
           rows={6}
           className="w-full resize-none rounded-lg border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
@@ -91,7 +118,7 @@ export default function NewDashboard() {
 
         <button
           onClick={handleGenerate}
-          disabled={loading || prompt.trim() === ""}
+          disabled={isDisabled || prompt.trim() === ""}
           className="flex items-center gap-2 rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
           {loading && (
@@ -103,6 +130,48 @@ export default function NewDashboard() {
           )}
           {loading ? "Generando..." : "Generar Dashboard"}
         </button>
+      </div>
+
+      {/* Template cards */}
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">
+          Plantillas predefinidas
+        </h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Usa una plantilla para empezar con un dashboard listo al instante
+        </p>
+
+        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {TEMPLATES.map((template) => (
+            <button
+              key={template.slug}
+              onClick={() => handleUseTemplate(template)}
+              disabled={isDisabled}
+              className="flex flex-col items-start rounded-lg border border-gray-200 bg-white p-5 text-left shadow-sm hover:border-blue-400 hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+            >
+              <h3 className="text-sm font-semibold text-gray-900">
+                {template.name}
+              </h3>
+              <p className="mt-1 text-xs text-gray-500 line-clamp-2">
+                {template.description}
+              </p>
+              <span className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-blue-600">
+                {loadingTemplate === template.slug ? (
+                  <>
+                    <span
+                      className="h-3 w-3 animate-spin rounded-full border-2 border-blue-600 border-t-transparent"
+                      role="status"
+                      aria-label="Cargando plantilla"
+                    />
+                    Creando...
+                  </>
+                ) : (
+                  "Usar plantilla"
+                )}
+              </span>
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/dashboard/lib/__tests__/templates.test.ts
+++ b/dashboard/lib/__tests__/templates.test.ts
@@ -133,8 +133,8 @@ describe("SQL rule compliance across all templates", () => {
 
   it("retail ventas queries exclude tienda 99", () => {
     for (const sql of allSql) {
-      if (/ps_ventas/.test(sql) && /tienda/.test(sql) && /GROUP BY/.test(sql)) {
-        expect(sql).toMatch(/<>\s*'99'/);
+      if (/ps_ventas/.test(sql) || /ps_lineas_ventas/.test(sql)) {
+        expect(sql).toMatch(/"?tienda"?\s*(<>|!=)\s*'99'/);
       }
     }
   });

--- a/dashboard/lib/__tests__/templates.test.ts
+++ b/dashboard/lib/__tests__/templates.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { TEMPLATES, type DashboardTemplate } from "../templates";
+import { validateSpec, DashboardSpecSchema } from "../schema";
+
+// ---------------------------------------------------------------------------
+// Structural tests
+// ---------------------------------------------------------------------------
+
+describe("TEMPLATES array", () => {
+  it("exports exactly 5 templates", () => {
+    expect(TEMPLATES).toHaveLength(5);
+  });
+
+  it("has unique slugs", () => {
+    const slugs = TEMPLATES.map((t) => t.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("every template has a non-empty name and description", () => {
+    for (const t of TEMPLATES) {
+      expect(t.name.length).toBeGreaterThan(0);
+      expect(t.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zod validation for each template spec
+// ---------------------------------------------------------------------------
+
+describe.each(TEMPLATES.map((t) => [t.slug, t] as [string, DashboardTemplate]))(
+  "template '%s' passes Zod validation",
+  (_slug, template) => {
+    it("validateSpec does not throw", () => {
+      expect(() => validateSpec(template.spec)).not.toThrow();
+    });
+
+    it("safeParse returns success", () => {
+      const result = DashboardSpecSchema.safeParse(template.spec);
+      expect(result.success).toBe(true);
+    });
+
+    it("has a non-empty title in the spec", () => {
+      expect(template.spec.title.length).toBeGreaterThan(0);
+    });
+
+    it("has at least one widget", () => {
+      expect(template.spec.widgets.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("every widget SQL is non-empty", () => {
+      for (const widget of template.spec.widgets) {
+        if (widget.type === "kpi_row") {
+          for (const item of widget.items) {
+            expect(item.sql.trim().length).toBeGreaterThan(0);
+          }
+        } else {
+          expect(widget.sql.trim().length).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it("every widget SQL references ps_* tables", () => {
+      const allSql: string[] = [];
+      for (const widget of template.spec.widgets) {
+        if (widget.type === "kpi_row") {
+          for (const item of widget.items) {
+            allSql.push(item.sql);
+          }
+        } else {
+          allSql.push(widget.sql);
+        }
+      }
+      for (const sql of allSql) {
+        expect(sql).toMatch(/ps_/);
+      }
+    });
+
+    it("every widget SQL uses CURRENT_DATE-relative dates (no hardcoded dates)", () => {
+      const allSql: string[] = [];
+      for (const widget of template.spec.widgets) {
+        if (widget.type === "kpi_row") {
+          for (const item of widget.items) {
+            allSql.push(item.sql);
+          }
+        } else {
+          allSql.push(widget.sql);
+        }
+      }
+      for (const sql of allSql) {
+        // If the SQL contains a date filter, it should use CURRENT_DATE, not hardcoded dates
+        if (/>=|<=|BETWEEN/.test(sql) && /date|fecha/i.test(sql)) {
+          expect(sql).toMatch(/CURRENT_DATE/);
+        }
+      }
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SQL rule compliance
+// ---------------------------------------------------------------------------
+
+describe("SQL rule compliance across all templates", () => {
+  const allSql: string[] = [];
+  for (const t of TEMPLATES) {
+    for (const widget of t.spec.widgets) {
+      if (widget.type === "kpi_row") {
+        for (const item of widget.items) {
+          allSql.push(item.sql);
+        }
+      } else {
+        allSql.push(widget.sql);
+      }
+    }
+  }
+
+  it("never uses the 'total' column without _si suffix for retail ventas", () => {
+    for (const sql of allSql) {
+      if (/ps_ventas/.test(sql) || /ps_lineas_ventas/.test(sql)) {
+        // Should not have standalone "total" as aggregate target (total_si is ok)
+        // Match SUM("total") or SUM(total) but not SUM("total_si") or SUM("total_coste_si")
+        expect(sql).not.toMatch(/SUM\(\s*"?total"?\s*\)(?!_)/);
+      }
+    }
+  });
+
+  it("never uses fecha_documento", () => {
+    for (const sql of allSql) {
+      expect(sql).not.toMatch(/fecha_documento/);
+    }
+  });
+
+  it("retail ventas queries exclude tienda 99", () => {
+    for (const sql of allSql) {
+      if (/ps_ventas/.test(sql) && /tienda/.test(sql) && /GROUP BY/.test(sql)) {
+        expect(sql).toMatch(/<>\s*'99'/);
+      }
+    }
+  });
+});

--- a/dashboard/lib/templates/compras.ts
+++ b/dashboard/lib/templates/compras.ts
@@ -1,0 +1,77 @@
+/**
+ * Template: Responsable de Compras
+ *
+ * Purchasing overview: monthly totals, top suppliers, recent purchase lines.
+ */
+import type { DashboardSpec } from "@/lib/schema";
+
+export const name = "Responsable de Compras";
+
+export const description =
+  "Panel para el responsable de compras: total compras del mes, proveedores activos, top proveedores y ultimas lineas.";
+
+export const spec: DashboardSpec = {
+  title: "Cuadro de Mandos — Compras",
+  description,
+  widgets: [
+    {
+      id: "compras-kpis",
+      type: "kpi_row",
+      items: [
+        {
+          label: "Pedidos de Compra (mes)",
+          sql: `SELECT COUNT(DISTINCT "reg_pedido") AS value
+FROM "public"."ps_compras"
+WHERE "fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)`,
+          format: "number",
+        },
+        {
+          label: "Proveedores Activos",
+          sql: `SELECT COUNT(DISTINCT "num_proveedor") AS value
+FROM "public"."ps_compras"
+WHERE "fecha_creacion" >= DATE_TRUNC('year', CURRENT_DATE)`,
+          format: "number",
+        },
+        {
+          label: "Lineas de Compra (mes)",
+          sql: `SELECT COUNT(*) AS value
+FROM "public"."ps_lineas_compras" lc
+JOIN "public"."ps_compras" c ON lc."num_pedido" = c."reg_pedido"
+WHERE c."fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)`,
+          format: "number",
+        },
+      ],
+    },
+    {
+      id: "compras-por-proveedor",
+      type: "bar_chart",
+      title: "Pedidos por Proveedor (top 10, YTD)",
+      sql: `SELECT pr."nombre" AS label,
+       COUNT(DISTINCT c."reg_pedido") AS value
+FROM "public"."ps_compras" c
+JOIN "public"."ps_proveedores" pr ON c."num_proveedor" = pr."reg_proveedor"
+WHERE c."fecha_creacion" >= DATE_TRUNC('year', CURRENT_DATE)
+GROUP BY pr."nombre"
+ORDER BY value DESC
+LIMIT 10`,
+      x: "label",
+      y: "value",
+    },
+    {
+      id: "compras-ultimas-recepciones",
+      type: "table",
+      title: "Ultimos Pedidos de Compra",
+      sql: `SELECT c."reg_pedido" AS "Pedido",
+       pr."nombre" AS "Proveedor",
+       COUNT(lc."codigo") AS "Lineas",
+       SUM(lc."unidades") AS "Unidades",
+       c."fecha_creacion" AS "Fecha"
+FROM "public"."ps_compras" c
+JOIN "public"."ps_proveedores" pr ON c."num_proveedor" = pr."reg_proveedor"
+JOIN "public"."ps_lineas_compras" lc ON lc."num_pedido" = c."reg_pedido"
+GROUP BY c."reg_pedido", pr."nombre", c."fecha_creacion"
+ORDER BY c."fecha_creacion" DESC
+LIMIT 20`,
+    },
+  ],
+};

--- a/dashboard/lib/templates/compras.ts
+++ b/dashboard/lib/templates/compras.ts
@@ -1,15 +1,15 @@
 /**
  * Template: Responsable de Compras
  *
- * Purchasing overview: monthly totals, top suppliers, recent purchase orders,
- * recent receptions, and purchase lines by store.
+ * Purchasing overview: monthly KPIs, top suppliers, recent purchase orders,
+ * recent receptions, and monthly purchase-order trends.
  */
 import type { DashboardSpec } from "@/lib/schema";
 
 export const name = "Responsable de Compras";
 
 export const description =
-  "Panel para el responsable de compras: pedidos del mes, proveedores activos, top proveedores, ultimas recepciones y lineas por tienda.";
+  "Panel para el responsable de compras: pedidos del mes, proveedores activos, top proveedores, ultimas recepciones y tendencia mensual de pedidos.";
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Compras",

--- a/dashboard/lib/templates/compras.ts
+++ b/dashboard/lib/templates/compras.ts
@@ -1,14 +1,15 @@
 /**
  * Template: Responsable de Compras
  *
- * Purchasing overview: monthly totals, top suppliers, recent purchase lines.
+ * Purchasing overview: monthly totals, top suppliers, recent purchase orders,
+ * recent receptions, and purchase lines by store.
  */
 import type { DashboardSpec } from "@/lib/schema";
 
 export const name = "Responsable de Compras";
 
 export const description =
-  "Panel para el responsable de compras: total compras del mes, proveedores activos, top proveedores y ultimas lineas.";
+  "Panel para el responsable de compras: pedidos del mes, proveedores activos, top proveedores, ultimas recepciones y lineas por tienda.";
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Compras",
@@ -58,7 +59,7 @@ LIMIT 10`,
       y: "value",
     },
     {
-      id: "compras-ultimas-recepciones",
+      id: "compras-ultimos-pedidos",
       type: "table",
       title: "Ultimos Pedidos de Compra",
       sql: `SELECT c."reg_pedido" AS "Pedido",
@@ -72,6 +73,30 @@ JOIN "public"."ps_lineas_compras" lc ON lc."num_pedido" = c."reg_pedido"
 GROUP BY c."reg_pedido", pr."nombre", c."fecha_creacion"
 ORDER BY c."fecha_creacion" DESC
 LIMIT 20`,
+    },
+    {
+      id: "compras-recepciones-recientes",
+      type: "table",
+      title: "Recepciones Recientes (ultimos 30 dias)",
+      sql: `SELECT a."reg_albaran" AS "Albaran",
+       a."fecha_creacion" AS "Fecha"
+FROM "public"."ps_albaranes" a
+WHERE a."fecha_creacion" >= CURRENT_DATE - INTERVAL '30 days'
+ORDER BY a."fecha_creacion" DESC
+LIMIT 20`,
+    },
+    {
+      id: "compras-tendencia-mensual",
+      type: "line_chart",
+      title: "Pedidos de Compra Mensuales (ultimos 12 meses)",
+      sql: `SELECT DATE_TRUNC('month', c."fecha_creacion") AS x,
+       COUNT(DISTINCT c."reg_pedido") AS y
+FROM "public"."ps_compras" c
+WHERE c."fecha_creacion" >= CURRENT_DATE - INTERVAL '12 months'
+GROUP BY DATE_TRUNC('month', c."fecha_creacion")
+ORDER BY x`,
+      x: "x",
+      y: "y",
     },
   ],
 };

--- a/dashboard/lib/templates/general.ts
+++ b/dashboard/lib/templates/general.ts
@@ -1,0 +1,91 @@
+/**
+ * Template: Director General
+ *
+ * Executive overview: retail + wholesale revenue, channel mix, 12-month trend.
+ */
+import type { DashboardSpec } from "@/lib/schema";
+
+export const name = "Director General";
+
+export const description =
+  "Panel ejecutivo: ventas retail, facturacion mayorista, margen global, mix de canales y tendencia 12 meses.";
+
+export const spec: DashboardSpec = {
+  title: "Cuadro de Mandos — Director General",
+  description,
+  widgets: [
+    {
+      id: "general-kpis",
+      type: "kpi_row",
+      items: [
+        {
+          label: "Ventas Retail Netas",
+          sql: `SELECT COALESCE(SUM("total_si"), 0) AS value
+FROM "public"."ps_ventas"
+WHERE "entrada" = true
+  AND "tienda" <> '99'
+  AND "fecha_creacion" >= DATE_TRUNC('year', CURRENT_DATE)`,
+          format: "currency",
+          prefix: "€",
+        },
+        {
+          label: "Facturacion Mayorista",
+          sql: `SELECT COALESCE(SUM("base1" + "base2" + "base3"), 0) AS value
+FROM "public"."ps_gc_facturas"
+WHERE "abono" = false
+  AND "fecha_factura" >= DATE_TRUNC('year', CURRENT_DATE)`,
+          format: "currency",
+          prefix: "€",
+        },
+        {
+          label: "Margen Global Retail",
+          sql: `SELECT ROUND(
+  (SUM(lv."total_si") - SUM(lv."total_coste_si"))
+  / NULLIF(SUM(lv."total_si"), 0) * 100, 1
+) AS value
+FROM "public"."ps_lineas_ventas" lv
+JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
+WHERE v."entrada" = true
+  AND lv."tienda" <> '99'
+  AND lv."total_si" > 0
+  AND lv."fecha_creacion" >= DATE_TRUNC('year', CURRENT_DATE)`,
+          format: "percent",
+        },
+      ],
+    },
+    {
+      id: "general-mix-canales",
+      type: "donut_chart",
+      title: "Mix Retail vs Mayorista (YTD)",
+      sql: `SELECT 'Retail' AS label,
+       COALESCE(SUM("total_si"), 0) AS value
+FROM "public"."ps_ventas"
+WHERE "entrada" = true
+  AND "tienda" <> '99'
+  AND "fecha_creacion" >= DATE_TRUNC('year', CURRENT_DATE)
+UNION ALL
+SELECT 'Mayorista' AS label,
+       COALESCE(SUM("base1" + "base2" + "base3"), 0) AS value
+FROM "public"."ps_gc_facturas"
+WHERE "abono" = false
+  AND "fecha_factura" >= DATE_TRUNC('year', CURRENT_DATE)`,
+      x: "label",
+      y: "value",
+    },
+    {
+      id: "general-tendencia-12m",
+      type: "line_chart",
+      title: "Tendencia Mensual (ultimos 12 meses)",
+      sql: `SELECT DATE_TRUNC('month', "fecha_creacion") AS x,
+       SUM("total_si") AS y
+FROM "public"."ps_ventas"
+WHERE "entrada" = true
+  AND "tienda" <> '99'
+  AND "fecha_creacion" >= CURRENT_DATE - INTERVAL '12 months'
+GROUP BY DATE_TRUNC('month', "fecha_creacion")
+ORDER BY x`,
+      x: "x",
+      y: "y",
+    },
+  ],
+};

--- a/dashboard/lib/templates/general.ts
+++ b/dashboard/lib/templates/general.ts
@@ -1,14 +1,15 @@
 /**
  * Template: Director General
  *
- * Executive overview: retail + wholesale revenue, channel mix, 12-month trend.
+ * Executive overview: retail + wholesale revenue, channel mix, margin,
+ * 12-month trend (retail + wholesale), and top product families.
  */
 import type { DashboardSpec } from "@/lib/schema";
 
 export const name = "Director General";
 
 export const description =
-  "Panel ejecutivo: ventas retail, facturacion mayorista, margen global, mix de canales y tendencia 12 meses.";
+  "Panel ejecutivo: ventas retail, facturacion mayorista, margen global, mix de canales, tendencia 12 meses y top familias.";
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Director General",
@@ -75,17 +76,48 @@ WHERE "abono" = false
     {
       id: "general-tendencia-12m",
       type: "line_chart",
-      title: "Tendencia Mensual (ultimos 12 meses)",
-      sql: `SELECT DATE_TRUNC('month', "fecha_creacion") AS x,
-       SUM("total_si") AS y
-FROM "public"."ps_ventas"
-WHERE "entrada" = true
-  AND "tienda" <> '99'
-  AND "fecha_creacion" >= CURRENT_DATE - INTERVAL '12 months'
-GROUP BY DATE_TRUNC('month', "fecha_creacion")
-ORDER BY x`,
+      title: "Tendencia Mensual Retail + Mayorista (ultimos 12 meses)",
+      sql: `SELECT mes, SUM(importe) AS y, mes AS x FROM (
+  SELECT DATE_TRUNC('month', "fecha_creacion") AS mes,
+         SUM("total_si") AS importe
+  FROM "public"."ps_ventas"
+  WHERE "entrada" = true
+    AND "tienda" <> '99'
+    AND "fecha_creacion" >= CURRENT_DATE - INTERVAL '12 months'
+  GROUP BY DATE_TRUNC('month', "fecha_creacion")
+  UNION ALL
+  SELECT DATE_TRUNC('month', "fecha_factura") AS mes,
+         SUM("base1" + "base2" + "base3") AS importe
+  FROM "public"."ps_gc_facturas"
+  WHERE "abono" = false
+    AND "fecha_factura" >= CURRENT_DATE - INTERVAL '12 months'
+  GROUP BY DATE_TRUNC('month', "fecha_factura")
+) combined
+GROUP BY mes
+ORDER BY mes`,
       x: "x",
       y: "y",
+    },
+    {
+      id: "general-top-familias",
+      type: "table",
+      title: "Top 10 Familias por Ventas (YTD)",
+      sql: `SELECT fm."fami_grup_marc" AS "Familia",
+       SUM(lv."total_si") AS "Ventas Netas",
+       SUM(lv."unidades") AS "Unidades",
+       ROUND((SUM(lv."total_si") - SUM(lv."total_coste_si"))
+         / NULLIF(SUM(lv."total_si"), 0) * 100, 1) AS "Margen %"
+FROM "public"."ps_lineas_ventas" lv
+JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
+JOIN "public"."ps_articulos" p ON lv."codigo" = p."codigo"
+JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
+WHERE v."entrada" = true
+  AND lv."tienda" <> '99'
+  AND lv."total_si" > 0
+  AND lv."fecha_creacion" >= DATE_TRUNC('year', CURRENT_DATE)
+GROUP BY fm."fami_grup_marc"
+ORDER BY "Ventas Netas" DESC
+LIMIT 10`,
     },
   ],
 };

--- a/dashboard/lib/templates/index.ts
+++ b/dashboard/lib/templates/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Dashboard templates index.
+ *
+ * Each template exports { name, description, spec } where spec is a valid
+ * DashboardSpec.  This module re-exports them as a typed array for the UI.
+ */
+import type { DashboardSpec } from "@/lib/schema";
+
+import * as ventas from "./ventas";
+import * as stock from "./stock";
+import * as mayorista from "./mayorista";
+import * as general from "./general";
+import * as compras from "./compras";
+
+export interface DashboardTemplate {
+  /** Unique slug derived from the file name. */
+  slug: string;
+  /** Human-readable name shown in the UI. */
+  name: string;
+  /** Short description shown below the name. */
+  description: string;
+  /** The pre-built dashboard spec (valid DashboardSpec). */
+  spec: DashboardSpec;
+}
+
+export const TEMPLATES: DashboardTemplate[] = [
+  { slug: "ventas", name: ventas.name, description: ventas.description, spec: ventas.spec },
+  { slug: "stock", name: stock.name, description: stock.description, spec: stock.spec },
+  { slug: "mayorista", name: mayorista.name, description: mayorista.description, spec: mayorista.spec },
+  { slug: "general", name: general.name, description: general.description, spec: general.spec },
+  { slug: "compras", name: compras.name, description: compras.description, spec: compras.spec },
+];

--- a/dashboard/lib/templates/mayorista.ts
+++ b/dashboard/lib/templates/mayorista.ts
@@ -1,14 +1,15 @@
 /**
  * Template: Director Mayorista
  *
- * Wholesale channel: invoicing KPIs, breakdown by sales rep, top clients.
+ * Wholesale channel: invoicing KPIs, breakdown by sales rep, top clients,
+ * pending delivery notes, and period comparison.
  */
 import type { DashboardSpec } from "@/lib/schema";
 
 export const name = "Director Mayorista";
 
 export const description =
-  "Panel para el director del canal mayorista: facturacion neta, desglose por comercial y top clientes.";
+  "Panel para el director del canal mayorista: facturacion neta, desglose por comercial, top clientes, albaranes pendientes y comparativa de periodos.";
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Mayorista",
@@ -74,6 +75,37 @@ WHERE f."abono" = false
 GROUP BY c."nombre"
 ORDER BY "Facturacion Neta" DESC
 LIMIT 10`,
+    },
+    {
+      id: "mayorista-albaranes-recientes",
+      type: "table",
+      title: "Albaranes Recientes (ultimos 30 dias)",
+      sql: `SELECT a."n_albaran" AS "Albaran",
+       c."nombre" AS "Cliente",
+       a."entregadas" AS "Unidades",
+       SUM(a."base1" + a."base2" + a."base3") AS "Importe Neto",
+       a."fecha_envio" AS "Fecha"
+FROM "public"."ps_gc_albaranes" a
+JOIN "public"."ps_clientes" c ON a."num_cliente" = c."reg_cliente"
+WHERE a."abono" = false
+  AND a."fecha_envio" >= CURRENT_DATE - INTERVAL '30 days'
+GROUP BY a."n_albaran", c."nombre", a."entregadas", a."fecha_envio"
+ORDER BY a."fecha_envio" DESC
+LIMIT 20`,
+    },
+    {
+      id: "mayorista-comparativa-mensual",
+      type: "line_chart",
+      title: "Facturacion Mensual (ultimos 12 meses)",
+      sql: `SELECT DATE_TRUNC('month', f."fecha_factura") AS x,
+       SUM(f."base1" + f."base2" + f."base3") AS y
+FROM "public"."ps_gc_facturas" f
+WHERE f."abono" = false
+  AND f."fecha_factura" >= CURRENT_DATE - INTERVAL '12 months'
+GROUP BY DATE_TRUNC('month', f."fecha_factura")
+ORDER BY x`,
+      x: "x",
+      y: "y",
     },
   ],
 };

--- a/dashboard/lib/templates/mayorista.ts
+++ b/dashboard/lib/templates/mayorista.ts
@@ -2,14 +2,14 @@
  * Template: Director Mayorista
  *
  * Wholesale channel: invoicing KPIs, breakdown by sales rep, top clients,
- * pending delivery notes, and period comparison.
+ * recent delivery notes, and period comparison.
  */
 import type { DashboardSpec } from "@/lib/schema";
 
 export const name = "Director Mayorista";
 
 export const description =
-  "Panel para el director del canal mayorista: facturacion neta, desglose por comercial, top clientes, albaranes pendientes y comparativa de periodos.";
+  "Panel para el director del canal mayorista: facturacion neta, desglose por comercial, top clientes, albaranes recientes y comparativa de periodos.";
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Mayorista",

--- a/dashboard/lib/templates/mayorista.ts
+++ b/dashboard/lib/templates/mayorista.ts
@@ -1,0 +1,79 @@
+/**
+ * Template: Director Mayorista
+ *
+ * Wholesale channel: invoicing KPIs, breakdown by sales rep, top clients.
+ */
+import type { DashboardSpec } from "@/lib/schema";
+
+export const name = "Director Mayorista";
+
+export const description =
+  "Panel para el director del canal mayorista: facturacion neta, desglose por comercial y top clientes.";
+
+export const spec: DashboardSpec = {
+  title: "Cuadro de Mandos — Mayorista",
+  description,
+  widgets: [
+    {
+      id: "mayorista-kpis",
+      type: "kpi_row",
+      items: [
+        {
+          label: "Facturacion Neta",
+          sql: `SELECT COALESCE(SUM("base1" + "base2" + "base3"), 0) AS value
+FROM "public"."ps_gc_facturas"
+WHERE "abono" = false
+  AND "fecha_factura" >= DATE_TRUNC('month', CURRENT_DATE)`,
+          format: "currency",
+          prefix: "€",
+        },
+        {
+          label: "Facturas",
+          sql: `SELECT COUNT(DISTINCT "reg_factura") AS value
+FROM "public"."ps_gc_facturas"
+WHERE "abono" = false
+  AND "fecha_factura" >= DATE_TRUNC('month', CURRENT_DATE)`,
+          format: "number",
+        },
+        {
+          label: "Clientes Activos",
+          sql: `SELECT COUNT(DISTINCT "num_cliente") AS value
+FROM "public"."ps_gc_facturas"
+WHERE "abono" = false
+  AND "fecha_factura" >= DATE_TRUNC('year', CURRENT_DATE)`,
+          format: "number",
+        },
+      ],
+    },
+    {
+      id: "mayorista-por-comercial",
+      type: "bar_chart",
+      title: "Facturacion por Comercial (mes actual)",
+      sql: `SELECT c."comercial" AS label,
+       SUM(f."base1" + f."base2" + f."base3") AS value
+FROM "public"."ps_gc_facturas" f
+JOIN "public"."ps_gc_comerciales" c ON f."num_comercial" = c."reg_comercial"
+WHERE f."abono" = false
+  AND f."fecha_factura" >= DATE_TRUNC('month', CURRENT_DATE)
+GROUP BY c."comercial"
+ORDER BY value DESC`,
+      x: "label",
+      y: "value",
+    },
+    {
+      id: "mayorista-top-clientes",
+      type: "table",
+      title: "Top 10 Clientes Mayorista (YTD)",
+      sql: `SELECT c."nombre" AS "Cliente",
+       COUNT(DISTINCT f."reg_factura") AS "Facturas",
+       SUM(f."base1" + f."base2" + f."base3") AS "Facturacion Neta"
+FROM "public"."ps_gc_facturas" f
+JOIN "public"."ps_clientes" c ON f."num_cliente" = c."reg_cliente"
+WHERE f."abono" = false
+  AND f."fecha_factura" >= DATE_TRUNC('year', CURRENT_DATE)
+GROUP BY c."nombre"
+ORDER BY "Facturacion Neta" DESC
+LIMIT 10`,
+    },
+  ],
+};

--- a/dashboard/lib/templates/stock.ts
+++ b/dashboard/lib/templates/stock.ts
@@ -1,0 +1,75 @@
+/**
+ * Template: Responsable de Stock
+ *
+ * Stock overview: totals, distribution by store, low-stock alerts.
+ */
+import type { DashboardSpec } from "@/lib/schema";
+
+export const name = "Responsable de Stock";
+
+export const description =
+  "Panel para el responsable de stock: unidades totales, distribucion por tienda y alertas de stock bajo.";
+
+export const spec: DashboardSpec = {
+  title: "Cuadro de Mandos — Stock",
+  description,
+  widgets: [
+    {
+      id: "stock-kpis",
+      type: "kpi_row",
+      items: [
+        {
+          label: "Unidades en Stock",
+          sql: `SELECT COALESCE(SUM("stock"), 0) AS value
+FROM "public"."ps_stock_tienda"
+WHERE "stock" > 0`,
+          format: "number",
+        },
+        {
+          label: "Tiendas con Stock",
+          sql: `SELECT COUNT(DISTINCT "tienda") AS value
+FROM "public"."ps_stock_tienda"
+WHERE "stock" > 0`,
+          format: "number",
+        },
+        {
+          label: "Referencias Activas",
+          sql: `SELECT COUNT(DISTINCT s."codigo") AS value
+FROM "public"."ps_stock_tienda" s
+JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
+WHERE s."stock" > 0 AND p."anulado" = false`,
+          format: "number",
+        },
+      ],
+    },
+    {
+      id: "stock-por-tienda",
+      type: "bar_chart",
+      title: "Stock por Tienda (excluye almacen central)",
+      sql: `SELECT "tienda" AS label, SUM("stock") AS value
+FROM "public"."ps_stock_tienda"
+WHERE "stock" > 0 AND "tienda" <> '99'
+GROUP BY "tienda"
+ORDER BY value DESC`,
+      x: "label",
+      y: "value",
+    },
+    {
+      id: "stock-bajo",
+      type: "table",
+      title: "Articulos con Stock Bajo (< 5 unidades en alguna tienda)",
+      sql: `SELECT s."tienda" AS "Tienda",
+       p."ccrefejofacm" AS "Referencia",
+       p."descripcion" AS "Descripcion",
+       SUM(s."stock") AS "Stock"
+FROM "public"."ps_stock_tienda" s
+JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
+WHERE s."stock" > 0 AND s."stock" < 5
+  AND s."tienda" <> '99'
+  AND p."anulado" = false
+GROUP BY s."tienda", p."ccrefejofacm", p."descripcion"
+ORDER BY "Stock" ASC
+LIMIT 50`,
+    },
+  ],
+};

--- a/dashboard/lib/templates/stock.ts
+++ b/dashboard/lib/templates/stock.ts
@@ -27,7 +27,7 @@ WHERE "stock" > 0 AND "tienda" <> '99'`,
           format: "number",
         },
         {
-          label: "Unidades en Almacen Central",
+          label: "Unidades en Almacén Central",
           sql: `SELECT COALESCE(SUM("stock"), 0) AS value
 FROM "public"."ps_stock_tienda"
 WHERE "stock" > 0 AND "tienda" = '99'`,
@@ -53,7 +53,7 @@ WHERE s."stock" > 0 AND p."anulado" = false`,
     {
       id: "stock-por-tienda",
       type: "bar_chart",
-      title: "Stock por Tienda (excluye almacen central)",
+      title: "Stock por Tienda (excluye almacén central)",
       sql: `SELECT "tienda" AS label, SUM("stock") AS value
 FROM "public"."ps_stock_tienda"
 WHERE "stock" > 0 AND "tienda" <> '99'
@@ -65,10 +65,10 @@ ORDER BY value DESC`,
     {
       id: "stock-bajo",
       type: "table",
-      title: "Articulos con Stock Bajo (< 5 unidades en alguna tienda)",
+      title: "Artículos con Stock Bajo (< 5 unidades en alguna tienda)",
       sql: `SELECT s."tienda" AS "Tienda",
        p."ccrefejofacm" AS "Referencia",
-       p."descripcion" AS "Descripcion",
+       p."descripcion" AS "Descripción",
        SUM(s."stock") AS "Stock"
 FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
@@ -82,17 +82,17 @@ LIMIT 50`,
     {
       id: "stock-sin-stock",
       type: "table",
-      title: "Articulos Sin Stock en Tiendas (con stock en almacen)",
+      title: "Artículos Sin Stock en Tiendas (con stock en almacén)",
       sql: `SELECT p."ccrefejofacm" AS "Referencia",
-       p."descripcion" AS "Descripcion",
-       SUM(CASE WHEN s."tienda" = '99' THEN s."stock" ELSE 0 END) AS "Stock Almacen"
+       p."descripcion" AS "Descripción",
+       SUM(CASE WHEN s."tienda" = '99' THEN s."stock" ELSE 0 END) AS "Stock Almacén"
 FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
 WHERE p."anulado" = false
 GROUP BY p."ccrefejofacm", p."descripcion"
 HAVING SUM(CASE WHEN s."tienda" <> '99' THEN s."stock" ELSE 0 END) = 0
    AND SUM(CASE WHEN s."tienda" = '99' THEN s."stock" ELSE 0 END) > 0
-ORDER BY "Stock Almacen" DESC
+ORDER BY "Stock Almacén" DESC
 LIMIT 30`,
     },
     {

--- a/dashboard/lib/templates/stock.ts
+++ b/dashboard/lib/templates/stock.ts
@@ -1,14 +1,15 @@
 /**
  * Template: Responsable de Stock
  *
- * Stock overview: totals, distribution by store, low-stock alerts.
+ * Stock overview: totals (incl. central warehouse), distribution by store,
+ * low-stock alerts, out-of-stock items, stock in central warehouse, recent transfers.
  */
 import type { DashboardSpec } from "@/lib/schema";
 
 export const name = "Responsable de Stock";
 
 export const description =
-  "Panel para el responsable de stock: unidades totales, distribucion por tienda y alertas de stock bajo.";
+  "Panel para el responsable de stock: unidades totales, distribucion por tienda, stock en almacen, sin stock y traspasos recientes.";
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Stock",
@@ -19,17 +20,24 @@ export const spec: DashboardSpec = {
       type: "kpi_row",
       items: [
         {
-          label: "Unidades en Stock",
+          label: "Unidades en Tiendas",
           sql: `SELECT COALESCE(SUM("stock"), 0) AS value
 FROM "public"."ps_stock_tienda"
-WHERE "stock" > 0`,
+WHERE "stock" > 0 AND "tienda" <> '99'`,
+          format: "number",
+        },
+        {
+          label: "Unidades en Almacen Central",
+          sql: `SELECT COALESCE(SUM("stock"), 0) AS value
+FROM "public"."ps_stock_tienda"
+WHERE "stock" > 0 AND "tienda" = '99'`,
           format: "number",
         },
         {
           label: "Tiendas con Stock",
           sql: `SELECT COUNT(DISTINCT "tienda") AS value
 FROM "public"."ps_stock_tienda"
-WHERE "stock" > 0`,
+WHERE "stock" > 0 AND "tienda" <> '99'`,
           format: "number",
         },
         {
@@ -70,6 +78,38 @@ WHERE s."stock" > 0 AND s."stock" < 5
 GROUP BY s."tienda", p."ccrefejofacm", p."descripcion"
 ORDER BY "Stock" ASC
 LIMIT 50`,
+    },
+    {
+      id: "stock-sin-stock",
+      type: "table",
+      title: "Articulos Sin Stock en Tiendas (con stock en almacen)",
+      sql: `SELECT p."ccrefejofacm" AS "Referencia",
+       p."descripcion" AS "Descripcion",
+       SUM(CASE WHEN s."tienda" = '99' THEN s."stock" ELSE 0 END) AS "Stock Almacen"
+FROM "public"."ps_stock_tienda" s
+JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
+WHERE p."anulado" = false
+GROUP BY p."ccrefejofacm", p."descripcion"
+HAVING SUM(CASE WHEN s."tienda" <> '99' THEN s."stock" ELSE 0 END) = 0
+   AND SUM(CASE WHEN s."tienda" = '99' THEN s."stock" ELSE 0 END) > 0
+ORDER BY "Stock Almacen" DESC
+LIMIT 30`,
+    },
+    {
+      id: "stock-traspasos-recientes",
+      type: "table",
+      title: "Traspasos Recientes (ultimos 30 dias)",
+      sql: `SELECT t."fecha_s" AS "Fecha",
+       t."tienda_salida" AS "Origen",
+       t."tienda_entrada" AS "Destino",
+       COUNT(*) AS "Lineas",
+       SUM(t."unidades_s") AS "Unidades"
+FROM "public"."ps_traspasos" t
+WHERE t."entrada" = false
+  AND t."fecha_s" >= CURRENT_DATE - INTERVAL '30 days'
+GROUP BY t."fecha_s", t."tienda_salida", t."tienda_entrada"
+ORDER BY t."fecha_s" DESC
+LIMIT 30`,
     },
   ],
 };

--- a/dashboard/lib/templates/ventas.ts
+++ b/dashboard/lib/templates/ventas.ts
@@ -81,9 +81,9 @@ ORDER BY x`,
     {
       id: "ventas-top-articulos",
       type: "table",
-      title: "Top 10 Articulos (mes actual)",
+      title: "Top 10 Artículos (mes actual)",
       sql: `SELECT p."ccrefejofacm" AS "Referencia",
-       p."descripcion" AS "Descripcion",
+       p."descripcion" AS "Descripción",
        SUM(lv."unidades") AS "Unidades",
        SUM(lv."total_si") AS "Ventas Netas"
 FROM "public"."ps_lineas_ventas" lv

--- a/dashboard/lib/templates/ventas.ts
+++ b/dashboard/lib/templates/ventas.ts
@@ -1,0 +1,100 @@
+/**
+ * Template: Responsable de Ventas
+ *
+ * KPIs de ventas retail, desglose por tienda, tendencia semanal, top articulos.
+ * All dates are CURRENT_DATE-relative so the dashboard always shows fresh data.
+ */
+import type { DashboardSpec } from "@/lib/schema";
+
+export const name = "Responsable de Ventas";
+
+export const description =
+  "Panel para el responsable de ventas retail: KPIs, desglose por tienda, tendencia semanal y top articulos.";
+
+export const spec: DashboardSpec = {
+  title: "Cuadro de Mandos — Ventas Retail",
+  description,
+  widgets: [
+    {
+      id: "ventas-kpis",
+      type: "kpi_row",
+      items: [
+        {
+          label: "Ventas Netas",
+          sql: `SELECT COALESCE(SUM("total_si"), 0) AS value
+FROM "public"."ps_ventas"
+WHERE "entrada" = true
+  AND "tienda" <> '99'
+  AND "fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)`,
+          format: "currency",
+          prefix: "€",
+        },
+        {
+          label: "Tickets",
+          sql: `SELECT COUNT(DISTINCT "reg_ventas") AS value
+FROM "public"."ps_ventas"
+WHERE "entrada" = true
+  AND "tienda" <> '99'
+  AND "fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)`,
+          format: "number",
+        },
+        {
+          label: "Ticket Medio",
+          sql: `SELECT ROUND(SUM("total_si") / NULLIF(COUNT(DISTINCT "reg_ventas"), 0), 2) AS value
+FROM "public"."ps_ventas"
+WHERE "entrada" = true
+  AND "tienda" <> '99'
+  AND "fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)`,
+          format: "currency",
+          prefix: "€",
+        },
+      ],
+    },
+    {
+      id: "ventas-por-tienda",
+      type: "bar_chart",
+      title: "Ventas por Tienda (mes actual)",
+      sql: `SELECT "tienda" AS label, SUM("total_si") AS value
+FROM "public"."ps_ventas"
+WHERE "entrada" = true
+  AND "tienda" <> '99'
+  AND "fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)
+GROUP BY "tienda"
+ORDER BY value DESC`,
+      x: "label",
+      y: "value",
+    },
+    {
+      id: "ventas-tendencia-semanal",
+      type: "line_chart",
+      title: "Tendencia Semanal (ultimas 12 semanas)",
+      sql: `SELECT DATE_TRUNC('week', "fecha_creacion") AS x, SUM("total_si") AS y
+FROM "public"."ps_ventas"
+WHERE "entrada" = true
+  AND "tienda" <> '99'
+  AND "fecha_creacion" >= CURRENT_DATE - INTERVAL '12 weeks'
+GROUP BY DATE_TRUNC('week', "fecha_creacion")
+ORDER BY x`,
+      x: "x",
+      y: "y",
+    },
+    {
+      id: "ventas-top-articulos",
+      type: "table",
+      title: "Top 10 Articulos (mes actual)",
+      sql: `SELECT p."ccrefejofacm" AS "Referencia",
+       p."descripcion" AS "Descripcion",
+       SUM(lv."unidades") AS "Unidades",
+       SUM(lv."total_si") AS "Ventas Netas"
+FROM "public"."ps_lineas_ventas" lv
+JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
+JOIN "public"."ps_articulos" p ON lv."codigo" = p."codigo"
+WHERE v."entrada" = true
+  AND lv."tienda" <> '99'
+  AND lv."fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)
+GROUP BY p."ccrefejofacm", p."descripcion"
+ORDER BY "Ventas Netas" DESC
+LIMIT 10`,
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- Add 5 pre-built dashboard templates (Ventas, Stock, Mayorista, Director General, Compras) as typed TypeScript exports in `dashboard/lib/templates/`
- Update the create page to show template cards in a responsive grid below the free-form prompt
- Templates save directly to the database (no LLM call) and redirect to the view page instantly
- All SQL uses `CURRENT_DATE`-relative dates, `total_si` for revenue, excludes `tienda = '99'` from retail, and follows all project SQL conventions

## Test plan
- [x] All 5 template specs pass Zod `DashboardSpecSchema` validation
- [x] SQL rule compliance tests: no `fecha_documento`, no standalone `total`, retail queries exclude tienda 99
- [x] All SQL references `ps_*` tables with `CURRENT_DATE`-relative dates
- [x] `npx vitest run` — 297 tests pass (19 files)
- [x] `npx next lint` — no warnings or errors

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)