### PR TITLE
Add ps stack update for one-shot dev refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Single entry point for all operations. **Usage:** `ps <group> [subcommand] [opti
 | `ps stack up` | Start all containers |
 | `ps stack down` | Stop all containers |
 | `ps stack restart` | Restart all containers |
-| `ps stack update` | Pull latest main, rebuild images, restart stack |
+| `ps stack update` | Pull latest, rebuild images, restart stack |
 | `ps stack status` | Show container status and WrenAI UI health |
 | `ps stack logs [svc]` | Show logs (follow); optional service name |
 | `ps stack open` | Open WrenAI UI in browser |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ Single entry point for all operations. **Usage:** `ps <group> [subcommand] [opti
 | `ps stack up` | Start all containers |
 | `ps stack down` | Stop all containers |
 | `ps stack restart` | Restart all containers |
+| `ps stack update` | Pull latest main, rebuild images, restart stack |
 | `ps stack status` | Show container status and WrenAI UI health |
 | `ps stack logs [svc]` | Show logs (follow); optional service name |
 | `ps stack open` | Open WrenAI UI in browser |

--- a/cli/commands/stack.sh
+++ b/cli/commands/stack.sh
@@ -20,7 +20,7 @@ Subcommands:
   up              Start all containers
   down            Stop all containers
   restart         Restart all containers
-  update          Pull latest main, rebuild images, restart stack
+  update          Pull latest, rebuild images, restart stack
   status          Show container status
   logs [svc]      Show logs (follow); optional service name
   open            Open WrenAI UI in browser

--- a/cli/commands/stack.sh
+++ b/cli/commands/stack.sh
@@ -20,6 +20,7 @@ Subcommands:
   up              Start all containers
   down            Stop all containers
   restart         Restart all containers
+  update          Pull latest main, rebuild images, restart stack
   status          Show container status
   logs [svc]      Show logs (follow); optional service name
   open            Open WrenAI UI in browser
@@ -46,6 +47,41 @@ cmd_restart() {
     echo -e "${CYAN}Restarting stack...${NC}"
     $DC restart
     echo -e "${GREEN}Stack restarted.${NC}"
+}
+
+cmd_update() {
+    cd "${REPO_ROOT}"
+
+    local branch
+    branch="$(git rev-parse --abbrev-ref HEAD)"
+    if [ "$branch" != "main" ]; then
+        echo -e "${YELLOW}Current branch is '${branch}', not 'main'.${NC}"
+        printf "Pull and rebuild on this branch anyway? [y/N] "
+        read -r answer || answer=''
+        if [ "${answer}" != "y" ] && [ "${answer}" != "Y" ]; then
+            echo "Aborted."
+            exit 0
+        fi
+    fi
+
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        echo -e "${YELLOW}Working tree has uncommitted changes.${NC}"
+        printf "Continue? git pull will fail if it would overwrite them. [y/N] "
+        read -r answer || answer=''
+        if [ "${answer}" != "y" ] && [ "${answer}" != "Y" ]; then
+            echo "Aborted."
+            exit 0
+        fi
+    fi
+
+    echo -e "${CYAN}Pulling latest from origin/${branch}...${NC}"
+    git pull --ff-only origin "$branch"
+
+    echo -e "${CYAN}Rebuilding images and starting stack...${NC}"
+    $DC up -d --build
+
+    echo ""
+    cmd_status
 }
 
 cmd_status() {
@@ -123,6 +159,7 @@ case "$SUBCMD" in
     up)          cmd_up ;;
     down)        cmd_down ;;
     restart)     cmd_restart ;;
+    update)      cmd_update ;;
     status)      cmd_status ;;
     logs)        cmd_logs "${1:-}" ;;
     open)        cmd_open ;;

--- a/cli/commands/stack.sh
+++ b/cli/commands/stack.sh
@@ -54,6 +54,11 @@ cmd_update() {
 
     local branch
     branch="$(git rev-parse --abbrev-ref HEAD)"
+    if [ "$branch" = "HEAD" ]; then
+        echo -e "${YELLOW}Repository is in a detached HEAD state.${NC}"
+        echo "Please check out a branch (for example: git checkout main) and run this command again."
+        exit 1
+    fi
     if [ "$branch" != "main" ]; then
         echo -e "${YELLOW}Current branch is '${branch}', not 'main'.${NC}"
         printf "Pull and rebuild on this branch anyway? [y/N] "
@@ -64,8 +69,8 @@ cmd_update() {
         fi
     fi
 
-    if ! git diff --quiet || ! git diff --cached --quiet; then
-        echo -e "${YELLOW}Working tree has uncommitted changes.${NC}"
+    if [ -n "$(git status --porcelain)" ]; then
+        echo -e "${YELLOW}Working tree has uncommitted or untracked changes.${NC}"
         printf "Continue? git pull will fail if it would overwrite them. [y/N] "
         read -r answer || answer=''
         if [ "${answer}" != "y" ] && [ "${answer}" != "Y" ]; then

--- a/cli/ps.sh
+++ b/cli/ps.sh
@@ -34,7 +34,7 @@ Examples:
   ps setup                 First-time setup (create .env, symlink)
   ps setup check           Verify prerequisites
   ps stack up              Start all containers
-  ps stack update          Pull latest main, rebuild images, restart stack
+  ps stack update          Pull latest, rebuild images, restart stack
   ps stack status          Show container status
   ps stack logs [svc]      Tail logs
   ps etl run               Run ETL sync once

--- a/cli/ps.sh
+++ b/cli/ps.sh
@@ -19,7 +19,7 @@ Usage: ps <command> [options] [args]
 
 Available commands:
   setup        First-time setup and prerequisites check
-  stack        Docker Compose stack management (up/down/status/logs/open/destroy)
+  stack        Docker Compose stack management (up/down/update/status/logs/open/destroy)
   etl          ETL operations (run/status/tables/logs)
   sql          4D SQL operations (schema, query, explore)
   wren         WrenAI knowledge management (push/validate/status)
@@ -34,6 +34,7 @@ Examples:
   ps setup                 First-time setup (create .env, symlink)
   ps setup check           Verify prerequisites
   ps stack up              Start all containers
+  ps stack update          Pull latest main, rebuild images, restart stack
   ps stack status          Show container status
   ps stack logs [svc]      Tail logs
   ps etl run               Run ETL sync once


### PR DESCRIPTION
## Summary
- Adds `ps stack update`: pulls latest `main`, rebuilds local images (`etl`, `dashboard`), restarts the stack, and prints status — replaces the manual `git pull && docker compose up -d --build` dance.
- Interactive guard: confirms before pulling when on a non-main branch or with uncommitted changes; uses `git pull --ff-only` to avoid surprise merges.
- Registers the subcommand in `cli/ps.sh` help and the AGENTS.md CLI table.

## Test plan
- [ ] `ps stack --help` lists `update`
- [ ] `ps stack update` on `main` with a clean tree pulls, rebuilds, and ends with `ps stack status`
- [ ] `ps stack update` on a feature branch prompts for confirmation and aborts on `n`
- [ ] `ps stack update` with uncommitted changes prompts for confirmation