### PR TITLE
fix(release/install): Docker image matrix, release assets, macOS install

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,9 +1,11 @@
 # Nightly beta release — creates a GitHub prerelease tag (vX.Y.Z-beta.N) if
 # there are commits since the last tag. Also triggerable manually.
 #
-# The created prerelease triggers release-docker.yml, which builds & pushes
-# powershop-etl and powershop-dashboard images tagged with the version and
-# the rolling `:beta` tag.
+# After creating the release, this workflow explicitly dispatches
+# release-docker.yml to build and push the ETL + Dashboard images. We
+# can't rely on the `release: published` trigger because releases created
+# by GITHUB_TOKEN inside a workflow intentionally do NOT fire downstream
+# workflow events (GitHub recursion guard).
 name: Release Beta
 
 on:
@@ -24,6 +26,7 @@ on:
 
 permissions:
   contents: write
+  actions: write  # needed to dispatch release-docker.yml after publishing
 
 concurrency:
   group: release-beta
@@ -130,14 +133,35 @@ jobs:
           } > "$NOTES"
           echo "path=$NOTES" >> "$GITHUB_OUTPUT"
 
-      - name: Create prerelease
+      - name: Create prerelease with deploy assets
         if: steps.version.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
-          gh release create "${{ steps.version.outputs.tag }}" \
-            --title "${{ steps.version.outputs.tag }} (beta)" \
+          # `docker-compose.prod.yml` and `wren-config.yaml` are the two
+          # files install-prod.sh downloads per release — attach them so
+          # installers don't need to clone the repo at exactly the right
+          # commit.
+          gh release create "$TAG" \
+            --title "$TAG (beta)" \
             --notes-file "${{ steps.changelog.outputs.path }}" \
             --target "${{ github.event.repository.default_branch }}" \
-            --prerelease
+            --prerelease \
+            docker-compose.prod.yml \
+            wren-config.yaml
+
+      - name: Dispatch release-docker.yml
+        if: steps.version.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Releases created by GITHUB_TOKEN do not fire the `release:
+          # published` event, so we dispatch release-docker.yml directly.
+          gh workflow run release-docker.yml \
+            --ref "${{ github.event.repository.default_branch }}" \
+            --field "tag=$TAG"
+          echo "Dispatched release-docker.yml for $TAG."

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -6,12 +6,23 @@
 #   - Prereleases also get the rolling `:beta` tag.
 #   - Stable releases (non-prerelease) also get the rolling `:latest` tag.
 #
+# Can also be invoked manually via workflow_dispatch with a release tag —
+# this is the trigger release-beta.yml uses, because releases created from
+# within a workflow by GITHUB_TOKEN don't fire the `release: published`
+# event (GitHub recursion guard).
+#
 # Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN
 name: Release Docker Images
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to (re)build images for (e.g. v0.1.0-beta.2)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -30,7 +41,35 @@ jobs:
             context: ./dashboard
             dockerfile: ./dashboard/Dockerfile
     steps:
-      - uses: actions/checkout@v4
+      - name: Resolve release metadata
+        id: rel
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          EVENT_PRERELEASE: ${{ github.event.release.prerelease }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+            # gh release view prints "true"/"false" for isPrerelease
+            PRERELEASE=$(gh release view "$TAG" --repo "${{ github.repository }}" --json isPrerelease --jq '.isPrerelease')
+          else
+            TAG="$EVENT_TAG"
+            PRERELEASE="$EVENT_PRERELEASE"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=${PRERELEASE}" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=${TAG} prerelease=${PRERELEASE}"
+
+      - name: Check out the release ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.rel.outputs.tag }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -44,8 +83,8 @@ jobs:
       - name: Compute tags
         id: tags
         env:
-          VERSION: ${{ github.event.release.tag_name }}
-          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+          VERSION: ${{ steps.rel.outputs.tag }}
+          IS_PRERELEASE: ${{ steps.rel.outputs.prerelease }}
           NAMESPACE: ${{ secrets.DOCKERHUB_USERNAME }}
           IMAGE: ${{ matrix.image }}
         run: |
@@ -72,6 +111,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           provenance: false

--- a/deploy/install-prod.sh
+++ b/deploy/install-prod.sh
@@ -12,7 +12,9 @@
 #   curl -fsSL https://raw.githubusercontent.com/alvarolobato/powershop-analytics/main/deploy/install-prod.sh | bash
 #
 # Environment overrides:
-#   PS_PROD_HOME      — installation directory (default: /opt/powershop)
+#   PS_PROD_HOME      — installation directory. Default: $HOME/powershop on
+#                       macOS (Docker Desktop, no sudo), /opt/powershop on
+#                       Linux (FHS, requires sudo for the parent dir).
 #   VERSION           — release tag to pin (default: latest prerelease for beta
 #                       channel, latest stable release for stable channel)
 #   CHANNEL           — 'beta' (default) or 'stable'. Sets ETL_VERSION /
@@ -26,10 +28,22 @@
 set -euo pipefail
 
 REPO="alvarolobato/powershop-analytics"
-PROJECT_DIR="${PS_PROD_HOME:-/opt/powershop}"
 RELEASE_BASE="https://github.com/${REPO}/releases/download"
 API_BASE="https://api.github.com/repos/${REPO}"
 CHANNEL="${CHANNEL:-beta}"
+
+# Default install dir is platform-specific. On Linux we use /opt/powershop
+# (FHS-conventional, requires sudo). On macOS /opt isn't a standard spot
+# for user-installed apps and Docker Desktop runs as the logged-in user —
+# default to $HOME/powershop so the install needs no sudo.
+OS_NAME="$(uname -s)"
+if [ -n "${PS_PROD_HOME:-}" ]; then
+  PROJECT_DIR="$PS_PROD_HOME"
+elif [ "$OS_NAME" = "Darwin" ]; then
+  PROJECT_DIR="${HOME}/powershop"
+else
+  PROJECT_DIR="/opt/powershop"
+fi
 
 info()    { printf '\033[1;34m[INFO]\033[0m  %s\n' "$*"; }
 success() { printf '\033[1;32m[OK]\033[0m    %s\n' "$*"; }
@@ -96,8 +110,21 @@ dotenv_quote() {
 
 check_prerequisites() {
   info "Checking prerequisites..."
-  command -v docker >/dev/null 2>&1 || die "Docker is not installed. See https://docs.docker.com/engine/install/"
+  # Docker Desktop on macOS ships its CLI under /Applications but doesn't
+  # put it on non-login-shell PATH. If `docker` isn't found, look there
+  # before failing.
+  if ! command -v docker >/dev/null 2>&1; then
+    local mac_docker="/Applications/Docker.app/Contents/Resources/bin"
+    if [ -x "${mac_docker}/docker" ]; then
+      export PATH="${mac_docker}:$PATH"
+      info "Using Docker Desktop CLI at ${mac_docker}"
+    else
+      die "Docker is not installed. See https://docs.docker.com/engine/install/"
+    fi
+  fi
   docker compose version >/dev/null 2>&1 || die "'docker compose' v2 is not available."
+  # docker daemon must be up — on macOS this means Docker Desktop is running.
+  docker info >/dev/null 2>&1 || die "Cannot reach the Docker daemon. Start Docker Desktop (macOS) or the docker service (Linux) and retry."
   command -v curl >/dev/null 2>&1 || die "curl is required."
   success "Prerequisites OK"
 }


### PR DESCRIPTION
## Summary
Unblocks the beta deployment pipeline — three fixes uncovered while trying to install `v0.1.0-beta.1` on a macOS target.

### 1. `release-docker.yml` — build & push multi-arch images
- Added `workflow_dispatch` input `tag` so the image workflow can be (re)built for any release and so `release-beta.yml` can dispatch it directly. The `release: published` event [does not fire](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) for releases created by `GITHUB_TOKEN` in another workflow (recursion guard) — which is why `v0.1.0-beta.1` published no images.
- QEMU + `linux/amd64,linux/arm64` so Apple Silicon pulls natively.
- Checkout the release tag (not HEAD) so builds are reproducible per release.

### 2. `release-beta.yml` — attach assets + dispatch image build
- Upload `docker-compose.prod.yml` and `wren-config.yaml` as release assets (install-prod.sh expects to download them per tag).
- After `gh release create`, `gh workflow run release-docker.yml` with the new tag (needs `actions: write`).

### 3. `deploy/install-prod.sh` — macOS support
- Default `PROJECT_DIR` to `$HOME/powershop` on Darwin; keep `/opt/powershop` on Linux.
- Probe `/Applications/Docker.app/Contents/Resources/bin` for the `docker` CLI when it isn't on PATH.
- Fail early with a clear message when the Docker daemon isn't reachable.

## Test plan
- [ ] After merge, `gh workflow run release-beta.yml --field base_version=0.1.0 --field force=true` creates `v0.1.0-beta.2` with both assets attached.
- [ ] `release-docker.yml` runs automatically (dispatched by the beta workflow), produces `:v0.1.0-beta.2` + `:beta` images for `linux/amd64,linux/arm64`.
- [ ] `curl -fsSL .../install-prod.sh | bash` on macOS creates `$HOME/powershop`, downloads the two assets, and docker-compose comes up cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)