### PR TITLE
fix(ci): address-feedback honors no-pr-review (no Opus re-dispatch)

### DIFF
--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -273,7 +273,15 @@ jobs:
           if [ "$CURRENT_SHA" = "$INITIAL_SHA" ]; then
             echo "No commits pushed — nothing to re-review."
             echo "pushed=false" >> "$GITHUB_OUTPUT"
-            converge_comment
+            if echo ",$LABELS," | grep -q ",no-pr-review,"; then
+              gh pr edit "$PR" --repo "$REPO" \
+                --remove-label "ai-ready-for-review" \
+                --add-label "ai-awaiting-owner" || true
+              gh pr comment "$PR" \
+                --body "✅ **AI Factory**: \`no-pr-review\` — no new commits were needed. **Ready for your review and merge** when CI is green." || true
+            else
+              converge_comment
+            fi
             exit 0
           fi
 
@@ -326,6 +334,16 @@ jobs:
               --add-label "ai-awaiting-owner" || true
             gh pr comment "$PR" \
               --body "✅ **AI Factory**: Both automated Opus passes are done. This PR is **ready for your review and merge** — no further automated reviews will be scheduled." || true
+            exit 0
+          fi
+
+          # Owner opted out of further AI PR reviews — address-feedback may still run to fix threads, but never re-dispatch Opus.
+          if echo ",$LABELS," | grep -q ",no-pr-review,"; then
+            gh pr edit "$PR" --repo "$REPO" \
+              --remove-label "ai-ready-for-review" \
+              --add-label "ai-awaiting-owner" || true
+            gh pr comment "$PR" \
+              --body "✅ **AI Factory**: \`no-pr-review\` is set — no further automated Opus/Copilot PR reviews. Pending feedback was handled in this run; **ready for your review and merge** when CI is green."
             exit 0
           fi
 

--- a/docs/ai-factory.md
+++ b/docs/ai-factory.md
@@ -64,7 +64,7 @@ When a new issue is opened, the **Issue Triage** workflow runs automatically —
 | `ai-in-progress` | The worker is currently running (auto-set). |
 | `ai-planned` | The `/plan` command has posted an implementation plan (auto-set). |
 | `no-ai` | Human-only. Factory will not touch this issue. |
-| `no-pr-review` | Skip the AI PR review on this PR. |
+| `no-pr-review` | **Stop automated Opus/Copilot PR reviews** on this PR. Use when you only want **address-feedback** to clear inline comments, then **`ai-awaiting-owner`** when done. Does **not** block you from merging. |
 | `ai-ready-for-review` | **Automation queue only** — another AI PR review (Opus/Copilot pipeline) is scheduled or pending. This does **not** mean “ready for you”; it often means the bot is still working. |
 | `ai-awaiting-owner` | **Your cue** — automated review rounds are finished (or capped). The PR is **ready for your review and merge** (subject to CI being green). |
 | `auto-merge` | Merge automatically when CI passes and review approves *(reserved for future use)*. |


### PR DESCRIPTION
When `no-pr-review` is set, the route step after address-feedback no longer schedules Opus and sets `ai-awaiting-owner`. Same when address had nothing to commit.

Made with [Cursor](https://cursor.com)