### PR TITLE
fix(ai-factory): tag PRs with ai-awaiting-owner at owner handoff

### DIFF
--- a/.github/ai-factory/config.yml
+++ b/.github/ai-factory/config.yml
@@ -17,6 +17,7 @@ labels:
   no_ai: "no-ai"              # Human-only
   no_review: "no-pr-review"   # Skip AI PR review
   auto_merge: "auto-merge"    # Auto-merge when CI + review pass
+  awaiting_owner: "ai-awaiting-owner"  # Automated review cycle done — owner merges when ready
 
   # Priority (highest first)
   priorities:

--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -159,6 +159,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          gh pr edit ${{ needs.resolve.outputs.pr_number }} \
+            --remove-label "ai-awaiting-owner" || true
           gh pr comment ${{ needs.resolve.outputs.pr_number }} \
             --body "🤖 Addressing review feedback automatically (${{ needs.resolve.outputs.reason }}). See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
 
@@ -268,6 +270,7 @@ jobs:
             gh pr edit "$PR" --repo "$REPO" --remove-label "ai-ready-for-review" || true
             gh pr edit "$PR" --repo "$REPO" \
               --remove-label "ai-blocked" --remove-label "ai-auto-retry" || true
+            gh pr edit "$PR" --repo "$REPO" --add-label "ai-awaiting-owner" || true
             gh pr comment "$PR" \
               --body "✅ Review cycle converged — no new changes required. PR is ready for human merge decision." || true
           }
@@ -313,6 +316,7 @@ jobs:
             if ! echo ",$LABELS," | grep -q ",ai-o-after-2,"; then
               gh pr edit "$PR" --repo "$REPO" \
                 --add-label "ai-o-after-2" \
+                --add-label "ai-awaiting-owner" \
                 --remove-label "ai-phase-opus" \
                 --remove-label "ai-ready-for-review" \
                 --remove-label "ai-blocked" \

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -51,7 +51,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
-            --remove-label "ai-ready-for-review" || true
+            --remove-label "ai-ready-for-review" \
+            --remove-label "ai-awaiting-owner" || true
 
       - name: Resolve PR ref and title
         id: resolve
@@ -142,6 +143,8 @@ jobs:
           gh pr edit "${{ env.PR_NUMBER }}" --repo "${{ github.repository }}" \
             --remove-label "ai-ready-for-review" \
             --remove-label "ai-auto-retry" || true
+          gh pr edit "${{ env.PR_NUMBER }}" --repo "${{ github.repository }}" \
+            --add-label "ai-awaiting-owner" || true
           gh pr comment "${{ env.PR_NUMBER }}" \
             --body "✅ **AI Factory**: This PR has reached the maximum number of automated Opus review passes (**2**). No further Opus runs will be dispatched. Merge or continue manually."
 


### PR DESCRIPTION
## Why
`ai-awaiting-owner` existed in GitHub but workflows never set it, so PRs looked "ready" in comments only — nothing to filter in the PR list.

## Change
- **ai-address-feedback**: `converge_comment()` and final Opus (2/2) path **add** `ai-awaiting-owner`; **Announce start** removes it when the bot picks the PR up again.
- **ai-pr-review**: first step also removes `ai-awaiting-owner` when a new Opus review starts; **legacy max Opus** path adds it when automation stops.
- **config.yml**: document `awaiting_owner` in the label map.

Made with [Cursor](https://cursor.com)