### PR TITLE
feat(ai-factory): CI-green gate for owner handoff + auto CI remediation

### DIFF
--- a/.github/ai-factory/config.yml
+++ b/.github/ai-factory/config.yml
@@ -18,6 +18,7 @@ labels:
   no_review: "no-pr-review"   # Skip AI PR review
   auto_merge: "auto-merge"    # Auto-merge when CI + review pass
   awaiting_owner: "ai-awaiting-owner"  # Automated review cycle done — owner merges when ready
+  ci_failing: "ai-ci-failing"            # CI workflow red; AI CI remediation may run
 
   # Priority (highest first)
   priorities:

--- a/.github/scripts/ci-handoff-state.sh
+++ b/.github/scripts/ci-handoff-state.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Print whether PR CI jobs (from workflow "CI": lint, test, docker-build) are
+# safe for owner handoff. Used by ai-address-feedback and ai-pr-review.
+# Usage: ci-handoff-state.sh OWNER/REPO PR_NUMBER
+# stdout: ready | pending | failing
+set -euo pipefail
+REPO="${1:?repo}"
+PR="${2:?pr number}"
+gh pr view "$PR" --repo "$REPO" --json statusCheckRollup | jq -r '
+  .statusCheckRollup
+  | map(select(
+      (.workflowName == "CI")
+      or (.name == "lint")
+      or (.name == "test")
+      or (.name == "docker-build")
+    ))
+  | if length == 0 then "pending"
+    elif any(.[]; (.status // "") != "COMPLETED") then "pending"
+    elif any(.[]; (.conclusion // "") == "FAILURE" or .conclusion == "CANCELLED" or .conclusion == "TIMED_OUT") then "failing"
+    else "ready" end
+'

--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -160,7 +160,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr edit ${{ needs.resolve.outputs.pr_number }} \
-            --remove-label "ai-awaiting-owner" || true
+            --remove-label "ai-awaiting-owner" \
+            --remove-label "ai-ci-failing" || true
           gh pr comment ${{ needs.resolve.outputs.pr_number }} \
             --body "🤖 Addressing review feedback automatically (${{ needs.resolve.outputs.reason }}). See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
 
@@ -171,7 +172,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 80"
+          claude_args: "--permission-mode bypassPermissions --max-turns 80"
           allowed_bots: "claude[bot],copilot-pull-request-reviewer[bot],github-actions[bot]"
           prompt: |
             You are addressing review feedback on PR #${{ needs.resolve.outputs.pr_number }}.
@@ -253,6 +254,17 @@ jobs:
             - Read-only SQL policy still applies (no INSERT/UPDATE/DELETE in production queries).
             - Stay within this PR's scope — do not pull in unrelated work.
 
+      - name: Fetch CI handoff helper from default branch
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p .github/scripts
+          gh api "repos/${{ github.repository }}/contents/.github/scripts/ci-handoff-state.sh?ref=${{ github.event.repository.default_branch }}" \
+            --jq -r .content | base64 -d > .github/scripts/ci-handoff-state.sh
+          chmod +x .github/scripts/ci-handoff-state.sh
+
       - name: Route next automated review (or converge)
         id: route
         if: success()
@@ -266,13 +278,35 @@ jobs:
           INITIAL_SHA="${{ steps.initial_head.outputs.sha }}"
           LABELS=$(gh api "repos/$REPO/pulls/$PR" --jq '[.labels[].name] | join(",")')
 
+          ci_state() { bash .github/scripts/ci-handoff-state.sh "$REPO" "$PR"; }
+
+          owner_handoff_or_ci_gate() {
+            local hs
+            hs=$(ci_state)
+            gh label create "ai-ci-failing" --color D93F0B --description "CI failed; bot may auto-remediate" 2>/dev/null || true
+            if [ "$hs" = "ready" ]; then
+              gh pr edit "$PR" --repo "$REPO" --remove-label "ai-ci-failing" || true
+              gh pr edit "$PR" --repo "$REPO" --add-label "ai-awaiting-owner" || true
+              gh pr comment "$PR" --repo "$REPO" --body "$1" || true
+              return 0
+            fi
+            gh pr edit "$PR" --repo "$REPO" --remove-label "ai-awaiting-owner" || true
+            gh pr edit "$PR" --repo "$REPO" --add-label "ai-ci-failing" || true
+            if [ "$hs" = "failing" ]; then
+              gh pr comment "$PR" --repo "$REPO" \
+                --body "⚠️ **AI Factory**: Automated review is done, but **CI is failing** — not marking \`ai-awaiting-owner\`. Added \`ai-ci-failing\`. An **AI CI remediation** workflow will run (or re-run \`ai-ci-remediation.yml\` manually)." || true
+              gh workflow run ai-ci-remediation.yml --repo "$REPO" --field pr_number="$PR" || true
+            else
+              gh pr comment "$PR" --repo "$REPO" \
+                --body "⏳ **AI Factory**: Automated review is done, but **CI is still running or not reported yet** — not marking \`ai-awaiting-owner\`. Re-check after CI finishes." || true
+            fi
+          }
+
           converge_comment() {
             gh pr edit "$PR" --repo "$REPO" --remove-label "ai-ready-for-review" || true
             gh pr edit "$PR" --repo "$REPO" \
               --remove-label "ai-blocked" --remove-label "ai-auto-retry" || true
-            gh pr edit "$PR" --repo "$REPO" --add-label "ai-awaiting-owner" || true
-            gh pr comment "$PR" \
-              --body "✅ Review cycle converged — no new changes required. PR is ready for human merge decision." || true
+            owner_handoff_or_ci_gate "✅ Review cycle converged — no new changes required. PR is ready for human merge decision."
           }
 
           if [ "$CURRENT_SHA" = "$INITIAL_SHA" ]; then
@@ -316,12 +350,11 @@ jobs:
             if ! echo ",$LABELS," | grep -q ",ai-o-after-2,"; then
               gh pr edit "$PR" --repo "$REPO" \
                 --add-label "ai-o-after-2" \
-                --add-label "ai-awaiting-owner" \
                 --remove-label "ai-phase-opus" \
                 --remove-label "ai-ready-for-review" \
                 --remove-label "ai-blocked" \
                 --remove-label "ai-auto-retry" || true
-              gh pr comment "$PR" --body "✅ **AI Factory**: Automated **Opus** passes complete (**2**/2). PR is ready for human merge decision." || true
+              owner_handoff_or_ci_gate "✅ **AI Factory**: Automated **Opus** passes complete (**2**/2). PR is ready for human merge decision."
               exit 0
             fi
           fi

--- a/.github/workflows/ai-ci-remediation.yml
+++ b/.github/workflows/ai-ci-remediation.yml
@@ -1,0 +1,174 @@
+name: AI CI Remediation
+# When CI fails on a factory PR branch (ai/*), attempt an automated fix push.
+# Owner handoff (ai-awaiting-owner) is gated on CI green in ai-address-feedback / ai-pr-review.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number with failing CI"
+        required: true
+        type: number
+      triggering_run_id:
+        description: "Optional failed CI run id (for logs and dedup)"
+        required: false
+        type: string
+
+concurrency:
+  group: ai-ci-remediation-${{ github.event.inputs.pr_number || github.event.workflow_run.head_branch || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.pick.outputs.should_run }}
+      pr_number: ${{ steps.pick.outputs.pr_number }}
+      failed_run_id: ${{ steps.pick.outputs.failed_run_id }}
+      head_branch: ${{ steps.pick.outputs.head_branch }}
+    steps:
+      - name: Resolve PR and failed CI run
+        id: pick
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR="${{ inputs.pr_number }}"
+            RUN_ID="${{ inputs.triggering_run_id }}"
+            if [ -z "$RUN_ID" ]; then
+              BR=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq -r '.headRefName')
+              RUN_ID=$(gh run list --repo "$REPO" --workflow CI.yml --branch "$BR" \
+                --json databaseId,conclusion --jq '.[] | select(.conclusion=="failure") | .databaseId' | head -1)
+            fi
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "pr_number=$PR" >> "$GITHUB_OUTPUT"
+            echo "failed_run_id=${RUN_ID:-}" >> "$GITHUB_OUTPUT"
+            echo "head_branch=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq -r '.headRefName')" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event.workflow_run.conclusion }}" != "failure" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${{ github.event.workflow_run.event }}" != "pull_request" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          case "$BRANCH" in
+            ai/*) ;;
+            *)
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$PR" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if gh pr view "$PR" --repo "$REPO" --json labels --jq '[.labels[].name] | any(. == "no-ai")' | grep -q true; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          RUN_ID="${{ github.event.workflow_run.id }}"
+          MARKER="CI remediation attempted for run ${RUN_ID}"
+          if gh api "repos/$REPO/issues/$PR/comments" --paginate --jq -r '.[].body' | grep -Fq "$MARKER"; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR" >> "$GITHUB_OUTPUT"
+          echo "failed_run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "head_branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+  fix:
+    needs: resolve
+    if: needs.resolve.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+      FAILED_RUN_ID: ${{ needs.resolve.outputs.failed_run_id }}
+    steps:
+      - name: Mark CI failing / clear premature owner handoff
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "ai-ci-failing" --color D93F0B --description "CI failed; bot may auto-remediate" 2>/dev/null || true
+          gh pr edit "$PR_NUMBER" --repo "$REPO" \
+            --remove-label "ai-awaiting-owner" \
+            --add-label "ai-ci-failing" || true
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.resolve.outputs.head_branch }}
+
+      - name: Fetch failed CI logs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -n "$FAILED_RUN_ID" ]; then
+            gh run view "$FAILED_RUN_ID" --repo "$REPO" --log-failed > /tmp/ci-failed.log 2>&1 || true
+          else
+            echo "No failed run id supplied." > /tmp/ci-failed.log
+          fi
+          head -c 120000 /tmp/ci-failed.log > /tmp/ci-failed-truncated.log || true
+
+      - name: Auto-fix with Claude
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--permission-mode bypassPermissions --max-turns 120"
+          prompt: |
+            You are fixing **CI failures** for PR #${{ env.PR_NUMBER }} on branch `${{ needs.resolve.outputs.head_branch }}`.
+
+            Read **/tmp/ci-failed-truncated.log** on the runner first — it contains the failed **CI** job log excerpt.
+
+            Repository CI (`.github/workflows/ci.yml`) runs:
+            - `ruff check etl/` and `ruff format --check etl/`
+            - `pytest etl/tests/` (with empty P4D/Postgres env — tests self-skip when needed)
+            - `docker build` for `./etl/Dockerfile`
+
+            ## Tasks
+            1. Reproduce with the same commands locally in this checkout.
+            2. Make the **minimal** fixes so CI would pass.
+            3. Run `python -m ruff format` on any Python you changed.
+            4. Commit: `fix(ci): address CI failure (PR #${{ env.PR_NUMBER }})`
+            5. Push to the current branch: `git push`.
+
+            If you cannot fix in-repo, post a short PR comment and do not push noise commits.
+
+      - name: Record remediation attempt
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          RID="${FAILED_RUN_ID:-unknown}"
+          SERVER="${{ github.server_url }}"
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "🔧 **AI CI remediation** finished for failed CI [run $RID]($SERVER/$REPO/actions/runs/$RID). Bot workflow: [run ${{ github.run_id }}]($SERVER/$REPO/actions/runs/${{ github.run_id }}). CI remediation attempted for run $RID" || true

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -52,7 +52,8 @@ jobs:
         run: |
           gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
             --remove-label "ai-ready-for-review" \
-            --remove-label "ai-awaiting-owner" || true
+            --remove-label "ai-awaiting-owner" \
+            --remove-label "ai-ci-failing" || true
 
       - name: Resolve PR ref and title
         id: resolve
@@ -75,6 +76,16 @@ jobs:
         with:
           ref: ${{ steps.resolve.outputs.ref }}
           fetch-depth: 0
+
+      - name: Fetch CI handoff helper from default branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p .github/scripts
+          gh api "repos/${{ github.repository }}/contents/.github/scripts/ci-handoff-state.sh?ref=${{ github.event.repository.default_branch }}" \
+            --jq -r .content | base64 -d > .github/scripts/ci-handoff-state.sh
+          chmod +x .github/scripts/ci-handoff-state.sh
 
       - name: Load review guidelines
         id: guidelines
@@ -139,14 +150,32 @@ jobs:
         if: success() && steps.cap.outputs.skip == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ env.PR_NUMBER }}
         run: |
