### PR TITLE
fix(ci): unblock AI PR Review (bypassPermissions, higher turn cap)

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -102,7 +102,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-opus-4-6 --max-turns 35"
+          # Headless review: tool approvals stall the run; default cap was 35 turns.
+          claude_args: "--model claude-opus-4-6 --permission-mode bypassPermissions --max-turns 80"
           allowed_bots: "claude[bot],github-actions[bot],copilot-pull-request-reviewer[bot]"
           use_sticky_comment: "true"
           include_fix_links: "true"
@@ -124,6 +125,14 @@ jobs:
             ---
 
             ${{ steps.guidelines.outputs.CONTENT }}
+
+      - name: Clear PR review failure labels
+        if: success() && steps.cap.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
+            --remove-label "ai-blocked" --remove-label "ai-auto-retry" || true
 
       - name: Max automated Opus reviews reached (legacy)
         if: success() && steps.cap.outputs.skip == 'true'


### PR DESCRIPTION
## Problem
**AI PR Review** failed on #202 and #203 with `error_max_turns` at **35** and high `permission_denials_count` — headless Opus could not approve tool use, so the review never finished and the failure handler left `ai-blocked` + `ai-auto-retry`.

## Change
- `--permission-mode bypassPermissions` + `--max-turns 80` on the Opus review step.
- On **successful** review, remove stale `ai-blocked` and `ai-auto-retry` from the PR.

Post-merge: re-dispatch `ai-pr-review.yml` for #202 and #203.

Made with [Cursor](https://cursor.com)