### PR TITLE
Load catalogos before articulos to prevent cascade wipe

### DIFF
--- a/etl/main.py
+++ b/etl/main.py
@@ -266,8 +266,11 @@ def run_full_sync(conn_4d, conn_pg) -> None:
     # ------------------------------------------------------------------
     # 1. Catalog (full refresh, no watermark)
     # ------------------------------------------------------------------
-    _s("articulos", sync_articulos)
+    # Load catalogos BEFORE articulos: truncate_and_insert uses TRUNCATE ...
+    # CASCADE, and ps_articulos has FKs to all five catalog tables.  If
+    # articulos ran first, the next catalog truncate would cascade-wipe it.
     _s("catalogos", _run_sync_catalogos)
+    _s("articulos", sync_articulos)
 
     # ------------------------------------------------------------------
     # 2. Masters (full refresh, no watermark)

--- a/etl/tests/test_monitoring.py
+++ b/etl/tests/test_monitoring.py
@@ -12,8 +12,8 @@ from unittest.mock import MagicMock, patch
 
 _WM_MODULE = "etl.db.postgres"
 _SYNC_TARGETS = [
-    "etl.sync.articulos.sync_articulos",
     "etl.sync.articulos.sync_catalogos",
+    "etl.sync.articulos.sync_articulos",
     "etl.sync.maestros.sync_tiendas",
     "etl.sync.maestros.sync_clientes",
     "etl.sync.maestros.sync_proveedores",

--- a/etl/tests/test_run_tracking.py
+++ b/etl/tests/test_run_tracking.py
@@ -183,8 +183,8 @@ class TestPartialStatus:
 # Keep in sync with run_full_sync in etl/main.py
 _WM_MODULE = "etl.db.postgres"
 _SYNC_TARGETS = [
-    "etl.sync.articulos.sync_articulos",
     "etl.sync.articulos.sync_catalogos",
+    "etl.sync.articulos.sync_articulos",
     "etl.sync.maestros.sync_tiendas",
     "etl.sync.maestros.sync_clientes",
     "etl.sync.maestros.sync_proveedores",

--- a/etl/tests/test_scheduler.py
+++ b/etl/tests/test_scheduler.py
@@ -23,8 +23,8 @@ _WM_MODULE = "etl.db.postgres"
 # All sync targets that must be patched in every test, keyed by dotted path.
 # Order matches the pipeline in etl/main.py run_full_sync().
 _SYNC_TARGETS = [
-    "etl.sync.articulos.sync_articulos",
     "etl.sync.articulos.sync_catalogos",
+    "etl.sync.articulos.sync_articulos",
     "etl.sync.maestros.sync_tiendas",
     "etl.sync.maestros.sync_clientes",
     "etl.sync.maestros.sync_proveedores",
@@ -111,9 +111,10 @@ def test_sync_order():
         run_full_sync(conn_4d, conn_pg)
 
     expected_order = [
-        # Catalog
-        "sync_articulos",
+        # Catalog — catalogos first so TRUNCATE CASCADE on catalog tables
+        # doesn't wipe ps_articulos (which FKs into all five catalogs).
         "sync_catalogos",
+        "sync_articulos",
         # Masters
         "sync_tiendas",
         "sync_clientes",


### PR DESCRIPTION
## Summary
- Swap the order of `sync_catalogos` and `sync_articulos` in `run_full_sync` so catalogos loads first.
- Reason: `truncate_and_insert` uses `TRUNCATE ... CASCADE`, and `ps_articulos` has FKs to all five catalog tables. With articulos running first, every subsequent catalog truncate cascade-wiped `ps_articulos`, leaving it empty at end-of-sync (observed as `ps_articulos=0` in the post-sync row totals even though `articulos rows=40796` had just succeeded).
- Previously masked by the articulos FK violation fixed in #261; exposed once articulos started succeeding cleanly.
- Updated the three pipeline-order fixtures/assertions in `test_scheduler.py`, `test_monitoring.py`, `test_run_tracking.py` to match the new order.

## Test plan
- [x] `pytest etl/tests/test_scheduler.py` — 5/5 pass, including `test_sync_order`
- [x] `pytest etl/tests/test_scheduler.py etl/tests/test_monitoring.py etl/tests/test_run_tracking.py etl/tests/test_sync_articulos.py` — 13 passed (4 errors are preexisting psycopg2-missing environment issues, unrelated)
- [x] `ruff format` + `ruff check` clean on changed files
- [ ] Next ETL run reports non-zero `ps_articulos` in post-sync totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)