### PR TITLE
fix(release-beta): avoid SIGPIPE in changelog step

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -118,7 +118,9 @@ jobs:
             if [ -n "${LAST_TAG:-}" ]; then
               echo "Changes since \`${LAST_TAG}\`:"
               echo
-              git log "${LAST_TAG}..HEAD" --pretty=format:'- %s (%h)' --no-merges | head -n 50
+              # Use --max-count (not `| head`) so we don't SIGPIPE git under
+              # `set -o pipefail` when there are more than 50 commits.
+              git log "${LAST_TAG}..HEAD" --max-count=50 --pretty=format:'- %s (%h)' --no-merges
               echo
               echo
               echo "**Full diff**: https://github.com/${{ github.repository }}/compare/${LAST_TAG}...${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## Summary
- `git log ... | head -n 50` triggered SIGPIPE (exit 141) under `set -o pipefail` when the commit range has >50 entries.
- Observed in [release-beta run 24608669353](https://github.com/alvarolobato/powershop-analytics/actions/runs/24608669353): 326 commits between `v0.1.0` and `main`.
- Replace `| head -n 50` with `git log --max-count=50` (same output, no pipeline).

## Test plan
- [ ] Re-run `release-beta.yml` (workflow_dispatch) after merge — step "Build changelog" must succeed and produce the beta release + tag.
- [ ] Confirm `release-docker.yml` fires on the new release and pushes `:v0.1.0-beta.N` + `:beta` tags to Docker Hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)