### PR TITLE
fix(ci): AI factory — phased reviews, Opus cap, global queue

### DIFF
--- a/.github/ai-factory/config.yml
+++ b/.github/ai-factory/config.yml
@@ -43,6 +43,17 @@ labels:
     - "comp-infra"
     - "comp-docs"
 
+  # AI Factory — phased PR review (see ai-worker / ai-pr-review / ai-address-feedback)
+  review_phases:
+    - "ai-phase-copilot"   # Awaiting / in Copilot rounds (before Opus)
+    - "ai-cp-after-1"      # Addressed feedback after Copilot round 1
+    - "ai-cp-after-2"      # Addressed feedback after Copilot round 2
+    - "ai-phase-opus"      # In Opus review passes (max 2)
+    - "ai-o-after-1"       # Addressed after Opus pass 1
+    - "ai-o-after-2"       # Addressed after Opus pass 2 (terminal for AI review)
+    - "ai-legacy-opus-1"   # Legacy PRs: first Opus pass recorded
+    - "ai-legacy-opus-2"   # Legacy PRs: second Opus pass — further Opus runs skipped
+
   # PR size
   sizes:
     - "size-xs"     # <10 lines

--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -33,7 +33,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  actions: read
+  actions: write
   checks: read
   id-token: write
 
@@ -139,6 +139,7 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@v4
         with:
@@ -168,7 +169,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 200"
+          claude_args: "--max-turns 80"
           allowed_bots: "claude[bot],copilot-pull-request-reviewer[bot],github-actions[bot]"
           prompt: |
             You are addressing review feedback on PR #${{ needs.resolve.outputs.pr_number }}.
@@ -232,7 +233,8 @@ jobs:
             - If CI was failing, your commit must fix it. Run the same commands CI runs.
 
             ## Completion
