### PR TITLE
Fix ETL monitoring schema drift and surface per-table error_msg

### DIFF
--- a/etl/db/postgres.py
+++ b/etl/db/postgres.py
@@ -415,6 +415,9 @@ def record_table_sync(
     finished_at: datetime | None = None,
     sync_method: str | None = None,
     rows_total_after: int | None = None,
+    watermark_from: datetime | None = None,
+    watermark_to: datetime | None = None,
+    error_msg: str | None = None,
 ) -> None:
     """Insert a per-table sync record into etl_sync_run_tables."""
     try:
@@ -423,8 +426,9 @@ def record_table_sync(
                 """
                 INSERT INTO etl_sync_run_tables
                     (run_id, table_name, rows_synced, duration_ms, status,
-                     started_at, finished_at, sync_method, rows_total_after)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                     started_at, finished_at, sync_method, rows_total_after,
+                     watermark_from, watermark_to, error_msg)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
                     run_id,
@@ -436,6 +440,9 @@ def record_table_sync(
                     finished_at,
                     sync_method,
                     rows_total_after,
+                    watermark_from,
+                    watermark_to,
+                    error_msg,
                 ),
             )
         conn.commit()

--- a/etl/main.py
+++ b/etl/main.py
@@ -67,25 +67,30 @@ def _run_sync(
     from etl.db.postgres import get_watermark, set_watermark
 
     start = time.time()
+    started_at = datetime.now(timezone.utc)
     rows = 0
     ok = True
     duration_ms = 0
+    err: str | None = None
+    wm_from: datetime | None = None
+    wm_to: datetime | None = None
     try:
         if uses_watermark:
             since = get_watermark(conn_pg, name)
+            wm_from = since
             rows = sync_fn(conn_4d, conn_pg, since)
         else:
             rows = sync_fn(conn_4d, conn_pg)
         duration_ms = int((time.time() - start) * 1000)
-        set_watermark(conn_pg, name, datetime.now(timezone.utc), rows, "ok")
+        wm_to = datetime.now(timezone.utc)
+        set_watermark(conn_pg, name, wm_to, rows, "ok")
         logger.info("%s rows=%d duration_ms=%d", name, rows, duration_ms)
     except Exception as exc:
         duration_ms = int((time.time() - start) * 1000)
         ok = False
+        err = str(exc)
         try:
-            set_watermark(
-                conn_pg, name, datetime.now(timezone.utc), 0, "error", str(exc)
-            )
+            set_watermark(conn_pg, name, datetime.now(timezone.utc), 0, "error", err)
         except Exception as wm_exc:
             logger.error("Failed to write error watermark for %s: %s", name, wm_exc)
         logger.error("%s FAILED duration_ms=%d: %s", name, duration_ms, exc)
@@ -101,6 +106,12 @@ def _run_sync(
                 rows,
                 duration_ms,
                 status="ok" if ok else "failed",
+                started_at=started_at,
+                finished_at=datetime.now(timezone.utc),
+                sync_method="upsert_delta" if uses_watermark else None,
+                watermark_from=wm_from,
+                watermark_to=wm_to,
+                error_msg=err,
             )
         except Exception as mon_exc:
             logger.error(

--- a/etl/main.py
+++ b/etl/main.py
@@ -82,13 +82,15 @@ def _run_sync(
         else:
             rows = sync_fn(conn_4d, conn_pg)
         duration_ms = int((time.time() - start) * 1000)
-        wm_to = datetime.now(timezone.utc)
-        set_watermark(conn_pg, name, wm_to, rows, "ok")
+        now = datetime.now(timezone.utc)
+        if uses_watermark:
+            wm_to = now
+        set_watermark(conn_pg, name, now, rows, "ok")
         logger.info("%s rows=%d duration_ms=%d", name, rows, duration_ms)
     except Exception as exc:
         duration_ms = int((time.time() - start) * 1000)
         ok = False
-        err = str(exc)
+        err = str(exc)[:2000]
         wm_to = datetime.now(timezone.utc)
         try:
             set_watermark(conn_pg, name, wm_to, 0, "error", err)
@@ -109,7 +111,7 @@ def _run_sync(
                 status="ok" if ok else "failed",
                 started_at=started_at,
                 finished_at=datetime.now(timezone.utc),
-                sync_method="upsert_delta" if uses_watermark else None,
+                sync_method="upsert_delta" if uses_watermark else "full_refresh",
                 watermark_from=wm_from,
                 watermark_to=wm_to,
                 error_msg=err,

--- a/etl/main.py
+++ b/etl/main.py
@@ -89,8 +89,9 @@ def _run_sync(
         duration_ms = int((time.time() - start) * 1000)
         ok = False
         err = str(exc)
+        wm_to = datetime.now(timezone.utc)
         try:
-            set_watermark(conn_pg, name, datetime.now(timezone.utc), 0, "error", err)
+            set_watermark(conn_pg, name, wm_to, 0, "error", err)
         except Exception as wm_exc:
             logger.error("Failed to write error watermark for %s: %s", name, wm_exc)
         logger.error("%s FAILED duration_ms=%d: %s", name, duration_ms, exc)

--- a/etl/schema/init.sql
+++ b/etl/schema/init.sql
@@ -452,8 +452,15 @@ CREATE TABLE IF NOT EXISTS etl_sync_run_tables (
     status           TEXT         NOT NULL DEFAULT 'ok',
     rows_synced      INTEGER,
     sync_method      TEXT,
-    rows_total_after INTEGER
+    rows_total_after INTEGER,
+    watermark_from   TIMESTAMPTZ,
+    watermark_to     TIMESTAMPTZ,
+    error_msg        TEXT
 );
+
+ALTER TABLE etl_sync_run_tables ADD COLUMN IF NOT EXISTS watermark_from TIMESTAMPTZ;
+ALTER TABLE etl_sync_run_tables ADD COLUMN IF NOT EXISTS watermark_to   TIMESTAMPTZ;
+ALTER TABLE etl_sync_run_tables ADD COLUMN IF NOT EXISTS error_msg      TEXT;
 
 -- ============================================================
 -- Unique constraints required by wholesale FK targets

--- a/etl/tests/test_monitoring.py
+++ b/etl/tests/test_monitoring.py
@@ -220,3 +220,8 @@ def test_record_table_sync_status_on_failure():
     assert articulos_calls, "record_table_sync was not called for articulos"
     status_arg = articulos_calls[0].kwargs["status"]
     assert status_arg == "failed", f"Expected status=failed, got {status_arg!r}"
+    error_msg_arg = articulos_calls[0].kwargs.get("error_msg")
+    assert error_msg_arg is not None, "error_msg should not be None for failed sync"
+    assert "simulated articulos error" in error_msg_arg, (
+        f"Expected exception text in error_msg, got {error_msg_arg!r}"
+    )

--- a/etl/tests/test_run_tracking.py
+++ b/etl/tests/test_run_tracking.py
@@ -134,18 +134,69 @@ class TestRecordTableSync:
             )
             with pg_conn.cursor() as cur:
                 cur.execute(
-                    "SELECT table_name, status, rows_synced, sync_method, rows_total_after "
+                    "SELECT table_name, status, rows_synced, sync_method, rows_total_after,"
+                    " watermark_from, watermark_to, error_msg "
                     "FROM etl_sync_run_tables WHERE run_id = %s",
                     (run_id,),
                 )
                 rows = cur.fetchall()
             assert len(rows) == 1
-            table_name, status, rows_synced, sync_method, rows_total = rows[0]
+            (
+                table_name,
+                status,
+                rows_synced,
+                sync_method,
+                rows_total,
+                wm_from,
+                wm_to,
+                error_msg,
+            ) = rows[0]
             assert table_name == "ps_ventas"
             assert status == "success"
             assert rows_synced == 1234
             assert sync_method == "upsert_delta"
             assert rows_total == 911000
+            assert wm_from is None
+            assert wm_to is None
+            assert error_msg is None
+        finally:
+            _cleanup_run(pg_conn, run_id)
+
+    @_requires_monitoring
+    def test_record_table_sync_failure_row_with_new_fields(self, pg_conn):
+        """record_table_sync persists watermark_from, watermark_to, and error_msg for failed rows."""
+        _apply_monitoring_schema(pg_conn)
+        run_id = postgres.create_run(pg_conn, "scheduled")
+        try:
+            wm_from = datetime.now(timezone.utc)
+            wm_to = datetime.now(timezone.utc)
+            postgres.record_table_sync(
+                pg_conn,
+                run_id=run_id,
+                table_name="ps_ventas",
+                started_at=wm_from,
+                finished_at=wm_to,
+                duration_ms=500,
+                status="failed",
+                rows_synced=0,
+                sync_method="upsert_delta",
+                rows_total_after=None,
+                watermark_from=wm_from,
+                watermark_to=wm_to,
+                error_msg="simulated failure",
+            )
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    "SELECT watermark_from, watermark_to, error_msg "
+                    "FROM etl_sync_run_tables WHERE run_id = %s",
+                    (run_id,),
+                )
+                rows = cur.fetchall()
+            assert len(rows) == 1
+            db_wm_from, db_wm_to, db_error_msg = rows[0]
+            assert db_wm_from is not None
+            assert db_wm_to is not None
+            assert db_error_msg == "simulated failure"
         finally:
             _cleanup_run(pg_conn, run_id)
 


### PR DESCRIPTION
## Summary
The ETL run detail page (`/etl/[id]`) crashed with `column "watermark_from" does not exist` because the dashboard route selects `watermark_from, watermark_to, error_msg` from `etl_sync_run_tables`, but those columns were never defined in `init.sql` nor written by `record_table_sync()`.

This PR closes the drift and wires error capture end-to-end so failing tables surface a human-readable message in the UI.

## Changes
- **`etl/schema/init.sql`**: add `watermark_from`, `watermark_to`, `error_msg` to `etl_sync_run_tables` (both in `CREATE TABLE` and as idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for existing databases).
- **`etl/db/postgres.py` — `record_table_sync()`**: accept and persist the three new fields.
- **`etl/main.py` — `_run_one()`**: capture the exception text and the delta window (`wm_from` / `wm_to`) so failed tables get an error message and `upsert_delta` rows get their watermarks recorded. Also now passes `started_at`, `finished_at`, and `sync_method`, which were already supported by `record_table_sync` but never sent.

## Rollout note
The ALTER TABLE has already been applied to the running local database so the UI is unblocked immediately. The existing failed `articulos` row from run #1 was backfilled from `etl_watermarks.error_msg` in a one-off UPDATE — no code is needed for that.

## Test plan
- [x] ETL monitor page loads without 500 (verified locally — refresh `/etl/1`).
- [x] Failed table row in the detail page shows the real error text (FK constraint message).
- [ ] Next ETL run writes `watermark_from/to` and `error_msg` directly via the code path (no backfill needed).
- [ ] Copilot review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)