### PR TITLE
fix(ci): ai-awaiting-owner handoff when automated review ends

### DIFF
--- a/.github/ai-factory/config.yml
+++ b/.github/ai-factory/config.yml
@@ -43,6 +43,9 @@ labels:
     - "comp-infra"
     - "comp-docs"
 
+  # Human handoff — set by workflows when automated review budget is exhausted
+  human_handoff: "ai-awaiting-owner"
+
   # AI Factory — phased PR review (see ai-worker / ai-pr-review / ai-address-feedback)
   review_phases:
     - "ai-phase-copilot"   # Awaiting / in Copilot rounds (before Opus)
@@ -53,6 +56,7 @@ labels:
     - "ai-o-after-2"       # Addressed after Opus pass 2 (terminal for AI review)
     - "ai-legacy-opus-1"   # Legacy PRs: first Opus pass recorded
     - "ai-legacy-opus-2"   # Legacy PRs: second Opus pass — further Opus runs skipped
+    - "ai-awaiting-owner"  # Automation done — human should review and merge (see docs/ai-factory.md)
 
   # PR size
   sizes:

--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -311,14 +311,25 @@ jobs:
             if ! echo ",$LABELS," | grep -q ",ai-o-after-2,"; then
               gh pr edit "$PR" --repo "$REPO" \
                 --add-label "ai-o-after-2" \
+                --add-label "ai-awaiting-owner" \
                 --remove-label "ai-phase-opus" \
                 --remove-label "ai-ready-for-review" || true
-              gh pr comment "$PR" --body "✅ **AI Factory**: Automated **Opus** passes complete (**2**/2). PR is ready for human merge decision." || true
+              gh pr comment "$PR" --body "✅ **AI Factory**: Automated **Opus** passes complete (**2**/2). This PR is **ready for your review and merge**." || true
               exit 0
             fi
           fi
 
-          # Legacy PRs (no phased labels): same as before — re-dispatch Opus review (capped via ai-legacy-opus-* in ai-pr-review).
+          # Legacy PRs: after 2 successful Opus passes (labels set by ai-pr-review), do not schedule more AI review.
+          if echo ",$LABELS," | grep -q ",ai-legacy-opus-2,"; then
+            gh pr edit "$PR" --repo "$REPO" \
+              --remove-label "ai-ready-for-review" \
+              --add-label "ai-awaiting-owner" || true
+            gh pr comment "$PR" \
+              --body "✅ **AI Factory**: Both automated Opus passes are done. This PR is **ready for your review and merge** — no further automated reviews will be scheduled." || true
+            exit 0
+          fi
+
+          # Legacy PRs (no phased labels): re-dispatch Opus review (capped in ai-pr-review via ai-legacy-opus-*).
           gh pr edit "$PR" --repo "$REPO" --add-label "ai-ready-for-review" || true
           gh workflow run ai-pr-review.yml --repo "$REPO" --field pr_number="$PR" || true
           echo "Dispatched legacy Opus PR review for PR #$PR."

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -132,9 +132,10 @@ jobs:
         run: |
           gh pr edit "${{ env.PR_NUMBER }}" --repo "${{ github.repository }}" \
             --remove-label "ai-ready-for-review" \
-            --remove-label "ai-auto-retry" || true
+            --remove-label "ai-auto-retry" \
+            --add-label "ai-awaiting-owner" || true
           gh pr comment "${{ env.PR_NUMBER }}" \
-            --body "✅ **AI Factory**: This PR has reached the maximum number of automated Opus review passes (**2**). No further Opus runs will be dispatched. Merge or continue manually."
+            --body "✅ **AI Factory**: This PR has reached the maximum number of automated Opus review passes (**2**). No further Opus runs will be dispatched. **Ready for your review and merge.**"
 
       - name: Record legacy Opus pass
         if: success() && steps.cap.outputs.skip != 'true'

--- a/docs/ai-factory.md
+++ b/docs/ai-factory.md
@@ -65,8 +65,16 @@ When a new issue is opened, the **Issue Triage** workflow runs automatically —
 | `ai-planned` | The `/plan` command has posted an implementation plan (auto-set). |
 | `no-ai` | Human-only. Factory will not touch this issue. |
 | `no-pr-review` | Skip the AI PR review on this PR. |
+| `ai-ready-for-review` | **Automation queue only** — another AI PR review (Opus/Copilot pipeline) is scheduled or pending. This does **not** mean “ready for you”; it often means the bot is still working. |
+| `ai-awaiting-owner` | **Your cue** — automated review rounds are finished (or capped). The PR is **ready for your review and merge** (subject to CI being green). |
 | `auto-merge` | Merge automatically when CI passes and review approves *(reserved for future use)*. |
 | `p0-critical` → `p3-low` | Priority — the factory processes higher priorities first. |
+
+**When is a PR ready for you to review and merge?**
+
+1. Look for **`ai-awaiting-owner`** on the PR — the factory applies this when automated Opus passes are complete (or the legacy cap of two Opus runs is hit). That is the clearest signal.
+2. Do **not** treat **`ai-ready-for-review`** as “ready for human” — it means the automation pipeline may still run another AI review.
+3. Always confirm **CI is green** (and resolve any `ai-blocked` / failing checks) before merging.
 
 ### c) Use slash commands in comments
 


### PR DESCRIPTION
## Problem
`ai-ready-for-review` was misleading: legacy address-feedback always re-queued Opus and never stopped after two passes unless the cap path ran. Humans had no clear label for "your turn".

## Changes
- Stop legacy loop when `ai-legacy-opus-2` is present; apply `ai-awaiting-owner` and remove `ai-ready-for-review`.
- Phased flow: add `ai-awaiting-owner` when both Opus passes complete.
- Opus cap skip path: add `ai-awaiting-owner`.
- Document `ai-ready-for-review` vs `ai-awaiting-owner` in `docs/ai-factory.md`.

Label `ai-awaiting-owner` is created on the repo.

Made with [Cursor](https://cursor.com)