### PR TITLE
fix(ai-factory): stop silent failures — verify PRs, recover stuck work, ping owner

### DIFF
--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -2,10 +2,27 @@ name: AI Address PR Feedback
 on:
   pull_request_review:
     types: [submitted]
+  # Note: we deliberately do NOT trigger on pull_request_review_comment —
+  # a single review often fires many inline-comment events. Using only the
+  # aggregated review submission event keeps the workflow manageable. If
+  # any review slips past (e.g. because GitHub gates bot-triggered runs as
+  # `action_required`), the watchdog in ai-watchdog.yml catches it and
+  # dispatches this workflow manually.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to address feedback on"
+        required: true
+        type: number
+      reason:
+        description: "Why we are triggering manually (logged in the comment)"
+        required: false
+        type: string
+        default: "manual dispatch"
 
 concurrency:
-  group: ai-address-feedback-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: ai-address-feedback-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -16,37 +33,146 @@ permissions:
   id-token: write
 
 jobs:
+  # Resolve which PR we are operating on (works across three event types).
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.pick.outputs.pr_number }}
+      head_ref: ${{ steps.pick.outputs.head_ref }}
+      should_run: ${{ steps.pick.outputs.should_run }}
+      reason: ${{ steps.pick.outputs.reason }}
+    steps:
+      - name: Resolve PR number and decide
+        id: pick
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          EVENT="${{ github.event_name }}"
+          PR=""
+          SHOULD_RUN="false"
+          REASON=""
+
+          case "$EVENT" in
+            pull_request_review)
+              PR="${{ github.event.pull_request.number }}"
+              STATE="${{ github.event.review.state }}"
+              ACTOR="${{ github.event.review.user.login }}"
+              # Avoid loops: never react to our own bot's reviews.
+              if [ "$ACTOR" = "claude[bot]" ] || [ "$ACTOR" = "github-actions[bot]" ]; then
+                REASON="ignored self-review from $ACTOR"
+              # Run when a human requests changes OR any reviewer (including bots
+              # like Copilot) leaves a review that contains inline comments.
+              # Copilot always submits as COMMENTED even when it leaves inline
+              # change suggestions.
+              elif [ "$STATE" = "changes_requested" ]; then
+                SHOULD_RUN="true"
+                REASON="review requested changes (reviewer: $ACTOR)"
+              elif [ "$STATE" = "commented" ] || [ "$STATE" = "COMMENTED" ]; then
+                # Only run if this review carries inline comments — a plain
+                # overview comment without suggestions isn't actionable.
+                COMMENT_COUNT=$(gh api \
+                  "repos/${{ github.repository }}/pulls/$PR/reviews/${{ github.event.review.id }}/comments" \
+                  --jq 'length' 2>/dev/null || echo "0")
+                if [ "${COMMENT_COUNT:-0}" -gt 0 ]; then
+                  SHOULD_RUN="true"
+                  REASON="review with $COMMENT_COUNT inline comment(s) (reviewer: $ACTOR)"
+                else
+                  REASON="COMMENTED review with no inline comments from $ACTOR"
+                fi
+              fi
+              ;;
+            workflow_dispatch)
+              PR="${{ inputs.pr_number }}"
+              SHOULD_RUN="true"
+              REASON="${{ inputs.reason }}"
+              ;;
+          esac
+
+          if [ -z "$PR" ]; then
+            echo "No PR number resolved; skipping."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Pull PR state in one shot.
+          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/$PR")
+          HEAD_REF=$(echo "$PR_JSON" | jq -r '.head.ref')
+          SAME_REPO=$(echo "$PR_JSON" | jq -r '.head.repo.full_name == "${{ github.repository }}"')
+          STATE=$(echo "$PR_JSON" | jq -r '.state')
+          LABELS=$(echo "$PR_JSON" | jq -r '[.labels[].name] | join(",")')
+
+          if [ "$STATE" != "open" ]; then
+            SHOULD_RUN="false"
+            REASON="PR #$PR is $STATE; nothing to do"
+          fi
+          if [ "$SAME_REPO" != "true" ]; then
+            SHOULD_RUN="false"
+            REASON="PR #$PR is from a fork; cannot push fixes"
+          fi
+          if echo ",$LABELS," | grep -q ",no-address-feedback,"; then
+            SHOULD_RUN="false"
+            REASON="PR #$PR labelled no-address-feedback"
+          fi
+
+          echo "pr_number=$PR" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+          echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+          echo "Resolved: PR=$PR head=$HEAD_REF should_run=$SHOULD_RUN reason=$REASON"
+
   address:
-    # Only run for reviews that request changes, and not from this bot (avoid loops)
-    if: >-
-      github.event.review.state == 'changes_requested' &&
-      github.event.review.user.login != 'github-actions[bot]' &&
-      github.event.review.user.login != 'claude[bot]' &&
-      !contains(github.event.pull_request.labels.*.name, 'no-address-feedback') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    needs: resolve
+    if: needs.resolve.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ needs.resolve.outputs.head_ref }}
           fetch-depth: 0
 
