### PR TITLE
Fix and enhance dashboard templates after data model review (#142)

### DIFF
--- a/dashboard/lib/knowledge.ts
+++ b/dashboard/lib/knowledge.ts
@@ -928,20 +928,35 @@ export const SCHEMA: TableSchema[] = [
   {
     table: "ps_compras",
     alias: "PedidoCompra",
-    description: "Pedidos de compra a proveedores.",
-    keyColumns: ["reg_pedido (PK)", "num_proveedor (FK)"],
+    description:
+      "Pedidos de compra a proveedores. La fecha del pedido es fecha_pedido (NO fecha_creacion). fecha_recibido es NULL mientras el pedido está pendiente de recibir.",
+    keyColumns: [
+      "reg_pedido (PK)",
+      "num_proveedor (FK)",
+      "fecha_pedido",
+      "fecha_recibido",
+      "modificada",
+    ],
   },
   {
     table: "ps_lineas_compras",
     alias: "LineaPedidoCompra",
-    description: "Líneas de pedido de compra.",
-    keyColumns: ["num_pedido (FK)", "codigo", "unidades"],
+    description:
+      "Líneas de pedido de compra. NOTA: la tabla NO tiene columnas codigo ni unidades; el artículo se referencia por num_articulo (FK NUMERIC) y la tienda por num_tienda.",
+    keyColumns: [
+      "reg_linea_compra (PK)",
+      "num_pedido (FK → ps_compras.reg_pedido)",
+      "num_tienda (FK)",
+      "num_articulo (FK)",
+      "fecha",
+    ],
   },
   {
     table: "ps_albaranes",
     alias: "AlbaranRecepcion",
-    description: "Albaranes de recepción de mercancía.",
-    keyColumns: ["reg_albaran (PK)"],
+    description:
+      "Albaranes de recepción de mercancía. La fecha de recepción es fecha_recibido (NO fecha_creacion).",
+    keyColumns: ["reg_albaran (PK)", "fecha_recibido", "modificada"],
   },
   {
     table: "ps_facturas_compra",

--- a/dashboard/lib/templates/compras.ts
+++ b/dashboard/lib/templates/compras.ts
@@ -42,8 +42,7 @@ WHERE "fecha_pedido" >= DATE_TRUNC('year', CURRENT_DATE)`,
           label: "Pedidos Recibidos (mes)",
           sql: `SELECT COUNT(DISTINCT "reg_pedido") AS value
 FROM "public"."ps_compras"
-WHERE "fecha_recibido" >= DATE_TRUNC('month', CURRENT_DATE)
-  AND "fecha_recibido" IS NOT NULL`,
+WHERE "fecha_recibido" >= DATE_TRUNC('month', CURRENT_DATE)`,
           format: "number",
         },
         {

--- a/dashboard/lib/templates/compras.ts
+++ b/dashboard/lib/templates/compras.ts
@@ -3,6 +3,11 @@
  *
  * Purchasing overview: monthly KPIs, top suppliers, recent purchase orders,
  * recent receptions, and monthly purchase-order trends.
+ *
+ * Schema notes (from issue #142 data model review):
+ * - ps_compras uses fecha_pedido (NOT fecha_creacion)
+ * - ps_lineas_compras has num_articulo (NUMERIC FK), NOT codigo/unidades
+ * - ps_albaranes has fecha_recibido (NOT fecha_creacion)
  */
 import type { DashboardSpec } from "@/lib/schema";
 
@@ -23,14 +28,22 @@ export const spec: DashboardSpec = {
           label: "Pedidos de Compra (mes)",
           sql: `SELECT COUNT(DISTINCT "reg_pedido") AS value
 FROM "public"."ps_compras"
-WHERE "fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)`,
+WHERE "fecha_pedido" >= DATE_TRUNC('month', CURRENT_DATE)`,
           format: "number",
         },
         {
-          label: "Proveedores Activos",
+          label: "Proveedores Activos (YTD)",
           sql: `SELECT COUNT(DISTINCT "num_proveedor") AS value
 FROM "public"."ps_compras"
-WHERE "fecha_creacion" >= DATE_TRUNC('year', CURRENT_DATE)`,
+WHERE "fecha_pedido" >= DATE_TRUNC('year', CURRENT_DATE)`,
+          format: "number",
+        },
+        {
+          label: "Pedidos Recibidos (mes)",
+          sql: `SELECT COUNT(DISTINCT "reg_pedido") AS value
+FROM "public"."ps_compras"
+WHERE "fecha_recibido" >= DATE_TRUNC('month', CURRENT_DATE)
+  AND "fecha_recibido" IS NOT NULL`,
           format: "number",
         },
         {
@@ -38,7 +51,7 @@ WHERE "fecha_creacion" >= DATE_TRUNC('year', CURRENT_DATE)`,
           sql: `SELECT COUNT(*) AS value
 FROM "public"."ps_lineas_compras" lc
 JOIN "public"."ps_compras" c ON lc."num_pedido" = c."reg_pedido"
-WHERE c."fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)`,
+WHERE c."fecha_pedido" >= DATE_TRUNC('month', CURRENT_DATE)`,
           format: "number",
         },
       ],
@@ -51,7 +64,7 @@ WHERE c."fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)`,
        COUNT(DISTINCT c."reg_pedido") AS value
 FROM "public"."ps_compras" c
 JOIN "public"."ps_proveedores" pr ON c."num_proveedor" = pr."reg_proveedor"
-WHERE c."fecha_creacion" >= DATE_TRUNC('year', CURRENT_DATE)
+WHERE c."fecha_pedido" >= DATE_TRUNC('year', CURRENT_DATE)
 GROUP BY pr."nombre"
 ORDER BY value DESC
 LIMIT 10`,
@@ -64,14 +77,14 @@ LIMIT 10`,
       title: "Ultimos Pedidos de Compra",
       sql: `SELECT c."reg_pedido" AS "Pedido",
        pr."nombre" AS "Proveedor",
-       COUNT(lc."codigo") AS "Lineas",
-       SUM(lc."unidades") AS "Unidades",
-       c."fecha_creacion" AS "Fecha"
+       COUNT(lc."reg_linea_compra") AS "Lineas",
+       c."fecha_pedido" AS "Fecha Pedido",
+       c."fecha_recibido" AS "Fecha Recibido"
 FROM "public"."ps_compras" c
 JOIN "public"."ps_proveedores" pr ON c."num_proveedor" = pr."reg_proveedor"
-JOIN "public"."ps_lineas_compras" lc ON lc."num_pedido" = c."reg_pedido"
-GROUP BY c."reg_pedido", pr."nombre", c."fecha_creacion"
-ORDER BY c."fecha_creacion" DESC
+LEFT JOIN "public"."ps_lineas_compras" lc ON lc."num_pedido" = c."reg_pedido"
+GROUP BY c."reg_pedido", pr."nombre", c."fecha_pedido", c."fecha_recibido"
+ORDER BY c."fecha_pedido" DESC
 LIMIT 20`,
     },
     {
@@ -79,21 +92,38 @@ LIMIT 20`,
       type: "table",
       title: "Recepciones Recientes (ultimos 30 dias)",
       sql: `SELECT a."reg_albaran" AS "Albaran",
-       a."fecha_creacion" AS "Fecha"
+       a."fecha_recibido" AS "Fecha Recibido"
 FROM "public"."ps_albaranes" a
-WHERE a."fecha_creacion" >= CURRENT_DATE - INTERVAL '30 days'
-ORDER BY a."fecha_creacion" DESC
+WHERE a."fecha_recibido" >= CURRENT_DATE - INTERVAL '30 days'
+ORDER BY a."fecha_recibido" DESC
+LIMIT 20`,
+    },
+    {
+      id: "compras-pendientes-recibir",
+      type: "table",
+      title: "Pedidos Pendientes de Recibir",
+      sql: `SELECT c."reg_pedido" AS "Pedido",
+       pr."nombre" AS "Proveedor",
+       c."fecha_pedido" AS "Fecha Pedido",
+       COUNT(lc."reg_linea_compra") AS "Lineas"
+FROM "public"."ps_compras" c
+JOIN "public"."ps_proveedores" pr ON c."num_proveedor" = pr."reg_proveedor"
+LEFT JOIN "public"."ps_lineas_compras" lc ON lc."num_pedido" = c."reg_pedido"
+WHERE c."fecha_recibido" IS NULL
+  AND c."fecha_pedido" >= CURRENT_DATE - INTERVAL '6 months'
+GROUP BY c."reg_pedido", pr."nombre", c."fecha_pedido"
+ORDER BY c."fecha_pedido" DESC
 LIMIT 20`,
     },
     {
       id: "compras-tendencia-mensual",
       type: "line_chart",
       title: "Pedidos de Compra Mensuales (ultimos 12 meses)",
-      sql: `SELECT DATE_TRUNC('month', c."fecha_creacion") AS x,
+      sql: `SELECT DATE_TRUNC('month', c."fecha_pedido") AS x,
        COUNT(DISTINCT c."reg_pedido") AS y
 FROM "public"."ps_compras" c
-WHERE c."fecha_creacion" >= CURRENT_DATE - INTERVAL '12 months'
-GROUP BY DATE_TRUNC('month', c."fecha_creacion")
+WHERE c."fecha_pedido" >= CURRENT_DATE - INTERVAL '12 months'
+GROUP BY DATE_TRUNC('month', c."fecha_pedido")
 ORDER BY x`,
       x: "x",
       y: "y",

--- a/dashboard/lib/templates/general.ts
+++ b/dashboard/lib/templates/general.ts
@@ -9,7 +9,7 @@ import type { DashboardSpec } from "@/lib/schema";
 export const name = "Director General";
 
 export const description =
-  "Panel ejecutivo: ventas retail, facturacion mayorista, margen global, mix de canales, tendencia 12 meses y top familias.";
+  "Panel ejecutivo: ventas retail, facturacion mayorista, margen global, comparativa YoY, mix de canales, ventas por tienda, tendencia 12 meses, top familias y valor de stock.";
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Director General",
@@ -20,7 +20,7 @@ export const spec: DashboardSpec = {
       type: "kpi_row",
       items: [
         {
-          label: "Ventas Retail Netas",
+          label: "Ventas Retail Netas (YTD)",
           sql: `SELECT COALESCE(SUM("total_si"), 0) AS value
 FROM "public"."ps_ventas"
 WHERE "entrada" = true
@@ -30,7 +30,7 @@ WHERE "entrada" = true
           prefix: "€",
         },
         {
-          label: "Facturacion Mayorista",
+          label: "Facturacion Mayorista (YTD)",
           sql: `SELECT COALESCE(SUM("base1" + "base2" + "base3"), 0) AS value
 FROM "public"."ps_gc_facturas"
 WHERE "abono" = false
@@ -52,6 +52,27 @@ WHERE v."entrada" = true
   AND lv."fecha_creacion" >= DATE_TRUNC('year', CURRENT_DATE)`,
           format: "percent",
         },
+        {
+          label: "Retail YoY %",
+          sql: `SELECT ROUND(
+  (curr.ventas - prev.ventas) / NULLIF(ABS(prev.ventas), 0) * 100, 1
+) AS value
+FROM (
+  SELECT COALESCE(SUM("total_si"), 0) AS ventas
+  FROM "public"."ps_ventas"
+  WHERE "entrada" = true AND "tienda" <> '99'
+    AND "fecha_creacion" >= DATE_TRUNC('year', CURRENT_DATE)
+    AND "fecha_creacion" <= CURRENT_DATE
+) curr,
+(
+  SELECT COALESCE(SUM("total_si"), 0) AS ventas
+  FROM "public"."ps_ventas"
+  WHERE "entrada" = true AND "tienda" <> '99'
+    AND "fecha_creacion" >= DATE_TRUNC('year', CURRENT_DATE) - INTERVAL '1 year'
+    AND "fecha_creacion" <= CURRENT_DATE - INTERVAL '1 year'
+) prev`,
+          format: "percent",
+        },
       ],
     },
     {
@@ -70,6 +91,20 @@ SELECT 'Mayorista' AS label,
 FROM "public"."ps_gc_facturas"
 WHERE "abono" = false
   AND "fecha_factura" >= DATE_TRUNC('year', CURRENT_DATE)`,
+      x: "label",
+      y: "value",
+    },
+    {
+      id: "general-ventas-por-tienda",
+      type: "bar_chart",
+      title: "Ventas Retail por Tienda (YTD)",
+      sql: `SELECT "tienda" AS label, SUM("total_si") AS value
+FROM "public"."ps_ventas"
+WHERE "entrada" = true
+  AND "tienda" <> '99'
+  AND "fecha_creacion" >= DATE_TRUNC('year', CURRENT_DATE)
+GROUP BY "tienda"
+ORDER BY value DESC`,
       x: "label",
       y: "value",
     },
@@ -118,6 +153,37 @@ WHERE v."entrada" = true
 GROUP BY fm."fami_grup_marc"
 ORDER BY "Ventas Netas" DESC
 LIMIT 10`,
+    },
+    {
+      id: "general-valor-stock",
+      type: "kpi_row",
+      items: [
+        {
+          label: "Valor Stock Total al Coste",
+          sql: `SELECT COALESCE(ROUND(SUM(s."stock" * p."precio_coste"), 2), 0) AS value
+FROM "public"."ps_stock_tienda" s
+JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
+WHERE s."stock" > 0 AND p."anulado" = false`,
+          format: "currency",
+          prefix: "€",
+        },
+        {
+          label: "Unidades en Stock",
+          sql: `SELECT COALESCE(SUM("stock"), 0) AS value
+FROM "public"."ps_stock_tienda"
+WHERE "stock" > 0`,
+          format: "number",
+        },
+        {
+          label: "Pedidos Mayorista Pendientes",
+          sql: `SELECT COUNT(DISTINCT "reg_pedido") AS value
+FROM "public"."ps_gc_pedidos"
+WHERE "pedido_cerrado" = false
+  AND "abono" = false
+  AND "pendientes" > 0`,
+          format: "number",
+        },
+      ],
     },
   ],
 };

--- a/dashboard/lib/templates/mayorista.ts
+++ b/dashboard/lib/templates/mayorista.ts
@@ -78,16 +78,30 @@ ORDER BY value DESC`,
       id: "mayorista-top-clientes",
       type: "table",
       title: "Top 10 Clientes Mayorista (YTD)",
-      sql: `SELECT c."nombre" AS "Cliente",
-       COUNT(DISTINCT f."reg_factura") AS "Facturas",
-       SUM(f."base1" + f."base2" + f."base3") AS "Facturacion Neta",
-       ROUND((SUM(lf."total") - SUM(lf."total_coste"))
-         / NULLIF(SUM(lf."total"), 0) * 100, 1) AS "Margen %"
-FROM "public"."ps_gc_facturas" f
-JOIN "public"."ps_clientes" c ON f."num_cliente" = c."reg_cliente"
-JOIN "public"."ps_gc_lin_facturas" lf ON lf."num_factura" = f."n_factura"
-WHERE f."abono" = false
-  AND f."fecha_factura" >= DATE_TRUNC('year', CURRENT_DATE)
+      sql: `WITH facturas_ytd AS (
+  SELECT f."reg_factura",
+         f."n_factura",
+         f."num_cliente",
+         (f."base1" + f."base2" + f."base3") AS neto
+  FROM "public"."ps_gc_facturas" f
+  WHERE f."abono" = false
+    AND f."fecha_factura" >= DATE_TRUNC('year', CURRENT_DATE)
+), margenes AS (
+  SELECT lf."num_factura",
+         SUM(lf."total")       AS total_ingreso,
+         SUM(lf."total_coste") AS total_coste
+  FROM "public"."ps_gc_lin_facturas" lf
+  WHERE lf."num_factura" IN (SELECT "n_factura" FROM facturas_ytd)
+  GROUP BY lf."num_factura"
+)
+SELECT c."nombre" AS "Cliente",
+       COUNT(DISTINCT fy."reg_factura") AS "Facturas",
+       SUM(fy.neto) AS "Facturacion Neta",
+       ROUND((SUM(m.total_ingreso) - SUM(m.total_coste))
+         / NULLIF(SUM(m.total_ingreso), 0) * 100, 1) AS "Margen %"
+FROM facturas_ytd fy
+JOIN "public"."ps_clientes" c ON fy."num_cliente" = c."reg_cliente"
+LEFT JOIN margenes m ON m."num_factura" = fy."n_factura"
 GROUP BY c."nombre"
 ORDER BY "Facturacion Neta" DESC
 LIMIT 10`,

--- a/dashboard/lib/templates/mayorista.ts
+++ b/dashboard/lib/templates/mayorista.ts
@@ -9,7 +9,7 @@ import type { DashboardSpec } from "@/lib/schema";
 export const name = "Director Mayorista";
 
 export const description =
-  "Panel para el director del canal mayorista: facturacion neta, desglose por comercial, top clientes, albaranes recientes y comparativa de periodos.";
+  "Panel para el director del canal mayorista: facturacion neta, margen, desglose por comercial, top clientes, pedidos pendientes, albaranes recientes, top productos y comparativa mensual.";
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Mayorista",
@@ -37,7 +37,20 @@ WHERE "abono" = false
           format: "number",
         },
         {
-          label: "Clientes Activos",
+          label: "Margen Mayorista",
+          sql: `SELECT ROUND(
+  (SUM(lf."total") - SUM(lf."total_coste"))
+  / NULLIF(SUM(lf."total"), 0) * 100, 1
+) AS value
+FROM "public"."ps_gc_lin_facturas" lf
+JOIN "public"."ps_gc_facturas" f ON lf."num_factura" = f."n_factura"
+WHERE lf."total" > 0
+  AND f."abono" = false
+  AND f."fecha_factura" >= DATE_TRUNC('month', CURRENT_DATE)`,
+          format: "percent",
+        },
+        {
+          label: "Clientes Activos (YTD)",
           sql: `SELECT COUNT(DISTINCT "num_cliente") AS value
 FROM "public"."ps_gc_facturas"
 WHERE "abono" = false
@@ -67,14 +80,36 @@ ORDER BY value DESC`,
       title: "Top 10 Clientes Mayorista (YTD)",
       sql: `SELECT c."nombre" AS "Cliente",
        COUNT(DISTINCT f."reg_factura") AS "Facturas",
-       SUM(f."base1" + f."base2" + f."base3") AS "Facturacion Neta"
+       SUM(f."base1" + f."base2" + f."base3") AS "Facturacion Neta",
+       ROUND((SUM(lf."total") - SUM(lf."total_coste"))
+         / NULLIF(SUM(lf."total"), 0) * 100, 1) AS "Margen %"
 FROM "public"."ps_gc_facturas" f
 JOIN "public"."ps_clientes" c ON f."num_cliente" = c."reg_cliente"
+JOIN "public"."ps_gc_lin_facturas" lf ON lf."num_factura" = f."n_factura"
 WHERE f."abono" = false
   AND f."fecha_factura" >= DATE_TRUNC('year', CURRENT_DATE)
 GROUP BY c."nombre"
 ORDER BY "Facturacion Neta" DESC
 LIMIT 10`,
+    },
+    {
+      id: "mayorista-pedidos-pendientes",
+      type: "table",
+      title: "Pedidos Pendientes de Entregar",
+      sql: `SELECT c."nombre" AS "Cliente",
+       gp."n_pedido" AS "Pedido",
+       gp."fecha_pedido" AS "Fecha",
+       gp."unidades" AS "Pedidas",
+       gp."entregadas" AS "Entregadas",
+       gp."pendientes" AS "Pendientes",
+       gp."temporada" AS "Temporada"
+FROM "public"."ps_gc_pedidos" gp
+JOIN "public"."ps_clientes" c ON gp."num_cliente" = c."reg_cliente"
+WHERE gp."pedido_cerrado" = false
+  AND gp."abono" = false
+  AND gp."pendientes" > 0
+ORDER BY gp."fecha_pedido" DESC
+LIMIT 20`,
     },
     {
       id: "mayorista-albaranes-recientes",
@@ -83,15 +118,34 @@ LIMIT 10`,
       sql: `SELECT a."n_albaran" AS "Albaran",
        c."nombre" AS "Cliente",
        a."entregadas" AS "Unidades",
-       SUM(a."base1" + a."base2" + a."base3") AS "Importe Neto",
+       (a."base1" + a."base2" + a."base3") AS "Importe Neto",
        a."fecha_envio" AS "Fecha"
 FROM "public"."ps_gc_albaranes" a
 JOIN "public"."ps_clientes" c ON a."num_cliente" = c."reg_cliente"
 WHERE a."abono" = false
   AND a."fecha_envio" >= CURRENT_DATE - INTERVAL '30 days'
-GROUP BY a."n_albaran", c."nombre", a."entregadas", a."fecha_envio"
 ORDER BY a."fecha_envio" DESC
 LIMIT 20`,
+    },
+    {
+      id: "mayorista-top-productos",
+      type: "table",
+      title: "Top 10 Productos Mayorista (YTD)",
+      sql: `SELECT p."ccrefejofacm" AS "Referencia",
+       p."descripcion" AS "Descripción",
+       SUM(lf."unidades") AS "Unidades",
+       SUM(lf."total") AS "Importe",
+       ROUND((SUM(lf."total") - SUM(lf."total_coste"))
+         / NULLIF(SUM(lf."total"), 0) * 100, 1) AS "Margen %"
+FROM "public"."ps_gc_lin_facturas" lf
+JOIN "public"."ps_gc_facturas" f ON lf."num_factura" = f."n_factura"
+JOIN "public"."ps_articulos" p ON lf."codigo" = p."codigo"
+WHERE f."abono" = false
+  AND lf."unidades" > 0
+  AND f."fecha_factura" >= DATE_TRUNC('year', CURRENT_DATE)
+GROUP BY p."ccrefejofacm", p."descripcion"
+ORDER BY "Importe" DESC
+LIMIT 10`,
     },
     {
       id: "mayorista-comparativa-mensual",

--- a/dashboard/lib/templates/stock.ts
+++ b/dashboard/lib/templates/stock.ts
@@ -116,14 +116,14 @@ LIMIT 30`,
     {
       id: "stock-dead-stock",
       type: "table",
-      title: "Dead Stock (con stock > 10, sin ventas en 90 dias)",
+      title: "Dead Stock (stock total > 10, sin ventas en 90 dias)",
       sql: `SELECT p."ccrefejofacm" AS "Referencia",
        p."descripcion" AS "Descripción",
        SUM(s."stock") AS "Stock",
        p."clave_temporada" AS "Temporada"
 FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
-WHERE s."stock" > 10
+WHERE s."stock" > 0
   AND p."anulado" = false
   AND p."codigo" NOT IN (
     SELECT DISTINCT lv."codigo"
@@ -134,6 +134,7 @@ WHERE s."stock" > 10
       AND lv."fecha_creacion" >= CURRENT_DATE - INTERVAL '90 days'
   )
 GROUP BY p."ccrefejofacm", p."descripcion", p."clave_temporada"
+HAVING SUM(s."stock") > 10
 ORDER BY "Stock" DESC
 LIMIT 30`,
     },

--- a/dashboard/lib/templates/stock.ts
+++ b/dashboard/lib/templates/stock.ts
@@ -9,7 +9,7 @@ import type { DashboardSpec } from "@/lib/schema";
 export const name = "Responsable de Stock";
 
 export const description =
-  "Panel para el responsable de stock: unidades totales, distribucion por tienda, stock en almacen, sin stock y traspasos recientes.";
+  "Panel para el responsable de stock: unidades totales, valoracion al coste, distribucion por tienda y familia, stock bajo, dead stock, sin stock y traspasos recientes.";
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Stock",
@@ -34,11 +34,13 @@ WHERE "stock" > 0 AND "tienda" = '99'`,
           format: "number",
         },
         {
-          label: "Tiendas con Stock",
-          sql: `SELECT COUNT(DISTINCT "tienda") AS value
-FROM "public"."ps_stock_tienda"
-WHERE "stock" > 0 AND "tienda" <> '99'`,
-          format: "number",
+          label: "Valor Stock al Coste",
+          sql: `SELECT COALESCE(ROUND(SUM(s."stock" * p."precio_coste"), 2), 0) AS value
+FROM "public"."ps_stock_tienda" s
+JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
+WHERE s."stock" > 0 AND p."anulado" = false`,
+          format: "currency",
+          prefix: "€",
         },
         {
           label: "Referencias Activas",
@@ -59,6 +61,22 @@ FROM "public"."ps_stock_tienda"
 WHERE "stock" > 0 AND "tienda" <> '99'
 GROUP BY "tienda"
 ORDER BY value DESC`,
+      x: "label",
+      y: "value",
+    },
+    {
+      id: "stock-por-familia",
+      type: "bar_chart",
+      title: "Stock por Familia (unidades, top 10)",
+      sql: `SELECT fm."fami_grup_marc" AS label,
+       SUM(s."stock") AS value
+FROM "public"."ps_stock_tienda" s
+JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
+JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
+WHERE s."stock" > 0 AND p."anulado" = false
+GROUP BY fm."fami_grup_marc"
+ORDER BY value DESC
+LIMIT 10`,
       x: "label",
       y: "value",
     },
@@ -93,6 +111,30 @@ GROUP BY p."ccrefejofacm", p."descripcion"
 HAVING SUM(CASE WHEN s."tienda" <> '99' THEN s."stock" ELSE 0 END) = 0
    AND SUM(CASE WHEN s."tienda" = '99' THEN s."stock" ELSE 0 END) > 0
 ORDER BY "Stock Almacén" DESC
+LIMIT 30`,
+    },
+    {
+      id: "stock-dead-stock",
+      type: "table",
+      title: "Dead Stock (con stock > 10, sin ventas en 90 dias)",
+      sql: `SELECT p."ccrefejofacm" AS "Referencia",
+       p."descripcion" AS "Descripción",
+       SUM(s."stock") AS "Stock",
+       p."clave_temporada" AS "Temporada"
+FROM "public"."ps_stock_tienda" s
+JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
+WHERE s."stock" > 10
+  AND p."anulado" = false
+  AND p."codigo" NOT IN (
+    SELECT DISTINCT lv."codigo"
+    FROM "public"."ps_lineas_ventas" lv
+    JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
+    WHERE v."entrada" = true
+      AND lv."tienda" <> '99'
+      AND lv."fecha_creacion" >= CURRENT_DATE - INTERVAL '90 days'
+  )
+GROUP BY p."ccrefejofacm", p."descripcion", p."clave_temporada"
+ORDER BY "Stock" DESC
 LIMIT 30`,
     },
     {

--- a/dashboard/lib/templates/ventas.ts
+++ b/dashboard/lib/templates/ventas.ts
@@ -1,7 +1,8 @@
 /**
  * Template: Responsable de Ventas
  *
- * KPIs de ventas retail, desglose por tienda, tendencia semanal, top articulos.
+ * KPIs de ventas retail, devoluciones, desglose por tienda, tendencia semanal,
+ * formas de pago, margen por tienda, top articulos con margen.
  * All dates are CURRENT_DATE-relative so the dashboard always shows fresh data.
  */
 import type { DashboardSpec } from "@/lib/schema";
@@ -9,7 +10,7 @@ import type { DashboardSpec } from "@/lib/schema";
 export const name = "Responsable de Ventas";
 
 export const description =
-  "Panel para el responsable de ventas retail: KPIs, desglose por tienda, tendencia semanal y top articulos.";
+  "Panel para el responsable de ventas retail: KPIs y devoluciones, desglose por tienda, tendencia semanal, formas de pago, margen por tienda y top articulos.";
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Ventas Retail",
@@ -48,6 +49,16 @@ WHERE "entrada" = true
           format: "currency",
           prefix: "€",
         },
+        {
+          label: "Devoluciones",
+          sql: `SELECT COALESCE(ABS(SUM("total_si")), 0) AS value
+FROM "public"."ps_ventas"
+WHERE "entrada" = false
+  AND "tienda" <> '99'
+  AND "fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)`,
+          format: "currency",
+          prefix: "€",
+        },
       ],
     },
     {
@@ -79,13 +90,48 @@ ORDER BY x`,
       y: "y",
     },
     {
+      id: "ventas-formas-pago",
+      type: "donut_chart",
+      title: "Mix de Formas de Pago (mes actual)",
+      sql: `SELECT p."forma" AS label,
+       SUM(p."importe_cob") AS value
+FROM "public"."ps_pagos_ventas" p
+WHERE p."entrada" = true
+  AND p."tienda" <> '99'
+  AND p."fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)
+GROUP BY p."forma"
+ORDER BY value DESC`,
+      x: "label",
+      y: "value",
+    },
+    {
+      id: "ventas-margen-tienda",
+      type: "bar_chart",
+      title: "Margen Bruto % por Tienda (mes actual)",
+      sql: `SELECT lv."tienda" AS label,
+       ROUND((SUM(lv."total_si") - SUM(lv."total_coste_si"))
+         / NULLIF(SUM(lv."total_si"), 0) * 100, 1) AS value
+FROM "public"."ps_lineas_ventas" lv
+JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
+WHERE v."entrada" = true
+  AND lv."tienda" <> '99'
+  AND lv."total_si" > 0
+  AND lv."fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)
+GROUP BY lv."tienda"
+ORDER BY value DESC`,
+      x: "label",
+      y: "value",
+    },
+    {
       id: "ventas-top-articulos",
       type: "table",
       title: "Top 10 Artículos (mes actual)",
       sql: `SELECT p."ccrefejofacm" AS "Referencia",
        p."descripcion" AS "Descripción",
        SUM(lv."unidades") AS "Unidades",
-       SUM(lv."total_si") AS "Ventas Netas"
+       SUM(lv."total_si") AS "Ventas Netas",
+       ROUND((SUM(lv."total_si") - SUM(lv."total_coste_si"))
+         / NULLIF(SUM(lv."total_si"), 0) * 100, 1) AS "Margen %"
 FROM "public"."ps_lineas_ventas" lv
 JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
 JOIN "public"."ps_articulos" p ON lv."codigo" = p."codigo"

--- a/dashboard/lib/templates/ventas.ts
+++ b/dashboard/lib/templates/ventas.ts
@@ -137,6 +137,7 @@ JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
 JOIN "public"."ps_articulos" p ON lv."codigo" = p."codigo"
 WHERE v."entrada" = true
   AND lv."tienda" <> '99'
+  AND lv."total_si" > 0
   AND lv."fecha_creacion" >= DATE_TRUNC('month', CURRENT_DATE)
 GROUP BY p."ccrefejofacm", p."descripcion"
 ORDER BY "Ventas Netas" DESC


### PR DESCRIPTION
Compras template: fix all broken queries — ps_compras uses fecha_pedido
(not fecha_creacion), ps_lineas_compras has num_articulo (not codigo/
unidades), ps_albaranes has fecha_recibido (not fecha_creacion). Add
pedidos pendientes widget.

Ventas template: add devoluciones KPI, formas de pago donut chart,
margen bruto por tienda bar chart, margin % column to top articulos.

Stock template: add valor stock al coste KPI, stock por familia chart,
dead stock table (articles with stock >10 but no sales in 90 days).

Mayorista template: add margen mayorista KPI, margin % to top clientes,
pedidos pendientes de entregar table, top 10 productos mayorista table.

General template: add retail YoY % comparison KPI, ventas por tienda
bar chart, valor stock + unidades + pedidos pendientes KPI row.

All 598 tests pass (41 template-specific tests).

https://claude.ai/code/session_01TgdDXyE222FzNFZW5yGB3A