### PR TITLE
Coerce 0-valued catalog FKs to NULL on articulos sync

### DIFF
--- a/etl/sync/articulos.py
+++ b/etl/sync/articulos.py
@@ -84,6 +84,29 @@ def _map_row(source: dict[str, Any], mapping: dict[str, str]) -> dict[str, Any]:
     return result
 
 
+# PG column names on ps_articulos that point to catalog dimension tables via FK.
+# 4D stores "not assigned" as 0, but the catalog tables have no reg_* = 0 row —
+# coerce 0 → NULL so rows with no brand/family/etc don't violate FK constraints.
+_ARTICULOS_NULLABLE_FKS: frozenset[str] = frozenset(
+    {
+        "num_familia",
+        "num_departament",
+        "num_color",
+        "num_temporada",
+        "num_marca",
+    }
+)
+
+
+def _nullify_zero_fks(row: dict[str, Any]) -> dict[str, Any]:
+    """Replace 0 with None for optional FK columns in a mapped articulos row."""
+    for key in _ARTICULOS_NULLABLE_FKS:
+        value = row.get(key)
+        if value is not None and value == 0:
+            row[key] = None
+    return row
+
+
 # ---------------------------------------------------------------------------
 # Column mapping: 4D lowercase name → PostgreSQL column name
 # ---------------------------------------------------------------------------
@@ -245,7 +268,7 @@ def sync_articulos(conn_4d: Any, conn_pg: Any) -> int:
     from etl.db.postgres import truncate_and_insert
 
     raw_rows = safe_fetch(conn_4d, _SQL_ARTICULOS)
-    pg_rows = [_map_row(r, _ARTICULOS_MAPPING) for r in raw_rows]
+    pg_rows = [_nullify_zero_fks(_map_row(r, _ARTICULOS_MAPPING)) for r in raw_rows]
     count = truncate_and_insert(conn_pg, "ps_articulos", pg_rows)
 
     # Safety net: remove any MA rows that survived from a previous sync run

--- a/etl/tests/test_sync_articulos.py
+++ b/etl/tests/test_sync_articulos.py
@@ -13,6 +13,7 @@ What is tested:
 from __future__ import annotations
 
 import os
+from decimal import Decimal
 
 import pytest
 
@@ -167,3 +168,71 @@ class TestSyncArticulos:
             f"Only {non_empty}/{total} ({ratio:.1%}) rows have a non-empty"
             " ccrefejofacm.  Expected >= 90%."
         )
+
+
+class TestNullifyZeroFks:
+    """Unit tests for _nullify_zero_fks — no external connections needed.
+
+    4D uses 0 to mean "no brand/family/etc assigned", but the catalog tables
+    have no reg_* = 0 row, so those 0s must become NULL before insert or the
+    FK constraint rejects the row.
+    """
+
+    def test_zero_int_fks_become_none(self):
+        from etl.sync.articulos import _nullify_zero_fks
+
+        row = {
+            "reg_articulo": 123,
+            "num_familia": 0,
+            "num_departament": 0,
+            "num_color": 0,
+            "num_temporada": 0,
+            "num_marca": 0,
+            "num_proveedor": 0,
+        }
+        result = _nullify_zero_fks(row)
+        assert result["num_familia"] is None
+        assert result["num_departament"] is None
+        assert result["num_color"] is None
+        assert result["num_temporada"] is None
+        assert result["num_marca"] is None
+        # num_proveedor has no FK, must not be touched
+        assert result["num_proveedor"] == 0
+        # PK and unrelated fields untouched
+        assert result["reg_articulo"] == 123
+
+    def test_zero_decimal_fks_become_none(self):
+        from etl.sync.articulos import _nullify_zero_fks
+
+        row = {
+            "num_familia": Decimal("0"),
+            "num_marca": Decimal("0.000"),
+        }
+        result = _nullify_zero_fks(row)
+        assert result["num_familia"] is None
+        assert result["num_marca"] is None
+
+    def test_nonzero_fks_preserved(self):
+        from etl.sync.articulos import _nullify_zero_fks
+
+        row = {
+            "num_familia": Decimal("12.99"),
+            "num_departament": Decimal("3.99"),
+            "num_color": Decimal("45.99"),
+            "num_temporada": Decimal("7.99"),
+            "num_marca": Decimal("100.99"),
+        }
+        result = _nullify_zero_fks(row)
+        assert result["num_familia"] == Decimal("12.99")
+        assert result["num_departament"] == Decimal("3.99")
+        assert result["num_color"] == Decimal("45.99")
+        assert result["num_temporada"] == Decimal("7.99")
+        assert result["num_marca"] == Decimal("100.99")
+
+    def test_existing_none_preserved(self):
+        from etl.sync.articulos import _nullify_zero_fks
+
+        row = {"num_familia": None, "num_marca": None}
+        result = _nullify_zero_fks(row)
+        assert result["num_familia"] is None
+        assert result["num_marca"] is None


### PR DESCRIPTION
## Summary
- Null-coerce `num_familia`, `num_departament`, `num_color`, `num_temporada`, `num_marca` when the 4D source gives `0` ("not assigned"). The catalog dimension tables have no `reg_* = 0` row, so these 0s were violating `fk_art_*` constraints and failing the nightly `articulos` sync.
- Added a unit-test class `TestNullifyZeroFks` that doesn't need a live 4D/PG connection, so the coercion is covered in CI.

## Context
Observed last night: `sync_articulos` failed with
`Key (num_marca)=(0.000) is not present in table "ps_marcas"`. Same
pattern applies to the four other optional catalog FKs. `num_proveedor`
has no FK and is intentionally left alone.

## Test plan
- [x] `ruff format` + `ruff check` clean on changed files
- [x] `pytest etl/tests/test_sync_articulos.py::TestNullifyZeroFks` — 4/4 pass locally
- [ ] Next nightly ETL run (or manual `ps etl run`) succeeds on articulos

🤖 Generated with [Claude Code](https://claude.com/claude-code)