+      - name: Announce start
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ needs.resolve.outputs.pr_number }} \
+            --body "🤖 Addressing review feedback automatically (${{ needs.resolve.outputs.reason }}). See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+
       - name: Address Review Feedback
+        id: address
         uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--max-turns 200"
+          allowed_bots: "claude[bot],copilot-pull-request-reviewer[bot]"
           prompt: |
-            A reviewer has requested changes on this PR. Read ALL review comments and address them.
+            You are addressing review feedback on PR #${{ needs.resolve.outputs.pr_number }}.
+            Trigger reason: ${{ needs.resolve.outputs.reason }}.
+
+            ## Process
+            1. Fetch ALL unresolved review threads on the PR:
+               `gh api repos/${{ github.repository }}/pulls/${{ needs.resolve.outputs.pr_number }}/comments --paginate`
+               and the review summaries:
+               `gh api repos/${{ github.repository }}/pulls/${{ needs.resolve.outputs.pr_number }}/reviews --paginate`
+               Ignore any threads already resolved or where the latest reply is from claude[bot] or github-actions[bot] (avoid loops).
+            2. Also check CI status:
+               `gh pr checks ${{ needs.resolve.outputs.pr_number }}`
 
             ## What to fix (DO these):
-            - Typos, naming, and formatting issues
+            - Typos, naming, and formatting issues (including Spanish accents)
             - Type corrections and import cleanup
             - Simple logic corrections with obvious fixes
+            - Bug fixes called out by a reviewer with a clear suggestion
             - Documentation improvements
-            - Minor refactors suggested by reviewer
+            - Minor refactors suggested by the reviewer
             - Lint and style issues
+            - Adding missing tests when the reviewer explicitly asked for them
+            - CI failures that are straightforward (lint/type/import/trivial tests)
 
-            ## What NOT to fix (SKIP these):
+            ## What NOT to fix (reply and skip):
             - Architectural redesigns
             - Algorithm rewrites
             - Subjective style preferences with no clear consensus
@@ -54,14 +180,36 @@ jobs:
             - Changes that would significantly alter the PR scope
 
             ## For each review comment:
-            1. If you can fix it: apply the fix and reply to the comment thread explaining what you changed
-            2. If you should skip it: reply to the comment explaining WHY you're skipping it
+            1. If you fix it: apply the fix in the code, then reply to the comment thread using
+               `gh api ... /pulls/comments/{id}/replies -f body="..."` describing exactly what changed.
+            2. If you skip it: reply explaining WHY briefly.
+            3. Keep replies concise (1–3 sentences).
 
-            ## Also check CI:
-            If CI is failing, check the logs. Fix straightforward failures:
-            - Lint errors → fix them
-            - Type errors → fix them
-            - Missing imports → add them
-            - Simple test failures with obvious fixes → fix them
+            ## Commit strategy
+            - Stage all fixes and commit with: `fix: address review feedback (round N)`
+            - Push to the PR branch
+            - If CI was failing, your commit must fix it. Verify locally by running the same commands.
 