-            - After replying to all threads and committing fixes, re-request Copilot review:
+            - If the PR has labels `ai-phase-copilot` or `ai-phase-opus`, do **NOT** call `requested_reviewers` — the workflow decides the next review step after you push.
+            - Otherwise (legacy PRs), after replying to all threads and committing fixes, re-request Copilot review:
               ```bash
               gh api repos/${{ github.repository }}/pulls/${{ needs.resolve.outputs.pr_number }}/requested_reviewers \
                 --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
@@ -249,54 +251,77 @@ jobs:
             - Read-only SQL policy still applies (no INSERT/UPDATE/DELETE in production queries).
             - Stay within this PR's scope — do not pull in unrelated work.
 
-      - name: Check if changes were pushed
-        id: check_changes
+      - name: Route next automated review (or converge)
+        id: route
         if: success()
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ needs.resolve.outputs.pr_number }}
         run: |
-          # Compare current remote HEAD with the SHA we captured at checkout.
-          # If unchanged, address-feedback had nothing to fix — dispatching
-          # another pr-review would loop forever (pr-review → address-feedback
-          # → pr-review with no changes). Terminate the cycle instead.
-          CURRENT_SHA=$(gh api "repos/${{ github.repository }}/pulls/${{ needs.resolve.outputs.pr_number }}" --jq '.head.sha')
+          set -euo pipefail
+          CURRENT_SHA=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')
           INITIAL_SHA="${{ steps.initial_head.outputs.sha }}"
+          LABELS=$(gh api "repos/$REPO/pulls/$PR" --jq '[.labels[].name] | join(",")')
+
+          converge_comment() {
+            gh pr edit "$PR" --repo "$REPO" --remove-label "ai-ready-for-review" || true
+            gh pr comment "$PR" \
+              --body "✅ Review cycle converged — no new changes required. PR is ready for human merge decision." || true
+          }
+
           if [ "$CURRENT_SHA" = "$INITIAL_SHA" ]; then
-            echo "No commits pushed — cycle is converged. Skipping re-review dispatch."
+            echo "No commits pushed — nothing to re-review."
             echo "pushed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Commits pushed ($INITIAL_SHA → $CURRENT_SHA) — will re-dispatch review."
-            echo "pushed=true" >> "$GITHUB_OUTPUT"
+            converge_comment
+            exit 0
           fi
 
-      - name: Signal ready for re-review
-        if: success() && steps.check_changes.outputs.pushed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Explicitly dispatch ai-pr-review via workflow_dispatch.
-          # We cannot rely on a label event here: GitHub does not fire webhook
-          # events from GITHUB_TOKEN actions, so a labeled trigger would never
-          # cascade into a new workflow run from automation.
-          # workflow_dispatch via the API IS allowed even from GITHUB_TOKEN.
-          gh pr edit "${{ needs.resolve.outputs.pr_number }}" --repo "${{ github.repository }}" \
-            --add-label "ai-ready-for-review" || true
-          gh workflow run ai-pr-review.yml \
-            --repo "${{ github.repository }}" \
-            --field pr_number="${{ needs.resolve.outputs.pr_number }}" || true
-          echo "Dispatched review for PR #${{ needs.resolve.outputs.pr_number }}."
+          echo "Commits pushed ($INITIAL_SHA → $CURRENT_SHA)."
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Mark review cycle converged
-        if: success() && steps.check_changes.outputs.pushed == 'false'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Make sure ai-ready-for-review is removed so the watchdog's
-          # "Stalled ai-ready-for-review" step doesn't re-dispatch pr-review.
-          gh pr edit "${{ needs.resolve.outputs.pr_number }}" --repo "${{ github.repository }}" \
-            --remove-label "ai-ready-for-review" || true
-          gh pr comment "${{ needs.resolve.outputs.pr_number }}" \
-            --body "✅ Review cycle converged — no new changes required. PR is ready for human merge decision." || true
+          # Phased: 2× Copilot (cheap) then 2× Opus — see ai-worker.yml / ai-pr-review.yml
+          if echo ",$LABELS," | grep -q ",ai-phase-copilot,"; then
+            if ! echo ",$LABELS," | grep -q ",ai-cp-after-1,"; then
+              gh pr edit "$PR" --repo "$REPO" --add-label "ai-cp-after-1" || true
+              gh api "repos/$REPO/pulls/$PR/requested_reviewers" --method POST \
+                -f 'reviewers[]=copilot-pull-request-reviewer[bot]' || true
+              gh pr comment "$PR" --body "🤖 **AI Factory**: Copilot round **1**/2 addressed — requested **round 2** Copilot review." || true
+              exit 0
+            fi
+            if ! echo ",$LABELS," | grep -q ",ai-cp-after-2,"; then
+              gh pr edit "$PR" --repo "$REPO" \
+                --add-label "ai-cp-after-2" \
+                --remove-label "ai-phase-copilot" \
+                --add-label "ai-phase-opus" \
+                --add-label "ai-ready-for-review" || true
+              gh workflow run ai-pr-review.yml --repo "$REPO" --field pr_number="$PR" || true
+              gh pr comment "$PR" --body "🤖 **AI Factory**: Copilot rounds **complete** — starting **Opus** review (pass 1 of 2)." || true
+              exit 0
+            fi
+          fi
+
+          if echo ",$LABELS," | grep -q ",ai-phase-opus,"; then
+            if ! echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
+              gh pr edit "$PR" --repo "$REPO" --add-label "ai-o-after-1" --add-label "ai-ready-for-review" || true
+              gh workflow run ai-pr-review.yml --repo "$REPO" --field pr_number="$PR" || true
+              gh pr comment "$PR" --body "🤖 **AI Factory**: Opus pass **1**/2 addressed — running **Opus** pass 2." || true
+              exit 0
+            fi
+            if ! echo ",$LABELS," | grep -q ",ai-o-after-2,"; then
+              gh pr edit "$PR" --repo "$REPO" \
+                --add-label "ai-o-after-2" \
+                --remove-label "ai-phase-opus" \
+                --remove-label "ai-ready-for-review" || true
+              gh pr comment "$PR" --body "✅ **AI Factory**: Automated **Opus** passes complete (**2**/2). PR is ready for human merge decision." || true
+              exit 0
+            fi
+          fi
+
+          # Legacy PRs (no phased labels): same as before — re-dispatch Opus review (capped via ai-legacy-opus-* in ai-pr-review).
+          gh pr edit "$PR" --repo "$REPO" --add-label "ai-ready-for-review" || true
+          gh workflow run ai-pr-review.yml --repo "$REPO" --field pr_number="$PR" || true
+          echo "Dispatched legacy Opus PR review for PR #$PR."
 
       - name: Handle failure
         if: failure()

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -13,14 +13,16 @@ on:
         required: true
         type: number
 
+# One Opus PR review at a time across the repo — avoids Anthropic rate limits when many PRs move together.
 concurrency:
-  group: ai-pr-review-${{ github.event.pull_request.number || inputs.pr_number }}
-  cancel-in-progress: true
+  group: ai-pr-review-global
+  cancel-in-progress: false
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
+  actions: write
   id-token: write
 
 jobs:
@@ -38,6 +40,7 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
     steps:
@@ -49,7 +52,7 @@ jobs:
           gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
             --remove-label "ai-ready-for-review" || true
 
-      - name: Resolve PR ref
+      - name: Resolve PR ref and title
         id: resolve
         env:
           GH_TOKEN: ${{ github.token }}
@@ -61,6 +64,10 @@ jobs:
             SHA=$(gh api repos/$REPO/pulls/$PR_NUMBER --jq '.head.sha')
             echo "ref=$SHA" >> "$GITHUB_OUTPUT"
           fi
+          TITLE=$(gh api repos/$REPO/pulls/$PR_NUMBER --jq -r '.title')
+          echo "title<<TITLE_EOF" >> "$GITHUB_OUTPUT"
+          echo "$TITLE" >> "$GITHUB_OUTPUT"
+          echo "TITLE_EOF" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
         with:
@@ -77,21 +84,37 @@ jobs:
             echo 'PR_REVIEW_EOF'
           } >> "$GITHUB_OUTPUT"
 
+      - name: Check Opus review cap (legacy PRs)
+        id: cap
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LABELS=$(gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}" --jq '[.labels[].name] | join(",")')
+          SKIP=false
+          if echo ",$LABELS," | grep -q ",ai-legacy-opus-2,"; then
+            SKIP=true
+          fi
+          echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
+
       - name: Claude PR Review
+        if: steps.cap.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-opus-4-6"
+          claude_args: "--model claude-opus-4-6 --max-turns 35"
           allowed_bots: "claude[bot],github-actions[bot],copilot-pull-request-reviewer[bot]"
           use_sticky_comment: "true"
           include_fix_links: "true"
           classify_inline_comments: "true"
           prompt: |
-            You are reviewing PR #${{ env.PR_NUMBER }}: "${{ github.event.pull_request.title }}".
+            You are reviewing PR #${{ env.PR_NUMBER }}: "${{ steps.resolve.outputs.title }}".
 
             Follow the review guidelines below. Post a review with inline comments on the PR.
 
-            After reviewing, also request a Copilot review using:
+            ## Copilot follow-up (read carefully)
+            Run `gh pr view ${{ env.PR_NUMBER }} --json labels -q '.labels[].name'` before you finish.
+            - If the PR has label `ai-phase-opus`, do **NOT** request a Copilot review (Opus-only passes; address-feedback is dispatched by CI).
+            - Otherwise, after reviewing, request a Copilot review:
             ```bash
             gh api repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/requested_reviewers \
               --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
