### PR TITLE
fix(etl): stock/traspasos COUNT crashes on None-valued driver row

### DIFF
--- a/etl/sync/stock.py
+++ b/etl/sync/stock.py
@@ -131,12 +131,22 @@ def _build_expo_where(since: datetime | None, *, include_nulls: bool = False) ->
 
 
 def _count_expo(conn_4d, where: str) -> int:
-    """Return row count for Exportaciones with given WHERE clause."""
-    sql = f"SELECT COUNT(*) FROM Exportaciones {where}".strip()
+    """Return row count for Exportaciones with given WHERE clause.
+
+    Uses an explicit ``AS cnt`` alias so the returned column key is deterministic
+    across p4d driver versions — bare ``COUNT(*)`` has produced rows whose first
+    value is ``None``, which caused ``int(None)`` to blow up the whole sync. If
+    the driver still returns a row without a usable value, we treat it as 0
+    rather than abort: COUNT is used for progress logging only.
+    """
+    sql = f"SELECT COUNT(*) AS cnt FROM Exportaciones {where}".strip()
     rows = safe_fetch(conn_4d, sql)
-    # safe_fetch returns lowercase keys; COUNT(*) key depends on the 4D driver version.
-    row = rows[0]
-    return int(next(iter(row.values())))
+    if not rows:
+        return 0
+    val = rows[0].get("cnt")
+    if val is None and rows[0]:
+        val = next(iter(rows[0].values()))
+    return int(val) if val is not None else 0
 
 
 def _normalize_expo_row(src: dict) -> list[dict]:
@@ -358,11 +368,19 @@ def _build_traspasos_where(since: datetime | None) -> str:
 
 
 def _count_traspasos(conn_4d, where: str) -> int:
-    """Return row count for Traspasos with given WHERE clause."""
-    sql = f"SELECT COUNT(*) FROM Traspasos {where}".strip()
+    """Return row count for Traspasos with given WHERE clause.
+
+    See ``_count_expo`` for the rationale behind the explicit ``AS cnt`` alias
+    and the None-value fallback.
+    """
+    sql = f"SELECT COUNT(*) AS cnt FROM Traspasos {where}".strip()
     rows = safe_fetch(conn_4d, sql)
-    row = rows[0]
-    return int(next(iter(row.values())))
+    if not rows:
+        return 0
+    val = rows[0].get("cnt")
+    if val is None and rows[0]:
+        val = next(iter(rows[0].values()))
+    return int(val) if val is not None else 0
 
 
 def sync_traspasos(conn_4d, conn_pg, since: datetime | None = None) -> int:

