### PR TITLE
fix(ci): no-pr-review gate for AI PR Review + watchdog handoff

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -26,17 +26,54 @@ permissions:
   id-token: write
 
 jobs:
+  # workflow_dispatch used to ignore no-pr-review (first OR branch was always true).
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      skip_opus: ${{ steps.check.outputs.skip_opus }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            echo "skip_opus=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PR="${{ inputs.pr_number }}"
+          LABELS=$(gh api "repos/${{ github.repository }}/pulls/$PR" --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+          if echo ",$LABELS," | grep -q ",no-pr-review,"; then
+            echo "skip_opus=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip_opus=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Clear stale queue label when skipping Opus
+        if: github.event_name == 'workflow_dispatch' && steps.check.outputs.skip_opus == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR="${{ inputs.pr_number }}"
+          gh pr comment "$PR" --repo "${{ github.repository }}" \
+            --body "⏭️ **AI PR Review skipped** (\`no-pr-review\`). Removed stale \`ai-ready-for-review\` — use **AI Address PR Feedback** for inline threads." || true
+          gh pr edit "$PR" --repo "${{ github.repository }}" --remove-label "ai-ready-for-review" || true
+
   review:
+    needs: gate
     if: >-
+      needs.gate.outputs.skip_opus != 'true' &&
       (
         github.event_name == 'workflow_dispatch'
-      ) || (
-        github.event.pull_request.draft == false &&
-        !contains(github.event.pull_request.labels.*.name, 'no-pr-review') &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
+        ||
         (
-          github.event.action != 'labeled' ||
-          github.event.label.name == 'ai-ready-for-review'
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.draft == false &&
+          !contains(github.event.pull_request.labels.*.name, 'no-pr-review') &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          (
+            github.event.action != 'labeled' ||
+            github.event.label.name == 'ai-ready-for-review'
+          )
         )
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   watchdog:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       GH_TOKEN: ${{ github.token }}
       OWNER: ${{ github.repository_owner }}
@@ -121,6 +121,13 @@ jobs:
             NUM=$(echo "$pr" | jq -r '.number')
             TITLE=$(echo "$pr" | jq -r '.title')
             LABELS=$(echo "$pr" | jq -r '[.labels[].name] | join(",")')
+
+            # Owner stopped AI PR reviews — do not burn Opus; clear stale queue label.
+            if echo ",$LABELS," | grep -q ",no-pr-review,"; then
+              echo "PR #$NUM: has no-pr-review — removing ai-ready-for-review, skipping pr-review"
+              gh pr edit "$NUM" --repo "$REPO_FULL" --remove-label "ai-ready-for-review" || true
+              continue
+            fi
 
             # Skip blocked PRs — let the auto-retry step handle them.
             if echo ",$LABELS," | grep -q ",ai-blocked,"; then
@@ -453,9 +460,10 @@ jobs:
           # re-dispatch periodically (throttled) so waiting is enough without manual clicks.
           PRS=$(gh pr list --repo "$REPO_FULL" --state open \
             --label "no-pr-review" \
-            --json number,labels --limit 50)
+            --json number,labels,updatedAt --limit 50 \
+            | jq 'sort_by(.updatedAt)')
 
-          MAX_PER_RUN=4
+          MAX_PER_RUN=8
           LEN=$(echo "$PRS" | jq 'length')
           if [ "$LEN" -eq 0 ]; then
             echo "No open PRs with label no-pr-review."

--- a/docs/ai-factory.md
+++ b/docs/ai-factory.md
@@ -78,6 +78,18 @@ When a new issue is opened, the **Issue Triage** workflow runs automatically —
 
 **Waiting without clicking:** If you add **`no-pr-review`** (no Opus/Copilot), the **watchdog** re-dispatches **AI Address PR Feedback** on a cooldown until the PR reaches **`ai-awaiting-owner`**, unless you opted out with **`no-address-feedback`**. PRs that never get **`no-pr-review`** will not auto-handoff unless you run the full review pipeline or add that label yourself.
 
+### What is running right now?
+
+GitHub does not show “this PR’s bot job” on the PR page directly. Use:
+
+1. **Actions** → filter by **AI Address PR Feedback** or **AI PR Review** → open **In progress** runs.
+2. CLI (repo root, `gh` authenticated):
+   ```bash
+   gh run list --workflow "AI Address PR Feedback" --limit 8 --json status,conclusion,displayTitle,url
+   gh run list --workflow "AI PR Review" --limit 8 --json status,conclusion,displayTitle,url
+   ```
+   Only **one** address-feedback and **one** Opus PR review run at a time (global concurrency), so other PRs **queue** — a quiet PR may simply be waiting its turn.
+
 ### c) Use slash commands in comments
 
 Comment on any issue (not PR) with one of these:


### PR DESCRIPTION
## Context
PRs with `no-pr-review` (e.g. #177, #178, #182, #184, #185) could look "stuck" because `workflow_dispatch` of **AI PR Review** always ran Opus (first branch of the job `if` was unconditional), and the watchdog could keep re-dispatching pr-review for stale `ai-ready-for-review` without checking `no-pr-review`.

## Changes
- **`ai-pr-review.yml`**: Add a `gate` job that reads labels on `workflow_dispatch`; when `no-pr-review` is present, skip the `review` job, comment, and remove stale `ai-ready-for-review`.
- **`ai-watchdog.yml`**: Skip pr-review re-dispatch for `no-pr-review` PRs; sort `no-pr-review` handoff list by `updatedAt` (oldest first); `MAX_PER_RUN` 8; job timeout 20m.
- **`docs/ai-factory.md`**: How to see what is running (`gh run list` / Actions UI).

## Note on #178 / #184 / #185
Those branches currently report **mergeable: CONFLICTING** — they need conflict resolution with `main`; the factory cannot advance them until that is fixed.

## Definition of done
- [x] YAML parses (Ruby Psych)
- [ ] Merge after review

Made with [Cursor](https://cursor.com)