@@ -101,8 +124,32 @@ jobs:
 
             ${{ steps.guidelines.outputs.CONTENT }}
 
+      - name: Max automated Opus reviews reached (legacy)
+        if: success() && steps.cap.outputs.skip == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ env.PR_NUMBER }}" \
+            --body "✅ **AI Factory**: This PR has reached the maximum number of automated Opus review passes (**2**). No further Opus runs will be dispatched. Merge or continue manually."
+
+      - name: Record legacy Opus pass
+        if: success() && steps.cap.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LABELS=$(gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}" --jq '[.labels[].name] | join(",")')
+          if echo ",$LABELS," | grep -q ",ai-phase-copilot," || echo ",$LABELS," | grep -q ",ai-phase-opus,"; then
+            echo "Phased PR — skip legacy Opus counters."
+            exit 0
+          fi
+          if ! echo ",$LABELS," | grep -q ",ai-legacy-opus-1,"; then
+            gh pr edit "${{ env.PR_NUMBER }}" --add-label "ai-legacy-opus-1" || true
+          elif ! echo ",$LABELS," | grep -q ",ai-legacy-opus-2,"; then
+            gh pr edit "${{ env.PR_NUMBER }}" --add-label "ai-legacy-opus-2" || true
+          fi
+
       - name: Dispatch address-feedback
-        if: success()
+        if: success() && steps.cap.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -44,8 +44,9 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
     steps:
-      - name: Remove ai-ready-for-review label
-        if: github.event.action == 'labeled' && github.event.label.name == 'ai-ready-for-review'
+      # Most runs are workflow_dispatch; the label would otherwise linger and the
+      # watchdog would keep re-dispatching this workflow.
+      - name: Clear ai-ready-for-review (best-effort)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -64,7 +65,7 @@ jobs:
             SHA=$(gh api repos/$REPO/pulls/$PR_NUMBER --jq '.head.sha')
             echo "ref=$SHA" >> "$GITHUB_OUTPUT"
           fi