-            Commit all fixes with a message like: "fix: address review feedback"
+            ## Completion
+            - If you successfully addressed or replied to every thread, post a single summary comment
+              on the PR listing: threads addressed, threads skipped (with reasons), files touched,
+              tests run.
+            - If you could NOT address something and need human input, post a comment tagging
+              @alvarolobato and explain precisely what is blocking you. Then exit normally — do NOT
+              error out, so the workflow records the blocked state.
+
+            ## Important
+            - NEVER use --no-verify or bypass pre-commit hooks.
+            - NEVER force-push.
+            - Read-only SQL policy still applies (no INSERT/UPDATE/DELETE in production queries).
+            - Stay within this PR's scope — do not pull in unrelated work.
+
+      - name: Handle failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ needs.resolve.outputs.pr_number }} \
+            --body "❌ @alvarolobato — AI auto-address-feedback failed. [Workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). I will not re-attempt automatically; please inspect and re-trigger via workflow_dispatch if appropriate."
+          gh pr edit ${{ needs.resolve.outputs.pr_number }} \
+            --add-label "ai-blocked" || true

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -26,6 +26,16 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Load review guidelines
+        id: guidelines
+        run: |
+          {
+            echo 'CONTENT<<PR_REVIEW_EOF'
+            cat .github/ai-factory/prompts/pr-review.md
+            echo
+            echo 'PR_REVIEW_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Claude PR Review
         uses: anthropics/claude-code-action@v1
         with:
@@ -33,4 +43,19 @@ jobs:
           use_sticky_comment: "true"
           include_fix_links: "true"
           classify_inline_comments: "true"
-          prompt_file: .github/ai-factory/prompts/pr-review.md
+          prompt: |
+            You are reviewing PR #${{ github.event.pull_request.number }}: "${{ github.event.pull_request.title }}".
+
+            Follow the review guidelines below. Post a review with inline comments on the PR.
+
+            ---
+
+            ${{ steps.guidelines.outputs.CONTENT }}
+
+      - name: Handle failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "⚠️ @alvarolobato — AI PR Review failed on commit ${{ github.event.pull_request.head.sha }}. See the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details. The PR will not auto-review until this is fixed."

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -1,0 +1,199 @@
+name: AI Factory Watchdog
+# Periodically scans the factory for silent failures and actively recovers.
+# This is the safety net: if any of the event-driven workflows misses a
+# trigger (e.g. because GitHub gated it with `action_required`, or because
+# a label race cancelled the worker), the watchdog catches it and either
+# re-queues the work, triggers the address-feedback flow, or pings the
+# owner with `ai-blocked` + a clear explanation.
+on:
+  schedule:
+    # Every 15 minutes
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: ai-watchdog
+  cancel-in-progress: false
+
+jobs:
+  watchdog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      OWNER: ${{ github.repository_owner }}
+      REPO_FULL: ${{ github.repository }}
+      OWNER_HANDLE: alvarolobato
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stuck `ai-in-progress` issues
+        run: |
+          set -euo pipefail
+          # Any issue in `ai-in-progress` for >60 minutes is considered stuck.
+          NOW=$(date -u +%s)
+          STUCK_THRESHOLD_SECS=3600
+
+          # List open issues with ai-in-progress
+          ISSUES=$(gh issue list --repo "$REPO_FULL" \
+            --state open --label "ai-in-progress" \
+            --json number,updatedAt,title,labels --limit 100)
+
+          echo "$ISSUES" | jq -c '.[]' | while read -r row; do
+            NUM=$(echo "$row" | jq -r '.number')
+            TITLE=$(echo "$row" | jq -r '.title')
+            UPDATED=$(echo "$row" | jq -r '.updatedAt')
+            UPDATED_TS=$(date -u -d "$UPDATED" +%s)
+            AGE=$(( NOW - UPDATED_TS ))
+
+            if [ "$AGE" -ge "$STUCK_THRESHOLD_SECS" ]; then
+              echo "Issue #$NUM ($TITLE) stuck for ${AGE}s — marking ai-blocked"
+              gh issue edit "$NUM" --repo "$REPO_FULL" \
+                --remove-label "ai-in-progress" || true
+              gh issue edit "$NUM" --repo "$REPO_FULL" \
+                --add-label "ai-blocked" || true
+              gh issue comment "$NUM" --repo "$REPO_FULL" \
+                --body "⚠️ @$OWNER_HANDLE — AI Factory watchdog: this issue has been \`ai-in-progress\` for over an hour without progress. Marking as \`ai-blocked\`. This usually means the worker was cancelled, hit a silent failure, or was gated by GitHub's bot-actor policy. See the [Actions tab](${{ github.server_url }}/${{ github.repository }}/actions) for recent worker runs. Remove \`ai-blocked\` and re-add \`ai-work\` to retry." || true
+            fi
+          done
+
+      - name: Sub-tasks with ai-task but no PR, no progress
+        run: |
+          set -euo pipefail
+          # A sub-task labeled `ai-task` but with NO `ai-in-progress`,
+          # `ai-blocked`, or `ai-work` and NO PR referencing it is
+          # considered an orphan worker result (e.g. worker claimed success
+          # but produced nothing). Flag it.
+          ISSUES=$(gh issue list --repo "$REPO_FULL" \
+            --state open --label "ai-task" \
+            --json number,title,labels --limit 100)
+
+          echo "$ISSUES" | jq -c '.[]' | while read -r row; do
+            NUM=$(echo "$row" | jq -r '.number')
+            TITLE=$(echo "$row" | jq -r '.title')
+            LABELS=$(echo "$row" | jq -r '[.labels[].name] | join(",")')
+
+            # Skip if already in progress / blocked / queued / done
+            for SKIP in ai-in-progress ai-blocked ai-work; do
+              if echo ",$LABELS," | grep -q ",$SKIP,"; then
+                continue 2
+              fi
+            done
+
+            # Look for a PR that closes this sub-task
+            PR_COUNT=$(gh pr list --repo "$REPO_FULL" --state all \
+              --search "head:ai/issue-${NUM}- OR \"Closes #${NUM}\" in:body" \
+              --json number --jq 'length')
+
+            if [ "${PR_COUNT:-0}" = "0" ]; then
+              echo "Orphan sub-task #$NUM ($TITLE) has no PR and no active label — re-queuing."
+              gh issue edit "$NUM" --repo "$REPO_FULL" --add-label "ai-blocked" || true
+              gh issue comment "$NUM" --repo "$REPO_FULL" \
+                --body "⚠️ @$OWNER_HANDLE — AI Factory watchdog: this sub-task has \`ai-task\` but no PR, no \`ai-in-progress\`, and no \`ai-work\`. The worker likely reported success without actually creating a PR. Marking as \`ai-blocked\`. Remove \`ai-blocked\` and add \`ai-work\` to retry, or close if already covered by another PR." || true
+            fi
+          done
+
+      - name: Open PRs with unaddressed reviewer feedback
+        run: |
+          set -euo pipefail
+          # Find open PRs where the latest activity by claude[bot] is older
+          # than the latest review/review-comment by a non-self reviewer.
+          # That means feedback is sitting unaddressed.
+
+          PRS=$(gh pr list --repo "$REPO_FULL" --state open \
+            --json number,headRefName,labels,author --limit 50)
+
+          echo "$PRS" | jq -c '.[]' | while read -r pr; do
+            NUM=$(echo "$pr" | jq -r '.number')
+            LABELS=$(echo "$pr" | jq -r '[.labels[].name] | join(",")')
+
+            # Skip opt-outs
+            if echo ",$LABELS," | grep -q ",no-address-feedback,"; then
+              echo "PR #$NUM opted out of address-feedback — skipping."
+              continue
+            fi
+            if echo ",$LABELS," | grep -q ",ai-blocked,"; then
+              echo "PR #$NUM already ai-blocked — skipping."
+              continue
+            fi
+
+            # Latest non-self reviewer activity (review submission or inline comment)
+            LATEST_REVIEWER_ACTIVITY=$(
+              {
+                gh api "repos/$REPO_FULL/pulls/$NUM/reviews" --paginate \
+                  --jq '.[] | select(.user.login != "claude[bot]" and .user.login != "github-actions[bot]") | .submitted_at'
+                gh api "repos/$REPO_FULL/pulls/$NUM/comments" --paginate \
+                  --jq '.[] | select(.user.login != "claude[bot]" and .user.login != "github-actions[bot]") | .updated_at'
+              } | sort -r | head -1
+            )
+
+            if [ -z "$LATEST_REVIEWER_ACTIVITY" ]; then
+              echo "PR #$NUM has no reviewer activity — skipping."
+              continue
+            fi
+
+            # Latest claude[bot] activity on the PR (commit, review, or comment)
+            LATEST_BOT_ACTIVITY=$(
+              {
+                gh api "repos/$REPO_FULL/pulls/$NUM/commits" --paginate \
+                  --jq '.[] | select(.commit.author.email | contains("claude") or contains("github-actions")) | .commit.committer.date'
+                gh api "repos/$REPO_FULL/issues/$NUM/comments" --paginate \
+                  --jq '.[] | select(.user.login == "claude[bot]" or .user.login == "github-actions[bot]") | .updated_at'
+                gh api "repos/$REPO_FULL/pulls/$NUM/comments" --paginate \
+                  --jq '.[] | select(.user.login == "claude[bot]" or .user.login == "github-actions[bot]") | .updated_at'
+              } | sort -r | head -1
+            )
+
+            LATEST_BOT_TS=$(date -u -d "${LATEST_BOT_ACTIVITY:-1970-01-01}" +%s 2>/dev/null || echo 0)
+            LATEST_REV_TS=$(date -u -d "$LATEST_REVIEWER_ACTIVITY" +%s 2>/dev/null || echo 0)
+
+            # Only kick off if reviewer activity is newer AND at least 3 minutes
+            # old (give Copilot/humans time to finish writing).
+            NOW=$(date -u +%s)
+            AGE=$(( NOW - LATEST_REV_TS ))
+
+            if [ "$LATEST_REV_TS" -gt "$LATEST_BOT_TS" ] && [ "$AGE" -gt 180 ]; then
+              echo "PR #$NUM has unaddressed feedback (reviewer=$LATEST_REVIEWER_ACTIVITY bot=$LATEST_BOT_ACTIVITY) — dispatching address workflow."
+              gh workflow run ai-address-feedback.yml \
+                --repo "$REPO_FULL" \
+                --field pr_number="$NUM" \
+                --field reason="watchdog: feedback unaddressed since $LATEST_REVIEWER_ACTIVITY" || true
+            else
+              echo "PR #$NUM has no new unaddressed feedback."
+            fi
+          done
+
+      - name: Bot-triggered runs gated as `action_required`
+        run: |
+          set -euo pipefail
+          # When Copilot (or any bot) triggers a workflow, GitHub may gate
+          # it behind `action_required`. The watchdog detects these and
+          # surfaces them to the owner (we cannot auto-approve via the API
+          # without a PAT, but we can at least not let them rot silently).
+          RUNS=$(gh api "repos/$REPO_FULL/actions/runs?status=action_required&per_page=20" \
+            --jq '.workflow_runs[] | {id, name, event, actor: .actor.login, created_at, html_url}')
+
+          if [ -z "$RUNS" ]; then
+            echo "No action_required runs."
+            exit 0
+          fi
+
+          echo "$RUNS" | jq -c '.' | while read -r run; do
+            ID=$(echo "$run" | jq -r '.id')
+            NAME=$(echo "$run" | jq -r '.name')
+            ACTOR=$(echo "$run" | jq -r '.actor')
+            URL=$(echo "$run" | jq -r '.html_url')
+            CREATED=$(echo "$run" | jq -r '.created_at')
+            echo "action_required: $NAME id=$ID actor=$ACTOR url=$URL created=$CREATED"
+
+            # Try to approve (will no-op if the token lacks permission).
+            gh api "repos/$REPO_FULL/actions/runs/$ID/approve" --method POST 2>/dev/null \
+              && echo "Approved run $ID" \
+              || echo "Could not auto-approve run $ID (needs a PAT or human click)."
+          done

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -2,10 +2,28 @@ name: AI Worker
 on:
   issues:
     types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to resume work on"
+        required: true
+        type: number
+      phase:
+        description: "Phase to run: plan or implement"
+        required: true
+        type: choice
+        options:
+          - plan
+          - implement
 
+# Don't cancel in-progress workers. GitHub fires a `labeled` event for each
+# label added in rapid succession (e.g. triage applying component/priority labels),
+# which previously cancelled an already-running plan/implement and left the
+# issue stuck in `ai-in-progress`. We'd rather run duplicates and let the
+# inner steps no-op than leave issues orphaned.
 concurrency:
-  group: ai-worker-${{ github.event.issue.number }}
-  cancel-in-progress: true
+  group: ai-worker-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -22,10 +40,19 @@ jobs:
   # ─────────────────────────────────────────────────────────────────
   plan:
     if: >-
-      github.event.label.name == 'ai-work' &&
-      !contains(github.event.issue.labels.*.name, 'ai-task')
+      (
+        github.event_name == 'issues' &&
+        github.event.label.name == 'ai-work' &&
+        !contains(github.event.issue.labels.*.name, 'ai-task')
+      ) ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        inputs.phase == 'plan'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
     steps:
       - uses: actions/checkout@v4
 
@@ -33,11 +60,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue edit ${{ github.event.issue.number }} \
-            --remove-label "ai-work" \
-            --add-label "ai-in-progress"
-          gh issue comment ${{ github.event.issue.number }} \
-            --body "🔍 AI Worker — planning phase started. Analyzing the issue and codebase..."
+          gh issue edit "$ISSUE_NUMBER" \
+            --remove-label "ai-work" || true
+          gh issue edit "$ISSUE_NUMBER" \
+            --add-label "ai-in-progress" || true
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "🔍 AI Worker — planning phase started. Analyzing the issue and codebase. [Workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       - name: Plan and decompose
         id: plan
@@ -48,8 +76,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--max-turns 40"
           prompt: |
-            You are the AI Planner. Your job is to deeply analyse this issue, produce a
-            comprehensive implementation plan, and break it into actionable sub-tasks.
+            You are the AI Planner. Your job is to deeply analyse issue #${{ env.ISSUE_NUMBER }},
+            produce a comprehensive implementation plan, and break it into actionable sub-tasks.
 
             ## Step 1 — Understand the request
             Read the issue title, body, and ALL comments carefully.
@@ -58,7 +86,7 @@ jobs:
             Explore the codebase to understand the current state.
 
             ## Step 2 — Write a comprehensive plan comment
-            Post a comment on issue #${{ github.event.issue.number }} with this structure:
+            Post a comment on issue #${{ env.ISSUE_NUMBER }} with this structure:
 
             ---
             ## 🗺️ Implementation Plan
@@ -102,7 +130,7 @@ jobs:
               --title "PARENT_TITLE — Task N: TASK_TITLE" \
               --body "$(cat <<'BODY'
             ## Parent issue
-            Closes #${{ github.event.issue.number }}
+            Closes #${{ env.ISSUE_NUMBER }}
 
             ## Task
             TASK_DESCRIPTION
@@ -114,7 +142,7 @@ jobs:
             - list of checks
 
             ## Context
-            See parent issue #${{ github.event.issue.number }} for full plan.
+            See parent issue #${{ env.ISSUE_NUMBER }} for full plan.
             BODY
             )" | grep -o '[0-9]*$')
 
