### PR TITLE
fix(ai-factory): unblock /plan on PRs, worker permissions, bug-hunter queue

### DIFF
--- a/.github/workflows/ai-bug-hunter.yml
+++ b/.github/workflows/ai-bug-hunter.yml
@@ -21,7 +21,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 25"
+          claude_args: "--permission-mode bypassPermissions --max-turns 25"
           prompt: |
             You are the Bug Hunter. Scan the codebase for bugs and potential issues.
 
@@ -61,3 +61,16 @@ jobs:
             - Suggest fixes
 
             If no bugs found, do NOT create an issue. Silence is better than noise.
+
+            ## After you create a bug issue (required)
+            New issues do **not** run AI Worker by themselves. After `gh issue create` prints
+            the URL, capture the issue number `N` and run **two separate** label commands
+            (so GitHub fires `labeled` events reliably):
+
+            ```bash
+            gh issue edit N --add-label "ai-task"
+            gh issue edit N --add-label "ai-work"
+            ```
+
+            That queues **implementation** (single focused PR) for the bug. Do **not** add
+            `ai-planned` unless you also posted a plan comment.

--- a/.github/workflows/ai-plan.yml
+++ b/.github/workflows/ai-plan.yml
@@ -3,6 +3,10 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: ai-plan-${{ github.run_id }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   issues: write
@@ -11,8 +15,9 @@ permissions:
 
 jobs:
   plan:
+    # Do NOT require pull_request == null — PR review threads are still "issues"
+    # in the API; that guard skips `/plan` on pull requests entirely.
     if: >-
-      github.event.issue.pull_request == null &&
       startsWith(github.event.comment.body, '/plan') &&
       (
         github.event.comment.author_association == 'OWNER' ||
@@ -29,6 +34,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: >-
+            ${{ github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number) || format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - name: Generate Implementation Plan
         uses: anthropics/claude-code-action@v1
@@ -36,11 +45,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-opus-4-6 --max-turns 40"
+          claude_args: "--model claude-opus-4-6 --permission-mode bypassPermissions --max-turns 40"
           prompt: |
             You are the AI Planner. Generate a comprehensive implementation plan for this issue.
 
             The command was: "${{ github.event.comment.body }}"
+
+            If this thread is **pull request #${{ github.event.issue.number }}** (not a standalone issue), plan against the **PR branch** you are checked out on; post the plan as a **pull request** comment and mention linked issues by number from the PR body.
 
             ## Step 1 — Understand the request
             Read the issue title, body, and ALL comments carefully.

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -101,6 +101,62 @@ jobs:
             fi
           done
 
+      - name: Re-enable auto-retry for exhausted ai-task issues
+        run: |
+          set -euo pipefail
+          # After MAX_RETRIES the watchdog removes `ai-auto-retry`, leaving
+          # `ai-blocked` + `ai-task` with no path back into the retry loop.
+          # Restore `ai-auto-retry` once per week per issue (and only if the
+          # issue was previously escalated) so hardened workers can run again.
+          NOW=$(date -u +%s)
+          ISSUES=$(gh issue list --repo "$REPO_FULL" --state open \
+            --label "ai-blocked" --label "ai-task" \
+            --json number,title,labels --limit 100 --search "is:issue")
+
+          echo "$ISSUES" | jq -c '.[]' | while read -r row; do
+            NUM=$(echo "$row" | jq -r '.number')
+            TITLE=$(echo "$row" | jq -r '.title')
+            LABELS=$(echo "$row" | jq -r '[.labels[].name] | join(",")')
+
+            if echo ",$LABELS," | grep -q ",ai-auto-retry,"; then
+              continue
+            fi
+            if echo ",$LABELS," | grep -q ",ai-in-progress,"; then
+              continue
+            fi
+
+            PR_COUNT=$(gh pr list --repo "$REPO_FULL" --state all \
+              --search "head:ai/issue-${NUM}- OR \"Closes #${NUM}\" in:body" \
+              --json number --jq 'length')
+            if [ "${PR_COUNT:-0}" != "0" ]; then
+              continue
+            fi
+
+            ESC_AT=$(gh api "repos/$REPO_FULL/issues/$NUM/comments" --paginate \
+              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("will NOT be retried automatically")))] | last | .created_at // empty' 2>/dev/null || echo "")
+            if [ -z "$ESC_AT" ]; then
+              continue
+            fi
+            ESC_TS=$(date -u -d "$ESC_AT" +%s)
+            if [ "$(( NOW - ESC_TS ))" -lt 3600 ]; then
+              continue
+            fi
+
+            LAST_RESTORE=$(gh api "repos/$REPO_FULL/issues/$NUM/comments" --paginate \
+              --jq '[.[] | select(.body | test("restored ai-auto-retry for this sub-task"))] | last | .created_at // empty' 2>/dev/null || echo "")
+            if [ -n "$LAST_RESTORE" ]; then
+              LR_TS=$(date -u -d "$LAST_RESTORE" +%s)
+              if [ "$(( NOW - LR_TS ))" -lt 604800 ]; then
+                continue
+              fi
+            fi
+
+            echo "Restoring ai-auto-retry for exhausted sub-task #$NUM ($TITLE)"
+            gh issue edit "$NUM" --repo "$REPO_FULL" --add-label "ai-auto-retry" || true
+            gh issue comment "$NUM" --repo "$REPO_FULL" \
+              --body "🔄 AI Factory watchdog: restored ai-auto-retry for this sub-task (no PR yet). Worker/permissions budgets were increased; the next auto-retry cycle will dispatch implementation. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})." || true
+          done
+
       - name: Stalled ai-ready-for-review PRs
         run: |
           set -euo pipefail
@@ -360,8 +416,11 @@ jobs:
           #   - Allow up to 3 automatic retries per issue. After that, escalate to human.
           #   - Retry count = number of ❌ or ⚠️ failure comments posted by the worker.
 
-          MAX_RETRIES=3
+          MAX_RETRIES=10
           MIN_WAIT_SECS=5400  # 90 minutes
+          # Only count worker/planner failure comments from the last 14 days so
+          # old runs do not permanently exhaust the retry budget after we ship
+          # workflow fixes (e.g. bypassPermissions).
 
           # Use search API with `is:issue` to explicitly exclude PRs.
           # `gh issue list` can return PRs because GitHub's API treats them as
@@ -371,6 +430,8 @@ jobs:
             --state open --label "ai-blocked" \
             --json number,title,labels --limit 100 \
             --search "is:issue")
