### PR TITLE
ai: verify Copilot review really happened before converging

### DIFF
--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -280,10 +280,52 @@ jobs:
 
           ci_state() { bash .github/scripts/ci-handoff-state.sh "$REPO" "$PR"; }
 
+          # Did a non-claude, non-github-actions reviewer actually submit a review?
+          # Copilot posts as `Copilot` (user) or `copilot-pull-request-reviewer[bot]`.
+          # A human is anything else that isn't claude[bot]/github-actions[bot].
+          has_real_review() {
+            local count
+            count=$(gh api "repos/$REPO/pulls/$PR/reviews" \
+              --jq '[.[] | select(.user.login != "claude[bot]" and .user.login != "github-actions[bot]")] | length' 2>/dev/null || echo "0")
+            [ "${count:-0}" -gt 0 ]
+          }
+
+          # Is there an unresolved Copilot review request still pending?
+          copilot_review_pending() {
+            gh api "repos/$REPO/pulls/$PR/requested_reviewers" \
+              --jq '[.users[]?.login, .teams[]?.slug] | map(select(. == "Copilot" or . == "copilot-pull-request-reviewer")) | length' 2>/dev/null \
+              | grep -qv '^0$'
+          }
+
           owner_handoff_or_ci_gate() {
             local hs
             hs=$(ci_state)
             gh label create "ai-ci-failing" --color D93F0B --description "CI failed; bot may auto-remediate" 2>/dev/null || true
+
+            # Guard against falsely converging: never add ai-awaiting-owner unless a
+            # real (non-claude) review actually exists on the PR. If the Copilot
+            # request silently failed upstream (e.g. GITHUB_TOKEN lacks permission),
+            # re-request and bail out instead of falsely claiming the cycle converged.
+            if ! has_real_review; then
+              echo "::warning::No real (non-claude) review on PR #$PR — not converging."
+              if copilot_review_pending; then
+                gh pr comment "$PR" --repo "$REPO" --body "⏳ **AI Factory**: Automated address-feedback ran, but **no Copilot or human review has landed yet**. Leaving the review request pending — will re-check on next trigger." || true
+                return 0
+              fi
+              # No review and no pending request — retry Copilot.
+              local post_result copilot_added
+              post_result=$(gh api "repos/$REPO/pulls/$PR/requested_reviewers" --method POST \
+                -f 'reviewers[]=copilot-pull-request-reviewer[bot]' 2>&1 || true)
+              copilot_added=$(printf '%s' "$post_result" | jq -r '[.requested_reviewers[]?.login] | map(select(. == "Copilot" or . == "copilot-pull-request-reviewer")) | length' 2>/dev/null || echo "0")
+              if [ "${copilot_added:-0}" -gt 0 ]; then
+                gh pr comment "$PR" --repo "$REPO" --body "🔁 **AI Factory**: No Copilot/human review found on PR — re-requested **Copilot** review before converging." || true
+              else
+                gh pr edit "$PR" --repo "$REPO" --add-label "ai-blocked" || true
+                gh pr comment "$PR" --repo "$REPO" --body "⚠️ **AI Factory**: No Copilot/human review found **and** re-requesting Copilot returned no reviewer (likely a token-permissions issue with \`GITHUB_TOKEN\`). Not marking \`ai-awaiting-owner\`. cc @alvarolobato — please request Copilot review manually or check workflow token." || true
+              fi
+              return 0
+            fi
+
             if [ "$hs" = "ready" ]; then
               gh pr edit "$PR" --repo "$REPO" --remove-label "ai-ci-failing" || true
               gh pr edit "$PR" --repo "$REPO" --add-label "ai-awaiting-owner" || true
@@ -323,9 +365,17 @@ jobs:
           if echo ",$LABELS," | grep -q ",ai-phase-copilot,"; then
             if ! echo ",$LABELS," | grep -q ",ai-cp-after-1,"; then
               gh pr edit "$PR" --repo "$REPO" --add-label "ai-cp-after-1" || true
-              gh api "repos/$REPO/pulls/$PR/requested_reviewers" --method POST \
-                -f 'reviewers[]=copilot-pull-request-reviewer[bot]' || true
-              gh pr comment "$PR" --body "🤖 **AI Factory**: Copilot round **1**/2 addressed — requested **round 2** Copilot review." || true
+              POST_OUT=$(gh api "repos/$REPO/pulls/$PR/requested_reviewers" --method POST \
+                -f 'reviewers[]=copilot-pull-request-reviewer[bot]' 2>&1 || true)
+              COPILOT_ADDED=$(printf '%s' "$POST_OUT" \
+                | jq -r '[.requested_reviewers[]?.login] | map(select(. == "Copilot" or . == "copilot-pull-request-reviewer")) | length' 2>/dev/null || echo "0")
+              if [ "${COPILOT_ADDED:-0}" -gt 0 ]; then
+                gh pr comment "$PR" --body "🤖 **AI Factory**: Copilot round **1**/2 addressed — requested **round 2** Copilot review." || true
+              else
+                gh pr edit "$PR" --repo "$REPO" --add-label "ai-blocked" || true
+                gh pr comment "$PR" --body "⚠️ **AI Factory**: Tried to request **Copilot round 2** review but the API returned no reviewer (likely \`GITHUB_TOKEN\` permissions). cc @alvarolobato — please request manually." || true
+                echo "::warning::Copilot round-2 request silently failed on PR #$PR"
+              fi
               exit 0
             fi
             if ! echo ",$LABELS," | grep -q ",ai-cp-after-2,"; then

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -129,11 +129,19 @@ jobs:
             ## Copilot follow-up (read carefully)
             Run `gh pr view ${{ env.PR_NUMBER }} --json labels -q '.labels[].name'` before you finish.
             - If the PR has label `ai-phase-opus`, do **NOT** request a Copilot review (Opus-only passes; address-feedback is dispatched by CI).
-            - Otherwise, after reviewing, request a Copilot review:
+            - Otherwise, after reviewing, request a Copilot review **and verify the request landed**:
             ```bash
-            gh api repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/requested_reviewers \
-              --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
+            POST_OUT=$(gh api repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/requested_reviewers \
+              --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]' 2>&1 || true)
+            COPILOT_ADDED=$(printf '%s' "$POST_OUT" \
+              | jq -r '[.requested_reviewers[]?.login] | map(select(. == "Copilot" or . == "copilot-pull-request-reviewer")) | length' 2>/dev/null || echo "0")
+            if [ "${COPILOT_ADDED:-0}" -eq 0 ]; then
+              # GITHUB_TOKEN silently dropped the request — surface it loudly.
+              gh pr comment ${{ env.PR_NUMBER }} \
+                --body "⚠️ **AI Factory**: Requested Copilot review but the API returned no reviewer (likely a token-permissions issue). **Copilot has NOT been requested.** cc @alvarolobato."
+            fi
             ```
+            Do NOT claim Copilot has reviewed the PR unless you can see an actual review from `Copilot` / `copilot-pull-request-reviewer[bot]` in `gh api repos/{owner}/{repo}/pulls/{PR}/reviews`.
 
             ---
 

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -105,10 +105,42 @@ jobs:
         run: |
           LABELS=$(gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}" --jq '[.labels[].name] | join(",")')
           SKIP=false
+          SKIP_REASON=""
+
           if echo ",$LABELS," | grep -q ",ai-legacy-opus-2,"; then
             SKIP=true
+            SKIP_REASON="legacy-cap-reached"
           fi
+
+          # Claude Code Action's OIDC app-token exchange validates that workflow
+          # files on the PR branch match the default branch. If the PR modifies
+          # any `.github/workflows/*` file, the exchange fails with 401 and the
+          # Claude step hard-errors. Detect that up front and skip cleanly so
+          # PRs that edit workflows don't show a spurious red X.
+          if [ "$SKIP" != "true" ]; then
+            WORKFLOW_CHANGES=$(gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/files" --paginate \
+              --jq '[.[] | select(.filename | startswith(".github/workflows/"))] | length' 2>/dev/null || echo "0")
+            if [ "${WORKFLOW_CHANGES:-0}" -gt 0 ]; then
+              SKIP=true
+              SKIP_REASON="workflow-file-change"
+            fi
+          fi
+
           echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=$SKIP_REASON" >> "$GITHUB_OUTPUT"
+
+      - name: Skip Claude review — PR touches .github/workflows
+        if: steps.cap.outputs.skip == 'true' && steps.cap.outputs.skip_reason == 'workflow-file-change'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
+            --remove-label "ai-ready-for-review" || true
+          # Don't re-request Copilot here — the dispatcher already did. Just
+          # explain why Claude can't review this PR so nobody thinks it failed.
+          MSG="ℹ️ **AI Factory**: Skipping Claude PR review — this PR modifies files under \`.github/workflows/\`. The Claude Code Action's OIDC app-token exchange validates that workflow files on the PR branch match \`main\`, so self-reviewing a workflow change is blocked by design. **Copilot review still runs** (no such restriction). Merge with human + Copilot review."
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$MSG" || true
 
       - name: Claude PR Review
         if: steps.cap.outputs.skip != 'true'
@@ -156,7 +188,7 @@ jobs:
             --remove-label "ai-blocked" --remove-label "ai-auto-retry" || true
 
       - name: Max automated Opus reviews reached (legacy)
-        if: success() && steps.cap.outputs.skip == 'true'
+        if: success() && steps.cap.outputs.skip == 'true' && steps.cap.outputs.skip_reason == 'legacy-cap-reached'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -245,6 +245,100 @@ jobs:
             echo "Dispatched pr-review for stalled PR #$NUM ($TITLE)"
           done
 
+      - name: Open PRs with no AI PR Review run (cancelled/dropped)
+        run: |
+          set -euo pipefail
+          # The AI PR Review workflow uses a global `ai-pr-review-global`
+          # concurrency group (to serialise Opus reviews and stay under
+          # Anthropic's rate limit). When a burst of PRs opens simultaneously,
+          # GitHub keeps the in-progress run + the *latest* queued run and
+          # CANCELS everything in between. Those PRs are then missing
+          # `ai-phase-copilot`, `ai-phase-opus`, `ai-awaiting-owner`, etc. —
+          # they look "unreviewed" with no label trail to re-enter the flow.
+          #
+          # This step finds open PRs with NO pr-review phase labels and NO
+          # successful pr-review run in their history, and re-dispatches the
+          # review explicitly. Cap at MAX_COLD_RETRIES per PR to avoid loops.
+          MIN_PR_AGE_SECS=300   # 5 min — give the event-driven trigger a chance
+          MAX_COLD_RETRIES=3
+
+          PRS=$(gh pr list --repo "$REPO_FULL" --state open \
+            --json number,title,headRefName,headRefOid,createdAt,labels --limit 50)
+
+          echo "$PRS" | jq -c '.[]' | while read -r pr; do
+            NUM=$(echo "$pr" | jq -r '.number')
+            TITLE=$(echo "$pr" | jq -r '.title')
+            HEAD_SHA=$(echo "$pr" | jq -r '.headRefOid')
+            HEAD_BRANCH=$(echo "$pr" | jq -r '.headRefName')
+            CREATED_AT=$(echo "$pr" | jq -r '.createdAt')
+            LABELS=$(echo "$pr" | jq -r '[.labels[].name] | join(",")')
+
+            # Any label that proves pr-review already progressed on this PR.
+            for HAS in ai-ready-for-review ai-phase-copilot ai-phase-opus \
+                       ai-awaiting-owner ai-ci-failing ai-blocked \
+                       no-pr-review; do
+              if echo ",$LABELS," | grep -q ",$HAS,"; then
+                echo "PR #$NUM has '$HAS' — pr-review flow already handled it, skipping."
+                continue 2
+              fi
+            done
+
+            # Give the event-driven trigger a grace period.
+            NOW=$(date -u +%s)
+            CREATED_TS=$(date -u -d "$CREATED_AT" +%s 2>/dev/null || echo 0)
+            AGE=$(( NOW - CREATED_TS ))
+            if [ "$AGE" -lt "$MIN_PR_AGE_SECS" ]; then
+              echo "PR #$NUM is only ${AGE}s old — too soon, skipping."
+              continue
+            fi
+
+            # Is there any non-cancelled pr-review run for this PR's branch or sha?
+            # ai-pr-review runs keyed by pull_request event carry head_branch/head_sha;
+            # workflow_dispatch runs carry the PR number in inputs.pr_number.
+            RUNS_JSON=$(gh api \
+              "repos/$REPO_FULL/actions/workflows/ai-pr-review.yml/runs?per_page=100" \
+              --jq '.workflow_runs' 2>/dev/null || echo '[]')
+
+            MATCH_COUNT=$(echo "$RUNS_JSON" | jq --arg sha "$HEAD_SHA" --arg br "$HEAD_BRANCH" --arg num "$NUM" '
+              [ .[] | select(
+                .conclusion != "cancelled" and
+                (
+                  .head_sha == $sha or
+                  .head_branch == $br or
+                  ((.display_title // "") | test($num))
+                )
+              ) ] | length')
+
+            if [ "${MATCH_COUNT:-0}" != "0" ]; then
+              echo "PR #$NUM has $MATCH_COUNT non-cancelled pr-review run(s) — skipping."
+              continue
+            fi
+
+            # Cap watchdog re-dispatches per PR so a broken review loop can't
+            # hammer the workflow forever. Use a distinct marker from the
+            # stalled-label step above so counts don't collide.
+            COLD_RETRY_COUNT=$(gh api "repos/$REPO_FULL/issues/$NUM/comments" \
+              --paginate \
+              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("🔁 Watchdog: cold-dispatched pr-review")))]  | length' \
+              2>/dev/null || echo "0")
+
+            if [ "$COLD_RETRY_COUNT" -ge "$MAX_COLD_RETRIES" ]; then
+              echo "PR #$NUM hit MAX_COLD_RETRIES ($MAX_COLD_RETRIES) — escalating."
+              gh pr edit "$NUM" --repo "$REPO_FULL" --add-label "ai-blocked" || true
+              gh pr comment "$NUM" --repo "$REPO_FULL" \
+                --body "🚨 @$OWNER_HANDLE — pr-review never ran for this PR (likely cancelled by the global concurrency group) and $MAX_COLD_RETRIES watchdog re-dispatches still produced no completed review. Added \`ai-blocked\`. Please investigate." || true
+              continue
+            fi
+
+            echo "PR #$NUM ($TITLE): no pr-review run found, dispatching."
+            gh workflow run ai-pr-review.yml \
+              --repo "$REPO_FULL" \
+              --field pr_number="$NUM" || true
+            gh pr comment "$NUM" --repo "$REPO_FULL" \
+              --body "🔁 Watchdog: cold-dispatched pr-review (attempt $(( COLD_RETRY_COUNT + 1 )) of $MAX_COLD_RETRIES) — no completed \`ai-pr-review\` run was found for this PR, likely cancelled by the global \`ai-pr-review-global\` concurrency group during a burst of PR opens. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})." || true
+            sleep 15
+          done
+
       - name: Open PRs with unaddressed reviewer feedback
         run: |
           set -euo pipefail

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -370,13 +370,34 @@ jobs:
             --body "✅ AI Worker completed. See PR #${{ steps.verify.outputs.pr_number }}."
           # Automated review: two Copilot rounds first (cheaper), then up to two Opus PR reviews.
           # Do not dispatch Opus immediately — avoids rate limits and reduces token spend.
-          gh pr edit "${{ steps.verify.outputs.pr_number }}" \
-            --add-label "ai-phase-copilot" || true
-          gh api "repos/${{ github.repository }}/pulls/${{ steps.verify.outputs.pr_number }}/requested_reviewers" \
-            --method POST \
-            -f 'reviewers[]=copilot-pull-request-reviewer[bot]' || true
-          gh pr comment "${{ steps.verify.outputs.pr_number }}" \
-            --body "🤖 **AI Factory**: Automated review starts with **Copilot** (round 1 of 2), then Copilot round 2, then up to **two Opus** code reviews. Labels: \`ai-phase-copilot\` → \`ai-phase-opus\`." || true
+          PR_NUM="${{ steps.verify.outputs.pr_number }}"
+          REPO_NAME="${{ github.repository }}"
+
+          # Self-heal: phase labels must exist in the repo for the state machine to advance.
+          gh label create "ai-phase-copilot" --color "0052cc" --description "AI Factory: Copilot review in progress" 2>/dev/null || true
+          gh label create "ai-phase-opus" --color "6f42c1" --description "AI Factory: Opus review in progress" 2>/dev/null || true
+
+          gh pr edit "$PR_NUM" --add-label "ai-phase-copilot" || true
+
+          # Request Copilot and verify the request actually landed — GITHUB_TOKEN
+          # sometimes silently drops Copilot reviewer requests (returns 200 but
+          # with an empty requested_reviewers array). We must not claim Copilot
+          # review was requested when the API silently ignored us.
+          POST_OUT=$(gh api "repos/$REPO_NAME/pulls/$PR_NUM/requested_reviewers" \
+            --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]' 2>&1 || true)
+          COPILOT_ADDED=$(printf '%s' "$POST_OUT" \
+            | jq -r '[.requested_reviewers[]?.login] | map(select(. == "Copilot" or . == "copilot-pull-request-reviewer")) | length' 2>/dev/null || echo "0")
+
+          if [ "${COPILOT_ADDED:-0}" -gt 0 ]; then
+            gh pr comment "$PR_NUM" \
+              --body "🤖 **AI Factory**: Automated review starts with **Copilot** (round 1 of 2), then Copilot round 2, then up to **two Opus** code reviews. Labels: \`ai-phase-copilot\` → \`ai-phase-opus\`." || true
+          else
+            # Silent failure — don't advertise a review cycle that didn't start.
+            gh pr edit "$PR_NUM" --add-label "ai-blocked" || true
+            gh pr comment "$PR_NUM" \
+              --body "⚠️ **AI Factory**: Requested Copilot review but the API returned no reviewer (likely a permissions issue with \`GITHUB_TOKEN\` — it can't assign Copilot). **Copilot review has NOT started.** cc @alvarolobato — please request Copilot review manually via the PR sidebar or ensure workflows can assign \`copilot-pull-request-reviewer[bot]\`." || true
+            echo "::warning::Copilot reviewer request silently failed on PR #$PR_NUM"
+          fi
 
       - name: Handle success (issue closed deliberately)
         if: always() && steps.verify.outputs.outcome == 'issue_closed'


### PR DESCRIPTION
## Summary

Three connected bugs caused the AI Factory to falsely mark PRs `ai-awaiting-owner` when only `claude[bot]` had ever reviewed them (see #237, #238, #241, #242, #243 — all converged without any real Copilot or human review).

- **Phase labels were missing**: `ai-phase-copilot`, `ai-phase-opus`, `ai-cp-after-1/2`, `ai-o-after-1/2`, `ai-legacy-opus-1/2` didn't exist in the repo. `gh pr edit --add-label ai-phase-copilot` failed silently and the phased state machine in `ai-address-feedback.yml` never advanced past the legacy branch. Labels now exist; workers also self-heal via `gh label create … || true`.
- **Copilot reviewer request silently dropped**: `gh api …/requested_reviewers -f 'reviewers[]=copilot-pull-request-reviewer[bot]' \|\| true` from the workflow `GITHUB_TOKEN` returns 200 with an empty `requested_reviewers` array — Copilot never gets assigned, but the workflow went on to post a comment advertising that Copilot review had started. Both `ai-worker.yml` "Handle success" and the round-2 hop in `ai-address-feedback.yml` now parse the POST response; if no reviewer was added, they add `ai-blocked` and ping @alvarolobato instead.
- **`owner_handoff_or_ci_gate()` didn't verify real reviews**: added `ai-awaiting-owner` unconditionally even when no reviewer had ever submitted a review. Now gated by `has_real_review` (counts non-`claude[bot]`, non-`github-actions[bot]` reviews); if none exist, re-requests Copilot or escalates instead of converging.
- **`ai-pr-review.yml` Claude prompt**: now verifies the Copilot POST landed and must not claim Copilot reviewed unless an actual review exists on the PR.

Also adds a new watchdog recovery step for PRs whose `ai-pr-review.yml` run was cancelled by the global concurrency group (from merged PR #240 conversation — carried forward here since the original branch was already merged).

## Test plan

- [ ] Labels exist in repo (already created out-of-band): `gh label list | grep ai-phase`
- [ ] Dispatch a fresh worker run on a test issue and confirm `ai-phase-copilot` label is added and comment says "Copilot review starts…"
- [ ] Confirm `converge_comment` now posts the ⏳/🔁/⚠️ guarded message instead of ✅ when no real review exists
- [ ] Watchdog cold-dispatches `ai-pr-review.yml` for PRs whose run was cancelled (>5 min old, no phase labels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)