@@ -136,30 +164,74 @@ jobs:
             - Add label "ai-planned"
             - Post a final comment listing all created sub-issues
 
+            ## Step 5 — If you cannot complete the plan
+            If the issue is too vague, missing critical info, or blocked by something you cannot
+            resolve: DO NOT silently stop. Instead:
+            1. Post a comment tagging @alvarolobato explaining precisely what is blocking you
+               and what information you need.
+            2. Remove `ai-in-progress` and add `ai-blocked`.
+            3. Exit normally (so the workflow does not mark itself "failed").
+
             ## Rules
             - Create sub-issues in dependency order
             - Each sub-issue must have both "ai-task" AND "ai-work" labels so the
               implementation phase triggers automatically
             - Do NOT start implementing — only plan and decompose
 
-      - name: Handle plan success
-        if: success()
+      - name: Verify plan output
+        id: verify_plan
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue edit ${{ github.event.issue.number }} \
-            --remove-label "ai-in-progress"
+          set -euo pipefail
+          # A successful plan should either: (a) have created sub-issues and
+          # added `ai-planned`, (b) added `ai-blocked` (planner gave up cleanly).
+          LABELS=$(gh issue view "$ISSUE_NUMBER" --json labels --jq '[.labels[].name] | join(",")')
+          echo "Labels after plan: $LABELS"
+          if echo ",$LABELS," | grep -q ",ai-planned,"; then
+            echo "status=planned" >> "$GITHUB_OUTPUT"
+          elif echo ",$LABELS," | grep -q ",ai-blocked,"; then
+            echo "status=blocked" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=incomplete" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Flag incomplete plan
+        if: always() && steps.verify_plan.outputs.status == 'incomplete'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" \
+            --remove-label "ai-in-progress" || true
+          gh issue edit "$ISSUE_NUMBER" \
+            --add-label "ai-blocked" || true
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "⚠️ @alvarolobato — AI Planner finished but did not produce a plan (neither \`ai-planned\` nor \`ai-blocked\` was set, and no sub-issues were created). Marking as \`ai-blocked\`. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Please check the run log and either re-trigger with the \`ai-work\` label or clarify the issue."
 
       - name: Handle plan failure
         if: failure()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue edit ${{ github.event.issue.number }} \