-          gh pr edit "${{ env.PR_NUMBER }}" --repo "${{ github.repository }}" \
+          set -euo pipefail
+          gh pr edit "$PR" --repo "$REPO" \
             --remove-label "ai-ready-for-review" \
             --remove-label "ai-auto-retry" || true
-          gh pr edit "${{ env.PR_NUMBER }}" --repo "${{ github.repository }}" \
-            --add-label "ai-awaiting-owner" || true
-          gh pr comment "${{ env.PR_NUMBER }}" \
-            --body "✅ **AI Factory**: This PR has reached the maximum number of automated Opus review passes (**2**). No further Opus runs will be dispatched. Merge or continue manually."
+          HS=$(bash .github/scripts/ci-handoff-state.sh "$REPO" "$PR")
+          gh label create "ai-ci-failing" --color D93F0B --description "CI failed; bot may auto-remediate" 2>/dev/null || true
+          if [ "$HS" = "ready" ]; then
+            gh pr edit "$PR" --repo "$REPO" --remove-label "ai-ci-failing" || true
+            gh pr edit "$PR" --repo "$REPO" --add-label "ai-awaiting-owner" || true
+            gh pr comment "$PR" --repo "$REPO" \
+              --body "✅ **AI Factory**: This PR has reached the maximum number of automated Opus review passes (**2**). No further Opus runs will be dispatched. Merge or continue manually."
+          else
+            gh pr edit "$PR" --repo "$REPO" --remove-label "ai-awaiting-owner" || true
+            gh pr edit "$PR" --repo "$REPO" --add-label "ai-ci-failing" || true
+            if [ "$HS" = "failing" ]; then
+              gh pr comment "$PR" --repo "$REPO" \
+                --body "⚠️ **AI Factory**: Max automated Opus passes reached, but **CI is failing** — not marking \`ai-awaiting-owner\`. Added \`ai-ci-failing\`. **AI CI remediation** will be dispatched." || true
+              gh workflow run ai-ci-remediation.yml --repo "$REPO" --field pr_number="$PR" || true
+            else
+              gh pr comment "$PR" --repo "$REPO" \
+                --body "⏳ **AI Factory**: Max automated Opus passes reached, but **CI is still running** — not marking \`ai-awaiting-owner\` yet." || true
+            fi
+          fi
 
       - name: Record legacy Opus pass
         if: success() && steps.cap.outputs.skip != 'true'

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -507,6 +507,21 @@ jobs:
             sleep 30  # stagger to avoid hammering the rate limit
           done
 