-          TITLE=$(gh api repos/$REPO/pulls/$PR_NUMBER --jq -r '.title')
+          TITLE=$(gh api repos/$REPO/pulls/$PR_NUMBER --jq '.title')
           echo "title<<TITLE_EOF" >> "$GITHUB_OUTPUT"
           echo "$TITLE" >> "$GITHUB_OUTPUT"
           echo "TITLE_EOF" >> "$GITHUB_OUTPUT"
@@ -129,6 +130,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          gh pr edit "${{ env.PR_NUMBER }}" --repo "${{ github.repository }}" \
+            --remove-label "ai-ready-for-review" \
+            --remove-label "ai-auto-retry" || true
           gh pr comment "${{ env.PR_NUMBER }}" \
             --body "✅ **AI Factory**: This PR has reached the maximum number of automated Opus review passes (**2**). No further Opus runs will be dispatched. Merge or continue manually."
 

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -29,7 +29,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  actions: write
   id-token: write
 
 jobs:

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -29,6 +29,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  actions: write
   id-token: write
 
 jobs:
@@ -274,7 +275,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 200"
+          claude_args: "--max-turns 120"
           allowed_bots: "claude[bot],github-actions[bot]"
           prompt: |
             You are the AI Worker. Implement exactly what sub-task issue #${{ env.ISSUE_NUMBER }} describes — nothing more.
@@ -368,14 +369,15 @@ jobs:
             --remove-label "ai-in-progress" || true
           gh issue comment "$ISSUE_NUMBER" \
             --body "✅ AI Worker completed. See PR #${{ steps.verify.outputs.pr_number }}."
-          # Signal the PR is ready for its first review.
-          # Must use explicit workflow_dispatch — GITHUB_TOKEN label events
-          # do not cascade to new workflow runs (loop-prevention by GitHub).
+          # Automated review: two Copilot rounds first (cheaper), then up to two Opus PR reviews.
+          # Do not dispatch Opus immediately — avoids rate limits and reduces token spend.
           gh pr edit "${{ steps.verify.outputs.pr_number }}" \
-            --add-label "ai-ready-for-review" || true
-          gh workflow run ai-pr-review.yml \
-            --repo "${{ github.repository }}" \
-            --field pr_number="${{ steps.verify.outputs.pr_number }}" || true
+            --add-label "ai-phase-copilot" || true
+          gh api "repos/${{ github.repository }}/pulls/${{ steps.verify.outputs.pr_number }}/requested_reviewers" \
+            --method POST \
+            -f 'reviewers[]=copilot-pull-request-reviewer[bot]' || true
+          gh pr comment "${{ steps.verify.outputs.pr_number }}" \
+            --body "🤖 **AI Factory**: Automated review starts with **Copilot** (round 1 of 2), then Copilot round 2, then up to **two Opus** code reviews. Labels: \`ai-phase-copilot\` → \`ai-phase-opus\`." || true
 
       - name: Handle success (issue closed deliberately)
         if: always() && steps.verify.outputs.outcome == 'issue_closed'


### PR DESCRIPTION
## Summary

Implements the plan in #187: reduce Anthropic rate-limit failures, cut token spend on the review loop, and cap automated Opus passes while preserving two Copilot rounds before Opus.

## Changes

### Execution / “stuck” mitigations
- **`ai-pr-review`**: job `timeout-minutes: 45`, global concurrency `ai-pr-review-global` (serialize Opus reviews repo-wide), `--max-turns 35`, resolve PR title via API for `workflow_dispatch` (fixes empty title in prompts).
- **`ai-address-feedback`**: `timeout-minutes: 50`, `actions: write` so `gh workflow run` is permitted, `--max-turns` reduced 200 → 80.
- **`ai-worker`**: `actions: write` for workflow dispatch consistency.

### Token / cost
- **Implement** worker: `--max-turns` 200 → 120.
- **Phased review** for new PRs: **Copilot round 1 → address → Copilot round 2 → address → Opus pass 1 → address → Opus pass 2 → done** (labels `ai-phase-copilot` / `ai-phase-opus` / milestones).
- **Legacy PRs** (no phase labels): unchanged loop but **max 2 Opus** runs via `ai-legacy-opus-1` / `ai-legacy-opus-2`; third run posts a comment and skips Claude.
- Opus review prompt: if `ai-phase-opus`, do not request Copilot (instructions to check labels via `gh`).

### Config
- `.github/ai-factory/config.yml`: documents review phase labels.

## Testing
- Ruby `YAML.load_file` on modified workflows.

Closes #187