-            --remove-label "ai-in-progress" \
-            --add-label "ai-blocked"
-          gh issue comment ${{ github.event.issue.number }} \
-            --body "❌ AI Planner failed. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          gh issue edit "$ISSUE_NUMBER" \
+            --remove-label "ai-in-progress" || true
+          gh issue edit "$ISSUE_NUMBER" \
+            --add-label "ai-blocked" || true
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "❌ @alvarolobato — AI Planner failed. Marking as \`ai-blocked\`. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+
+      - name: Ensure ai-in-progress is cleared on cancel
+        if: cancelled()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" \
+            --remove-label "ai-in-progress" || true
+          gh issue edit "$ISSUE_NUMBER" \
+            --add-label "ai-blocked" || true
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "⚠️ @alvarolobato — AI Planner was cancelled. Marking as \`ai-blocked\`. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
 
   # ─────────────────────────────────────────────────────────────────
   # PHASE 2 — IMPLEMENT
@@ -168,10 +240,19 @@ jobs:
   # ─────────────────────────────────────────────────────────────────
   implement:
     if: >-
-      github.event.label.name == 'ai-work' &&
-      contains(github.event.issue.labels.*.name, 'ai-task')
+      (
+        github.event_name == 'issues' &&
+        github.event.label.name == 'ai-work' &&
+        contains(github.event.issue.labels.*.name, 'ai-task')
+      ) ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        inputs.phase == 'implement'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
     steps:
       - uses: actions/checkout@v4
 