--- a/etl/tests/test_sync_stock.py
+++ b/etl/tests/test_sync_stock.py
@@ -18,6 +18,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from etl.sync.stock import (
+    _count_expo,
+    _count_traspasos,
     _normalize_expo_row,
     _validate_since,
     sync_stock,
@@ -244,6 +246,58 @@ class TestValidateSince:
         """The name parameter is accepted without error."""
         dt = datetime(2026, 3, 15, 10, 0, 0, tzinfo=timezone.utc)
         _validate_since(dt, name="my_param")  # should not raise
+
+
+class TestCountHelpers:
+    """Unit tests for _count_expo / _count_traspasos — no real connection needed.
+
+    Regression coverage for the ``int() argument ... not 'NoneType'`` crash that
+    surfaced on stock/traspasos delta runs when the p4d driver returned a row
+    whose first value was ``None``.  The helpers are used for progress logging
+    only, so they must degrade to 0 instead of aborting the sync.
+    """
+
+    def test_count_expo_reads_cnt_alias(self):
+        conn = MagicMock()
+        with patch("etl.sync.stock.safe_fetch", return_value=[{"cnt": 42}]) as mf:
+            assert _count_expo(conn, "") == 42
+        sql = mf.call_args.args[1]
+        assert "COUNT(*) AS cnt" in sql
+        assert "FROM Exportaciones" in sql
+
+    def test_count_expo_none_value_returns_zero(self):
+        conn = MagicMock()
+        with patch("etl.sync.stock.safe_fetch", return_value=[{"cnt": None}]):
+            assert _count_expo(conn, "") == 0
+
+    def test_count_expo_empty_result_returns_zero(self):
+        conn = MagicMock()
+        with patch("etl.sync.stock.safe_fetch", return_value=[]):
+            assert _count_expo(conn, "") == 0
+
+    def test_count_expo_falls_back_to_first_value_when_alias_missing(self):
+        """Driver quirk: if ``cnt`` key is absent, use the first populated value."""
+        conn = MagicMock()
+        with patch("etl.sync.stock.safe_fetch", return_value=[{"expr_1": 7}]):
+            assert _count_expo(conn, "") == 7
+
+    def test_count_traspasos_reads_cnt_alias(self):
+        conn = MagicMock()
+        with patch("etl.sync.stock.safe_fetch", return_value=[{"cnt": 3}]) as mf:
+            assert _count_traspasos(conn, "") == 3
+        sql = mf.call_args.args[1]
+        assert "COUNT(*) AS cnt" in sql
+        assert "FROM Traspasos" in sql
+
+    def test_count_traspasos_none_value_returns_zero(self):
+        conn = MagicMock()
+        with patch("etl.sync.stock.safe_fetch", return_value=[{"cnt": None}]):
+            assert _count_traspasos(conn, "") == 0
+
+    def test_count_traspasos_empty_result_returns_zero(self):
+        conn = MagicMock()
+        with patch("etl.sync.stock.safe_fetch", return_value=[]):
+            assert _count_traspasos(conn, "") == 0
 
 
 # ---------------------------------------------------------------------------

--- a/etl/tests/test_sync_stock.py
+++ b/etl/tests/test_sync_stock.py
@@ -276,7 +276,7 @@ class TestCountHelpers:
             assert _count_expo(conn, "") == 0
 
     def test_count_expo_falls_back_to_first_value_when_alias_missing(self):
-        """Driver quirk: if ``cnt`` key is absent, use the first populated value."""
+        """Driver quirk: if ``cnt`` key is absent, use the first value in the row."""
         conn = MagicMock()
         with patch("etl.sync.stock.safe_fetch", return_value=[{"expr_1": 7}]):
             assert _count_expo(conn, "") == 7
@@ -298,6 +298,12 @@ class TestCountHelpers:
         conn = MagicMock()
         with patch("etl.sync.stock.safe_fetch", return_value=[]):
             assert _count_traspasos(conn, "") == 0
+
+    def test_count_traspasos_falls_back_to_first_value_when_alias_missing(self):
+        """Driver quirk: if ``cnt`` key is absent, use the first value in the row."""
+        conn = MagicMock()
+        with patch("etl.sync.stock.safe_fetch", return_value=[{"expr_1": 9}]):
+            assert _count_traspasos(conn, "") == 9
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Both `_count_expo` and `_count_traspasos` in `etl/sync/stock.py` called `int(next(iter(row.values())))` against an unaliased `SELECT COUNT(*)`. When the p4d driver returned a row whose first value was `None`, `int(None)` raised `int() argument must be a string, a bytes-like object or a real number, not 'NoneType'` and aborted the whole sync for those tables — visible as `Error` rows on the run-detail page.
- Fixed by adding an explicit `AS cnt` alias (consistent with every other test/module that reads a COUNT) and falling back to `0` on empty result or `None` value. COUNT is used for progress logging only; a missing count should not abort a sync that would otherwise succeed.
- Added 7 unit tests in `TestCountHelpers` covering the normal path, `None` value, empty result set, and the missing-alias fallback for both helpers.

## Why this happened

The original code had a comment acknowledging that "COUNT(*) key depends on the 4D driver version" but only handled the key-name variability, not the `None` value case. The delta queries (`WHERE FechaModifica > {d 'YYYY-MM-DD'}`) reached a state where the driver returned `{'some_key': None}` instead of an integer, and the whole pipeline step tipped over.

## Test plan

- [x] `ruff format` and `ruff check` clean on both files
- [x] `pytest etl/tests/test_sync_stock.py` — all 32 unit tests pass (3 integration tests skipped: no p4d locally)
- [ ] Next scheduled run (or manual `ps etl run`) should show `stock` and `traspasos` as `ok` rather than `Error` on the run-detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)