### PR TITLE
fix(ci): repair handoff script fetch in AI workflows

### DIFF
--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -262,7 +262,7 @@ jobs:
           set -euo pipefail
           mkdir -p .github/scripts
           gh api "repos/${{ github.repository }}/contents/.github/scripts/ci-handoff-state.sh?ref=${{ github.event.repository.default_branch }}" \
-            --jq -r .content | base64 -d > .github/scripts/ci-handoff-state.sh
+            | jq -r '.content' | base64 -d > .github/scripts/ci-handoff-state.sh
           chmod +x .github/scripts/ci-handoff-state.sh
 
       - name: Route next automated review (or converge)

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -83,8 +83,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .github/scripts
+          # gh api --jq must receive a single jq expression (-r is not a gh flag here).
           gh api "repos/${{ github.repository }}/contents/.github/scripts/ci-handoff-state.sh?ref=${{ github.event.repository.default_branch }}" \
-            --jq -r .content | base64 -d > .github/scripts/ci-handoff-state.sh
+            | jq -r '.content' | base64 -d > .github/scripts/ci-handoff-state.sh
           chmod +x .github/scripts/ci-handoff-state.sh
 
       - name: Load review guidelines

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -512,7 +512,7 @@ jobs:
           set -euo pipefail
           mkdir -p .github/scripts
           gh api "repos/$REPO_FULL/contents/.github/scripts/ci-handoff-state.sh?ref=${{ github.event.repository.default_branch }}" \
-            --jq -r .content | base64 -d > .github/scripts/ci-handoff-state.sh
+            | jq -r '.content' | base64 -d > .github/scripts/ci-handoff-state.sh
           chmod +x .github/scripts/ci-handoff-state.sh
           gh pr list --repo "$REPO_FULL" --state open --label "ai-ci-failing" --json number --jq -c '.[]' | while read -r row; do
             NUM=$(echo "$row" | jq -r '.number')


### PR DESCRIPTION
## Problem
Open PRs showed green product CI but failed **AI PR Review** on the step **Fetch CI handoff helper from default branch**. Logs reported `accepts 1 arg(s), received 2`.

## Cause
`gh api ... --jq -r .content` is invalid: `--jq` takes one argument, so `-r` was treated as a second endpoint/query argument.

## Change
Pipe full JSON from `gh api` to `jq -r '.content' | base64 -d` in:
- `.github/workflows/ai-pr-review.yml`
- `.github/workflows/ai-address-feedback.yml`
- `.github/workflows/ai-watchdog.yml`

## After merge
Re-run **AI PR Review** on PRs that were blocked only by this failure; remove stale `ai-blocked` / `ai-auto-retry` if the watchdog does not clear them.

Made with [Cursor](https://cursor.com)