@@ -179,11 +260,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue edit ${{ github.event.issue.number }} \
-            --remove-label "ai-work" \
-            --add-label "ai-in-progress"
-          gh issue comment ${{ github.event.issue.number }} \
-            --body "🤖 AI Worker — implementation started."
+          gh issue edit "$ISSUE_NUMBER" \
+            --remove-label "ai-work" || true
+          gh issue edit "$ISSUE_NUMBER" \
+            --add-label "ai-in-progress" || true
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "🤖 AI Worker — implementation started. [Workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       - name: Implement sub-task
         id: implement
@@ -195,30 +277,43 @@ jobs:
           claude_args: "--max-turns 200"
           allowed_bots: "claude[bot]"
           prompt: |
-            You are the AI Worker. Implement exactly what this sub-task describes — nothing more.
+            You are the AI Worker. Implement exactly what sub-task issue #${{ env.ISSUE_NUMBER }} describes — nothing more.
 
             ## Process
-            1. Read this sub-task issue: title, body, acceptance criteria
+            1. Read sub-task issue #${{ env.ISSUE_NUMBER }}: title, body, acceptance criteria
             2. Read the PARENT issue (linked in the body) for full context and architecture decisions
             3. Read CLAUDE.md and AGENTS.md
             4. Read relevant skill docs in docs/skills/ for the affected domain
-            5. Create branch: `ai/issue-${{ github.event.issue.number }}-{short-slug}`
-            6. Implement the changes:
+            5. Before starting, check whether another PR has already implemented part or all of this
+               task (the planner sometimes bundles work): `gh pr list --state all --search "issue-${{ env.ISSUE_NUMBER }}"`.
+               If the work is already done in a merged or open PR, post a comment on the issue
+               explaining which PR covers it, close the issue with `--reason completed`, and exit.
+            6. Create branch: `ai/issue-${{ env.ISSUE_NUMBER }}-{short-slug}`
+            7. Implement the changes:
                - Follow existing code style and patterns
                - Don't add unnecessary abstractions
                - Don't over-engineer — do exactly what's asked
                - Include tests for new functionality
-            7. Run validation:
+            8. Run validation:
                - ETL changes: `cd etl && python -m ruff check . && python -m pytest`
                - Dashboard changes: `cd dashboard && npm test`
                - Fix any failures before committing
-            8. Commit: `feat|fix|docs: description (closes #${{ github.event.issue.number }})`
-            9. Push the branch
-            10. Create a PR:
+            9. Commit: `feat|fix|docs: description (closes #${{ env.ISSUE_NUMBER }})`
+            10. Push the branch with `git push -u origin BRANCH`
+            11. Create a PR:
                 - Title references this sub-task
                 - Body: ## Summary, ## Changes, ## Test Results