+
+          FAILURE_CUTOFF="$(date -u -d '14 days ago' +%Y-%m-%dT%H:%M:%SZ)"
 
           echo "$ISSUES" | jq -c '.[]' | while read -r row; do
             NUM=$(echo "$row" | jq -r '.number')
@@ -387,9 +448,10 @@ jobs:
             # don't reset the clock and cause us to skip valid retries.
             FAILURE_COMMENTS=$(gh api "repos/$REPO_FULL/issues/$NUM/comments" \
               --paginate \
-              --jq '[.[] | select(
+              --jq --arg cutoff "$FAILURE_CUTOFF" '[.[] | select(
                 (.user.login == "github-actions[bot]" or .user.login == "claude[bot]") and
-                (.body | test("❌|⚠️.*AI (Worker|Planner)"))
+                (.body | test("❌|⚠️.*AI (Worker|Planner)")) and
+                (.created_at >= $cutoff)
               )]' 2>/dev/null || echo '[]')
 
             RETRY_COUNT=$(echo "$FAILURE_COMMENTS" | jq 'length')

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -74,7 +74,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 40"
+          claude_args: "--permission-mode bypassPermissions --max-turns 40"
           prompt: |
             You are the AI Planner. Your job is to deeply analyse issue #${{ env.ISSUE_NUMBER }},
             produce a comprehensive implementation plan, and break it into actionable sub-tasks.
@@ -274,7 +274,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 120"
+          claude_args: "--permission-mode bypassPermissions --max-turns 120"
           allowed_bots: "claude[bot],github-actions[bot]"
           prompt: |
             You are the AI Worker. Implement exactly what sub-task issue #${{ env.ISSUE_NUMBER }} describes — nothing more.


### PR DESCRIPTION
## Root causes addressed
- **#175 / #176**: AI Worker often exited without a PR (turns / tool permission denials). Watchdog then exhausted the retry budget and removed `ai-auto-retry`, leaving `ai-blocked` + `ai-task` stuck.
- **#181**: Bug Hunter creates issues but never added `ai-work` / `ai-task`, so nothing subscribed AI Worker. `/plan` on a **PR** thread was skipped by `pull_request == null` in `ai-plan.yml` (same class of bug as AI Command before #199).

## Changes
- `ai-worker.yml`: `--permission-mode bypassPermissions` on plan + implement.
- `ai-plan.yml`: remove PR-thread skip; checkout PR head when applicable; Opus + bypassPermissions; concurrency group.
- `ai-bug-hunter.yml`: bypassPermissions; instruct agent to `gh issue edit N --add-label ai-task` then `ai-work` after create.
- `ai-watchdog.yml`: count failures in a **14-day** sliding window; `MAX_RETRIES` **10**; new step restores `ai-auto-retry` weekly for exhausted `ai-task` issues with no PR.

## Post-merge (manual)
Dispatch worker for stuck issues if needed: `gh workflow run ai-worker.yml -f issue_number=175 -f phase=implement` (and 176, 181 after adding `ai-task` to #181 if missing).

Made with [Cursor](https://cursor.com)