### PR TITLE
feat(ai-factory): rate-limit-aware watchdog retries

### DIFF
--- a/.github/scripts/detect-rate-limit.sh
+++ b/.github/scripts/detect-rate-limit.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Detect an Anthropic / Claude Code rate-limit in the current workflow run's
+# live job logs. Called from `Handle failure` steps to distinguish a rate-limit
+# failure (retry when it lifts) from a generic transient failure (retry after
+# the watchdog's default wait).
+#
+# Usage: detect-rate-limit.sh RUN_ID [REPO]
+#   RUN_ID — the GitHub Actions run id (${{ github.run_id }})
+#   REPO   — OWNER/REPO; defaults to $GITHUB_REPOSITORY
+#
+# Env:
+#   GH_TOKEN — required; must have `actions: read`
+#
+# Output (stdout, key=value lines) and $GITHUB_OUTPUT when set:
+#   rate_limit_reset_epoch=<unix seconds>
+#   rate_limit_reset_iso=<YYYY-MM-DDTHH:MM:SSZ>
+#
+# If no rate-limit signal is detected, exits 0 silently without writing output.
+# On any infrastructure error (logs not fetchable, unzip missing, etc.) also
+# exits 0 silently so the caller falls back to generic failure handling.
+set -uo pipefail
+
+RUN_ID="${1:-}"
+REPO="${2:-${GITHUB_REPOSITORY:-}}"
+if [ -z "$RUN_ID" ] || [ -z "$REPO" ]; then
+  echo "detect-rate-limit: RUN_ID and REPO required" >&2
+  exit 0
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Fetch logs for every in-progress / completed job of this run. The job logs
+# endpoint returns plaintext even while a job is still running, so we can call
+# it from within the failing job itself.
+JOBS_JSON=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" 2>/dev/null || echo '{}')
+JOB_IDS=$(echo "$JOBS_JSON" \
+  | jq -r '.jobs[]? | select(.status == "in_progress" or .status == "completed") | .id' \
+  2>/dev/null || true)
+
+if [ -z "$JOB_IDS" ]; then
+  exit 0
+fi
+
+: > "$tmpdir/all.log"
+while IFS= read -r JID; do
+  [ -z "$JID" ] && continue
+  gh api "repos/$REPO/actions/jobs/$JID/logs" >> "$tmpdir/all.log" 2>/dev/null || true
+done <<< "$JOB_IDS"
+
+if [ ! -s "$tmpdir/all.log" ]; then
+  exit 0
+fi
+
+reset_epoch=""
+
+# Pattern 1: Claude Code's own human-readable marker embeds an epoch directly.
+#   e.g. "Claude AI usage limit reached|1745608800"
+val=$(grep -ohE 'Claude AI usage limit reached\|[0-9]{9,}' "$tmpdir/all.log" 2>/dev/null \
+  | head -1 | awk -F'|' '{print $2}')
+if [ -n "$val" ]; then
+  reset_epoch="$val"
+fi
+
+# Pattern 2: Anthropic response headers carry an ISO-8601 reset timestamp.
+#   e.g. "anthropic-ratelimit-unified-reset: 2026-04-18T20:15:00Z"
+#        "anthropic-ratelimit-tokens-reset: 2026-04-18T20:15:00Z"
+if [ -z "$reset_epoch" ]; then
+  iso=$(grep -ohiE 'anthropic-ratelimit-[a-z_]+-reset["]?[: ]+[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+Z-]+' \
+        "$tmpdir/all.log" 2>/dev/null \
+    | head -1 | grep -ohE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+Z-]+' | head -1)
+  if [ -n "$iso" ]; then
+    reset_epoch=$(date -u -d "$iso" +%s 2>/dev/null || echo "")
+  fi
+fi
+
+# Pattern 3: HTTP `Retry-After: <seconds>` header (relative).
+if [ -z "$reset_epoch" ]; then
+  sec=$(grep -ohiE 'retry[- ]?after["]?[: ]+[0-9]+' "$tmpdir/all.log" 2>/dev/null \
+    | head -1 | grep -ohE '[0-9]+$')
+  if [ -n "$sec" ]; then
+    reset_epoch=$(( $(date -u +%s) + sec ))
+  fi
+fi
+
+# Pattern 4: JSON error body "retry_after":<seconds>.
+if [ -z "$reset_epoch" ]; then
+  sec=$(grep -ohE '"retry_after"[[:space:]]*:[[:space:]]*[0-9]+' "$tmpdir/all.log" 2>/dev/null \
+    | head -1 | grep -ohE '[0-9]+$')
+  if [ -n "$sec" ]; then
+    reset_epoch=$(( $(date -u +%s) + sec ))
+  fi
+fi
+
+if [ -z "$reset_epoch" ]; then
+  exit 0
+fi
+
+# Sanity-clamp: must be in the future, capped at 12h.
+now=$(date -u +%s)
+if [ "$reset_epoch" -le "$now" ]; then
+  exit 0
+fi
+max=$((now + 43200))
+if [ "$reset_epoch" -gt "$max" ]; then
+  reset_epoch="$max"
+fi
+
+iso=$(date -u -d "@$reset_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+echo "rate_limit_reset_epoch=$reset_epoch"
+echo "rate_limit_reset_iso=$iso"
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "rate_limit_reset_epoch=$reset_epoch"
+    echo "rate_limit_reset_iso=$iso"
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -462,7 +462,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          RESET_LINE=""
+          if out=$(bash .github/scripts/detect-rate-limit.sh "${{ github.run_id }}" "${{ github.repository }}" 2>/dev/null); then
+            RESET_ISO=$(echo "$out" | awk -F= '/^rate_limit_reset_iso=/{print $2}')
+            if [ -n "$RESET_ISO" ]; then
+              RESET_LINE=" ⏳ Rate limit reset at $RESET_ISO — watchdog will wait until then before retrying."
+            fi
+          fi
           gh pr comment ${{ needs.resolve.outputs.pr_number }} \
-            --body "❌ AI Address Feedback failed (rate limit or transient error). Marked \`ai-blocked\` + \`ai-auto-retry\` — watchdog will retry automatically. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+            --body "❌ AI Address Feedback failed (rate limit or transient error). Marked \`ai-blocked\` + \`ai-auto-retry\` — watchdog will retry automatically.${RESET_LINE} See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
           gh pr edit ${{ needs.resolve.outputs.pr_number }} \
             --add-label "ai-blocked" --add-label "ai-auto-retry" || true

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -254,7 +254,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          RESET_LINE=""
+          if out=$(bash .github/scripts/detect-rate-limit.sh "${{ github.run_id }}" "${{ github.repository }}" 2>/dev/null); then
+            RESET_ISO=$(echo "$out" | awk -F= '/^rate_limit_reset_iso=/{print $2}')
+            if [ -n "$RESET_ISO" ]; then
+              RESET_LINE=" ⏳ Rate limit reset at $RESET_ISO — watchdog will wait until then before retrying."
+            fi
+          fi
           gh pr comment "$PR_NUMBER" \
-            --body "⚠️ AI PR Review failed. Marked \`ai-ready-for-review\` + \`ai-blocked\` + \`ai-auto-retry\` — watchdog will retry automatically. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+            --body "⚠️ AI PR Review failed. Marked \`ai-ready-for-review\` + \`ai-blocked\` + \`ai-auto-retry\` — watchdog will retry automatically.${RESET_LINE} See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
           gh pr edit "$PR_NUMBER" \
             --add-label "ai-ready-for-review" --add-label "ai-blocked" --add-label "ai-auto-retry" || true

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -437,11 +437,24 @@ jobs:
               --paginate \
               --jq '[.[] | select(
                 (.user.login == "github-actions[bot]" or .user.login == "claude[bot]") and
-                (.body | test("❌.*AI Address Feedback|❌.*AI Worker|⚠️.*AI (Worker|Planner)"))
+                (.body | test("❌.*AI Address Feedback|❌.*AI Worker|⚠️.*AI (Worker|Planner|PR Review)"))
               )]' 2>/dev/null || echo '[]')
 
             RETRY_COUNT=$(echo "$FAILURE_COMMENTS" | jq 'length')
             LAST_FAILURE_AT=$(echo "$FAILURE_COMMENTS" | jq -r 'last | .updated_at // empty')
+
+            # Rate-limit marker: the failing workflow's Handle failure step can
+            # embed "Rate limit reset at <ISO>" in the comment body when the
+            # Claude Code action hit an Anthropic 429. When present, honor it
+            # instead of the fixed MIN_WAIT_SECS floor.
+            LAST_BODY=$(echo "$FAILURE_COMMENTS" | jq -r 'last | .body // empty')
+            RESET_ISO=$(echo "$LAST_BODY" \
+              | grep -ohE 'Rate limit reset at [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+Z-]+' \
+              | head -1 | awk '{print $NF}')
+            RESET_TS=0
+            if [ -n "$RESET_ISO" ]; then
+              RESET_TS=$(date -u -d "$RESET_ISO" +%s 2>/dev/null || echo 0)
+            fi
 
             # Fall back to now-5400 if no failure comment found (label added manually)
             if [ -z "$LAST_FAILURE_AT" ]; then
@@ -452,7 +465,7 @@ jobs:
             NOW=$(date -u +%s)
             AGE=$(( NOW - LAST_FAILURE_TS ))
 
-            echo "PR #$NUM: retry_count=$RETRY_COUNT age_since_last_failure=${AGE}s last_failure=$LAST_FAILURE_AT"
+            echo "PR #$NUM: retry_count=$RETRY_COUNT age_since_last_failure=${AGE}s last_failure=$LAST_FAILURE_AT reset=${RESET_ISO:-none}"
 
             if [ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
               echo "PR #$NUM hit max retries — escalating to human."
@@ -462,7 +475,12 @@ jobs:
               continue
             fi
 
-            if [ "$AGE" -lt "$MIN_WAIT_SECS" ]; then
+            if [ "$RESET_TS" -gt "$NOW" ]; then
+              echo "PR #$NUM rate limit resets at $RESET_ISO (in $(( RESET_TS - NOW ))s) — skipping."
+              continue
+            fi
+
+            if [ -z "$RESET_ISO" ] && [ "$AGE" -lt "$MIN_WAIT_SECS" ]; then
               echo "PR #$NUM last failure was ${AGE}s ago — too soon (min ${MIN_WAIT_SECS}s). Skipping."
               continue
             fi
@@ -551,6 +569,19 @@ jobs:
             RETRY_COUNT=$(echo "$FAILURE_COMMENTS" | jq 'length')
             LAST_FAILURE_AT=$(echo "$FAILURE_COMMENTS" | jq -r 'last | .updated_at // empty')
 
+            # Rate-limit marker: the failing workflow's Handle failure step can
+            # embed "Rate limit reset at <ISO>" in the comment body when the
+            # Claude Code action hit an Anthropic 429. When present, honor it
+            # instead of the fixed MIN_WAIT_SECS floor.
+            LAST_BODY=$(echo "$FAILURE_COMMENTS" | jq -r 'last | .body // empty')
+            RESET_ISO=$(echo "$LAST_BODY" \
+              | grep -ohE 'Rate limit reset at [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+Z-]+' \
+              | head -1 | awk '{print $NF}')
+            RESET_TS=0
+            if [ -n "$RESET_ISO" ]; then
+              RESET_TS=$(date -u -d "$RESET_ISO" +%s 2>/dev/null || echo 0)
+            fi
+
             # If no failure comment found (manually tagged), treat as already past threshold
             if [ -z "$LAST_FAILURE_AT" ]; then
               LAST_FAILURE_TS=$(( $(date -u +%s) - MIN_WAIT_SECS - 1 ))
@@ -560,7 +591,7 @@ jobs:
             NOW=$(date -u +%s)
             AGE=$(( NOW - LAST_FAILURE_TS ))
 
-            echo "Issue #$NUM: retry_count=$RETRY_COUNT age_since_last_failure=${AGE}s labels=$LABELS"
+            echo "Issue #$NUM: retry_count=$RETRY_COUNT age_since_last_failure=${AGE}s labels=$LABELS reset=${RESET_ISO:-none}"
 
             if [ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
               # Exhausted retries — remove ai-auto-retry and ping human
@@ -572,7 +603,12 @@ jobs:
               continue
             fi
 
-            if [ "$AGE" -lt "$MIN_WAIT_SECS" ]; then
+            if [ "$RESET_TS" -gt "$NOW" ]; then
+              echo "Issue #$NUM rate limit resets at $RESET_ISO (in $(( RESET_TS - NOW ))s) — skipping."
+              continue
+            fi
+
+            if [ -z "$RESET_ISO" ] && [ "$AGE" -lt "$MIN_WAIT_SECS" ]; then
               echo "Issue #$NUM last failure was ${AGE}s ago — too soon to retry (min ${MIN_WAIT_SECS}s). Skipping."
               continue
             fi

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -447,13 +447,21 @@ jobs:
             # embed "Rate limit reset at <ISO>" in the comment body when the
             # Claude Code action hit an Anthropic 429. When present, honor it
             # instead of the fixed MIN_WAIT_SECS floor.
+            # NOTE: grep returns 1 when the marker is absent. With `set -euo
+            # pipefail` upstream, that would abort the step, so suppress the
+            # non-zero status and yield an empty string instead.
             LAST_BODY=$(echo "$FAILURE_COMMENTS" | jq -r 'last | .body // empty')
-            RESET_ISO=$(echo "$LAST_BODY" \
-              | grep -ohE 'Rate limit reset at [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+Z-]+' \
+            RESET_ISO=$(printf '%s' "$LAST_BODY" \
+              | { grep -ohE 'Rate limit reset at [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+Z-]+' || true; } \
               | head -1 | awk '{print $NF}')
             RESET_TS=0
             if [ -n "$RESET_ISO" ]; then
               RESET_TS=$(date -u -d "$RESET_ISO" +%s 2>/dev/null || echo 0)
+              # If the ISO failed to parse, clear the marker so the
+              # MIN_WAIT_SECS fallback still applies.
+              if [ "$RESET_TS" -eq 0 ]; then
+                RESET_ISO=""
+              fi
             fi
 
             # Fall back to now-5400 if no failure comment found (label added manually)
@@ -573,13 +581,21 @@ jobs:
             # embed "Rate limit reset at <ISO>" in the comment body when the
             # Claude Code action hit an Anthropic 429. When present, honor it
             # instead of the fixed MIN_WAIT_SECS floor.
+            # NOTE: grep returns 1 when the marker is absent. With `set -euo
+            # pipefail` upstream, that would abort the step, so suppress the
+            # non-zero status and yield an empty string instead.
             LAST_BODY=$(echo "$FAILURE_COMMENTS" | jq -r 'last | .body // empty')
-            RESET_ISO=$(echo "$LAST_BODY" \
-              | grep -ohE 'Rate limit reset at [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+Z-]+' \
+            RESET_ISO=$(printf '%s' "$LAST_BODY" \
+              | { grep -ohE 'Rate limit reset at [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+Z-]+' || true; } \
               | head -1 | awk '{print $NF}')
             RESET_TS=0
             if [ -n "$RESET_ISO" ]; then
               RESET_TS=$(date -u -d "$RESET_ISO" +%s 2>/dev/null || echo 0)
+              # If the ISO failed to parse, clear the marker so the
+              # MIN_WAIT_SECS fallback still applies.
+              if [ "$RESET_TS" -eq 0 ]; then
+                RESET_ISO=""
+              fi
             fi
 
             # If no failure comment found (manually tagged), treat as already past threshold

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -30,6 +30,7 @@ permissions:
   issues: write
   pull-requests: write
   id-token: write
+  actions: read
 
 jobs:
   # ─────────────────────────────────────────────────────────────────
@@ -214,12 +215,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          RESET_LINE=""
+          if out=$(bash .github/scripts/detect-rate-limit.sh "${{ github.run_id }}" "${{ github.repository }}" 2>/dev/null); then
+            RESET_ISO=$(echo "$out" | awk -F= '/^rate_limit_reset_iso=/{print $2}')
+            if [ -n "$RESET_ISO" ]; then
+              RESET_LINE=" ⏳ Rate limit reset at $RESET_ISO — watchdog will wait until then before retrying."
+            fi
+          fi
           gh issue edit "$ISSUE_NUMBER" \
             --remove-label "ai-in-progress" || true
           gh issue edit "$ISSUE_NUMBER" \
             --add-label "ai-blocked" --add-label "ai-auto-retry" || true
           gh issue comment "$ISSUE_NUMBER" \
-            --body "❌ AI Planner failed. Marked \`ai-blocked\` + \`ai-auto-retry\` — watchdog will retry automatically. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+            --body "❌ AI Planner failed. Marked \`ai-blocked\` + \`ai-auto-retry\` — watchdog will retry automatically.${RESET_LINE} See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
 
       - name: Ensure ai-in-progress is cleared on cancel
         if: cancelled()
@@ -445,12 +453,19 @@ jobs:
           if [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ] && [ -n "$BRANCH" ]; then
             BRANCH_NOTE=" Partial work pushed to branch \`${BRANCH}\`."
           fi
+          RESET_LINE=""
+          if out=$(bash .github/scripts/detect-rate-limit.sh "${{ github.run_id }}" "${{ github.repository }}" 2>/dev/null); then
+            RESET_ISO=$(echo "$out" | awk -F= '/^rate_limit_reset_iso=/{print $2}')
+            if [ -n "$RESET_ISO" ]; then
+              RESET_LINE=" ⏳ Rate limit reset at $RESET_ISO — watchdog will wait until then before retrying."
+            fi
+          fi
           gh issue edit "$ISSUE_NUMBER" \
             --remove-label "ai-in-progress" || true
           gh issue edit "$ISSUE_NUMBER" \
             --add-label "ai-blocked" --add-label "ai-auto-retry" || true
           gh issue comment "$ISSUE_NUMBER" \
-            --body "❌ AI Worker failed.${BRANCH_NOTE} Marked \`ai-blocked\` + \`ai-auto-retry\` — watchdog will retry automatically. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+            --body "❌ AI Worker failed.${BRANCH_NOTE} Marked \`ai-blocked\` + \`ai-auto-retry\` — watchdog will retry automatically.${RESET_LINE} See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
 
       - name: Ensure ai-in-progress is cleared on cancel
         if: cancelled()


### PR DESCRIPTION
## Summary
- Detects Anthropic rate-limit failures in the Claude Code action's job logs and embeds a `Rate limit reset at <ISO>` marker in the failure comment.
- Teaches the watchdog to honor that marker: when a rate-limit reset is in the future, it skips retrying (overriding the blind 90-minute `MIN_WAIT_SECS` floor); otherwise it falls back to today's behavior.
- Without this, every 15-minute watchdog tick during an active rate-limit window burned a retry attempt and hit the limit again immediately.

## Changes
- `.github/scripts/detect-rate-limit.sh` — new helper. Fetches the current run's in-progress/completed job logs via `gh api`, scans for four Anthropic 429 signals (Claude Code `usage limit reached|<epoch>`, `anthropic-ratelimit-*-reset` headers, HTTP `Retry-After`, JSON `retry_after`), emits `rate_limit_reset_epoch` + `rate_limit_reset_iso`. Silent no-op on any failure so callers safely fall back.
- `.github/workflows/ai-worker.yml` — both Handle-failure steps (plan + implement) call the helper; added `actions: read` permission.
- `.github/workflows/ai-address-feedback.yml` — Handle failure calls the helper (`actions: write` already present).
- `.github/workflows/ai-pr-review.yml` — Handle failure calls the helper (`actions: write` already present).
- `.github/workflows/ai-watchdog.yml` — both auto-retry steps (PRs + issues) parse the reset marker from the last failure comment; skip retries while the reset is in the future. Widened the PR-retry regex to also match `⚠️ AI PR Review` failure comments so the rate-limit logic applies to pr-review failures too.

## Tradeoff
Log scraping is fragile: if Anthropic changes the error/header format we silently fall back to the existing 90-minute wait. That's a degradation, not a failure.

## Test plan
- [ ] Manually dispatch a workflow that hits an Anthropic rate limit (or synthesize a failure comment containing `Rate limit reset at <future-ISO>`) and confirm the next watchdog tick skips retry with `rate limit resets at …` in the log.
- [ ] Confirm a failure comment *without* the marker still retries after `MIN_WAIT_SECS` (unchanged behavior).
- [ ] Confirm `actions/runs/<id>/jobs` + `actions/jobs/<id>/logs` are reachable from inside each workflow (permission check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)