-                - Include `Closes #${{ github.event.issue.number }}` in the body
-                - No reviewers needed (AI PR Review handles it)
+                - Include `Closes #${{ env.ISSUE_NUMBER }}` in the body
+                - Verify the PR was created by running `gh pr view` on the branch.
+
+            ## If you cannot finish
+            NEVER silently stop. If something is blocking you:
+            1. Push whatever partial progress you have to the branch.
+            2. Post a comment on issue #${{ env.ISSUE_NUMBER }} tagging @alvarolobato with
+               a precise description of what is blocking you (unclear spec, missing access,
+               failing test you cannot diagnose, etc.).
+            3. Exit normally — the workflow will verify a PR was created and mark the
+               issue `ai-blocked` automatically if not.
 
             ## Rules
             - Read-only SQL: NEVER INSERT/UPDATE/DELETE/DROP in production queries
@@ -227,16 +322,59 @@ jobs:
             - 4D PKs are NUMERIC, never FLOAT8
             - For wide tables, specify columns explicitly
             - Scope strictly to this sub-task — do not implement other tasks
+            - NEVER use --no-verify or bypass pre-commit hooks
+            - NEVER force-push
 
-      - name: Handle success
-        if: success()
+      # Verify a PR was actually created for this issue. The `Handle success`
+      # step used to fire on step completion alone — but Claude can exit
+      # successfully without having created a branch or PR (e.g. if it
+      # decided work was already covered but didn't close the issue).
+      - name: Verify PR was created
+        id: verify
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue edit ${{ github.event.issue.number }} \
-            --remove-label "ai-in-progress"
-          gh issue comment ${{ github.event.issue.number }} \
-            --body "✅ AI Worker completed. PR created — check the linked pull request."
+          set -euo pipefail
+          # Look for a PR whose head branch follows ai/issue-<N>-... OR whose
+          # body contains "Closes #<N>".
+          PR_BY_BRANCH=$(gh pr list --state all --search "head:ai/issue-${ISSUE_NUMBER}-" \
+            --json number,state --jq '.[0].number // empty')
+          PR_BY_BODY=$(gh pr list --state all --search "Closes #${ISSUE_NUMBER} in:body" \
+            --json number,state --jq '.[0].number // empty')
+          PR_NUMBER="${PR_BY_BRANCH:-$PR_BY_BODY}"
+
+          # Also check if the issue was closed by the worker (deliberate no-op).
+          ISSUE_STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state')
+
+          if [ -n "$PR_NUMBER" ]; then
+            echo "outcome=pr_created" >> "$GITHUB_OUTPUT"
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "Found PR #$PR_NUMBER for issue #$ISSUE_NUMBER"
+          elif [ "$ISSUE_STATE" = "CLOSED" ]; then
+            echo "outcome=issue_closed" >> "$GITHUB_OUTPUT"
+            echo "Issue #$ISSUE_NUMBER was closed by the worker (deliberate no-op)."
+          else
+            echo "outcome=no_pr" >> "$GITHUB_OUTPUT"
+            echo "No PR and issue still open — implementation did not complete."
+          fi
+
+      - name: Handle success (PR created)
+        if: always() && steps.verify.outputs.outcome == 'pr_created'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" \
+            --remove-label "ai-in-progress" || true
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "✅ AI Worker completed. See PR #${{ steps.verify.outputs.pr_number }}."
+
+      - name: Handle success (issue closed deliberately)
+        if: always() && steps.verify.outputs.outcome == 'issue_closed'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Nothing to do — issue already closed."
 
       - name: Push partial work on failure
         if: failure()
@@ -255,6 +393,18 @@ jobs:
             fi
           fi
 
+      - name: Block on missing PR
+        if: always() && steps.verify.outputs.outcome == 'no_pr'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" \
+            --remove-label "ai-in-progress" || true
+          gh issue edit "$ISSUE_NUMBER" \
+            --add-label "ai-blocked" || true
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "⚠️ @alvarolobato — AI Worker finished but did NOT create a PR. Marking as \`ai-blocked\`. This usually means the agent either hit its turn limit, got confused about whether the work was already done, or failed to push the branch. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Re-label with \`ai-work\` (after removing \`ai-blocked\`) to retry, or clarify the issue."
+
       - name: Handle failure
         if: failure()
         env:
@@ -265,8 +415,21 @@ jobs:
           if [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ] && [ -n "$BRANCH" ]; then
             BRANCH_NOTE=" Partial work pushed to branch \`${BRANCH}\`."
           fi
-          gh issue edit ${{ github.event.issue.number }} \
-            --remove-label "ai-in-progress" \
-            --add-label "ai-blocked"
-          gh issue comment ${{ github.event.issue.number }} \
-            --body "❌ AI Worker failed.${BRANCH_NOTE} Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          gh issue edit "$ISSUE_NUMBER" \
+            --remove-label "ai-in-progress" || true
+          gh issue edit "$ISSUE_NUMBER" \
+            --add-label "ai-blocked" || true
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "❌ @alvarolobato — AI Worker failed.${BRANCH_NOTE} Marking as \`ai-blocked\`. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+
+      - name: Ensure ai-in-progress is cleared on cancel
+        if: cancelled()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" \
+            --remove-label "ai-in-progress" || true
+          gh issue edit "$ISSUE_NUMBER" \
+            --add-label "ai-blocked" || true
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "⚠️ @alvarolobato — AI Worker was cancelled. Marking as \`ai-blocked\`. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."