+      - name: Clear ai-ci-failing when CI is green
+        run: |
+          set -euo pipefail
+          mkdir -p .github/scripts
+          gh api "repos/$REPO_FULL/contents/.github/scripts/ci-handoff-state.sh?ref=${{ github.event.repository.default_branch }}" \
+            --jq -r .content | base64 -d > .github/scripts/ci-handoff-state.sh
+          chmod +x .github/scripts/ci-handoff-state.sh
+          gh pr list --repo "$REPO_FULL" --state open --label "ai-ci-failing" --json number --jq -c '.[]' | while read -r row; do
+            NUM=$(echo "$row" | jq -r '.number')
+            hs=$(bash .github/scripts/ci-handoff-state.sh "$REPO_FULL" "$NUM")
+            if [ "$hs" = "ready" ]; then
+              gh pr edit "$NUM" --repo "$REPO_FULL" --remove-label "ai-ci-failing" || true
+            fi
+          done
+
       - name: Bot-triggered runs gated as `action_required`
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Problem
PRs could get `ai-awaiting-owner` while **CI was still running or already red**, so "ready to merge" did not match reality.

## Change
- **`.github/scripts/ci-handoff-state.sh`**: classifies PR rollup checks for jobs from workflow **CI** (and names lint/test/docker-build) as `ready` | `pending` | `failing`.
- **`ai-address-feedback`**: owner handoff only adds `ai-awaiting-owner` when state is `ready`; otherwise strips it, adds `ai-ci-failing`, comments, and on `failing` dispatches **AI CI remediation**. Fetches the helper from the default branch so PR heads do not need the script. **`bypassPermissions`** on the address step.
- **`ai-pr-review`**: legacy max-Opus path uses the same gate; fetches the helper from default branch.
- **`ai-ci-remediation.yml`**: on `workflow_run` **CI** `failure` for `ai/*` PR branches (deduped per failed run id), or `workflow_dispatch`, runs Claude with failed logs to push `fix(ci):` commits.
- **`ai-watchdog`**: removes `ai-ci-failing` when CI returns to green.
- **`config.yml`**: documents `ci_failing` label.

## Notes
- First merge must land before `workflow_run` remediation can fire (workflow must exist on default branch).
- Remediation is limited to `ai/*` heads and skips PRs labeled `no-ai`.

Made with [Cursor](https://cursor.com)