### PR DESCRIPTION
## Summary

Four root causes made the AI factory stop silently — fixed, with a watchdog safety net so this class of failure can't recur.

### Root causes found

1. **`ai-pr-review.yml` was fully broken** — passed `prompt_file` which is not a valid input for `anthropics/claude-code-action@v1`. Every PR review failed with *"Invalid OIDC token"*. Confirmed on [run #24483823359](https://github.com/alvarolobato/powershop-analytics/actions/runs/24483823359) for PR #164 (and same on #162, #163).
2. **`ai-address-feedback.yml` never triggered on Copilot** — `if` required `state == 'changes_requested'`, but Copilot always submits as `COMMENTED` (even with inline change suggestions). 23 total unaddressed Copilot comments across the three ETL monitoring PRs.
3. **GitHub gates bot-triggered workflows** — even with the condition fixed, Copilot's `pull_request_review` lands in `action_required` ([run #24494629697](https://github.com/alvarolobato/powershop-analytics/actions/runs/24494629697)). Not resolvable from workflow YAML alone — needs a dispatcher.
4. **`ai-worker.yml` lied about success** — `Handle success` fired on step completion, not actual PR creation. Issues #154/#157/#159 got "✅ AI Worker completed. PR created" but no branch or PR exists. Combined with `cancel-in-progress: true`, a label race (triage adding multiple labels in quick succession) cancelled the worker mid-plan and left #160/#161 stuck in `ai-in-progress` forever.

### Changes

| File | Change |
|------|--------|
| `.github/workflows/ai-pr-review.yml` | Load guidelines file in a prior step, pass contents via valid `prompt` input. Ping `@alvarolobato` on failure. |
| `.github/workflows/ai-address-feedback.yml` | Handle `COMMENTED` reviews carrying inline comments. Skip self-reviews (`claude[bot]`/`github-actions[bot]`). Add `workflow_dispatch` so the watchdog can trigger it. Ping owner + add `ai-blocked` on failure. Ignore PRs labelled `no-address-feedback` or from forks. |
| `.github/workflows/ai-worker.yml` | Removed `cancel-in-progress`. Added `Verify PR was created` step that checks for `head:ai/issue-N-*` or `Closes #N` in body. Added `if: cancelled()` cleanup. Added `workflow_dispatch`. Every failure path now pings `@alvarolobato` and sets `ai-blocked`. |
| `.github/workflows/ai-watchdog.yml` *(new)* | Scheduled every 15 min. Recovers from silent failures: stuck `ai-in-progress` > 1h → `ai-blocked` + ping. Orphan `ai-task` without PR → `ai-blocked` + ping. PRs with unaddressed reviewer activity → dispatch `ai-address-feedback` (bypasses bot-gating). Tries to approve `action_required` runs. |

### How this prevents the failure mode

**The factory should never stop silently.** New guarantees:

- If the worker finishes without producing a PR → `ai-blocked` + ping (not a fake "success" comment).
- If a workflow is cancelled (label race, manual cancel) → `ai-blocked` + ping, never "in progress" forever.
- If Copilot leaves review comments → either the event-driven workflow fires immediately, or the 15-min watchdog catches it.
- If GitHub gates a bot-triggered run as `action_required` → the watchdog tries to approve and dispatches the equivalent `workflow_dispatch` so the work happens regardless.

### Existing stuck state (already cleaned up manually)

- Issues #154, #157, #159 (worker reported success without PR) → marked `ai-blocked` with explanatory comments.
- Issues #160, #161 (stuck in `ai-in-progress` from cancelled worker) → cleared, marked `ai-blocked`.
- PRs #162, #163, #164 (unaddressed Copilot feedback) → comments posted explaining the state. After this PR merges the watchdog will pick them up within 15 min and dispatch address-feedback.

## Test plan

- [x] All four workflow YAML files parse successfully (`yaml.safe_load`).
- [x] Verified trigger conditions match the observed Copilot review events (state `COMMENTED`, user `copilot-pull-request-reviewer[bot]`, submission with inline comments).
- [x] Verified the `verify PR was created` step correctly distinguishes the three outcomes (pr_created / issue_closed / no_pr).
- [ ] After merge: watchdog scheduled run completes successfully and dispatches address-feedback for PRs #162/#163/#164.
- [ ] After merge: address-feedback run on #164 addresses the 2 Copilot threads (bigint cast + watermark_to).
- [ ] After merge: address-feedback run on #162 addresses the 11 Copilot threads (accents, parseInt, reverse mutation).
- [ ] After merge: address-feedback run on #163 addresses the in-scope Copilot threads (encodeURIComponent, notFound reset, aria-expanded, unused import, KPI fix) — the broken `/etl` back link stays blocked on #157 landing.