### PR TITLE
fix(ci): use COPILOT_PAT to assign Copilot as reviewer

### DIFF
--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -213,6 +213,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ github.token }}
+          # PAT for assigning copilot-pull-request-reviewer[bot]; GITHUB_TOKEN
+          # silently drops Copilot reviewer requests. Claude must use this
+          # specifically when calling requested_reviewers (see prompt below).
+          COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--permission-mode bypassPermissions --max-turns 80"
@@ -280,9 +284,12 @@ jobs:
 
             ## Completion
             - If the PR has labels `ai-phase-copilot` or `ai-phase-opus`, do **NOT** call `requested_reviewers` — the workflow decides the next review step after you push.
-            - Otherwise (legacy PRs), after replying to all threads and committing fixes, re-request Copilot review:
+            - Otherwise (legacy PRs), after replying to all threads and committing fixes, re-request Copilot review.
+              GITHUB_TOKEN cannot assign Copilot — prefix the POST with the PAT exposed via `$COPILOT_PAT`
+              (fall back to the default token only if the env var is empty, so the warning path still fires):
               ```bash
-              gh api repos/${{ github.repository }}/pulls/${{ needs.resolve.outputs.pr_number }}/requested_reviewers \
+              GH_TOKEN="${COPILOT_PAT:-$GH_TOKEN}" gh api \
+                repos/${{ github.repository }}/pulls/${{ needs.resolve.outputs.pr_number }}/requested_reviewers \
                 --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
               ```
             - Post a single summary comment listing: threads addressed (with fix), threads skipped
@@ -313,6 +320,11 @@ jobs:
         if: success() && steps.workflow_change.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          # PAT-capable token for Copilot reviewer assignment. GITHUB_TOKEN
+          # cannot assign copilot-pull-request-reviewer[bot]. Only used on
+          # the explicit requested_reviewers POST; all other gh calls still
+          # use GITHUB_TOKEN to keep PAT rate-limit spend minimal.
+          COPILOT_TOKEN: ${{ secrets.COPILOT_PAT || github.token }}
           REPO: ${{ github.repository }}
           PR: ${{ needs.resolve.outputs.pr_number }}
         run: |
@@ -355,16 +367,16 @@ jobs:
                 gh pr comment "$PR" --repo "$REPO" --body "⏳ **AI Factory**: Automated address-feedback ran, but **no Copilot or human review has landed yet**. Leaving the review request pending — will re-check on next trigger." || true
                 return 0
               fi
-              # No review and no pending request — retry Copilot.
+              # No review and no pending request — retry Copilot with the PAT-capable token.
               local post_result copilot_added
-              post_result=$(gh api "repos/$REPO/pulls/$PR/requested_reviewers" --method POST \
+              post_result=$(GH_TOKEN="$COPILOT_TOKEN" gh api "repos/$REPO/pulls/$PR/requested_reviewers" --method POST \
                 -f 'reviewers[]=copilot-pull-request-reviewer[bot]' 2>&1 || true)
               copilot_added=$(printf '%s' "$post_result" | jq -r '[.requested_reviewers[]?.login] | map(select(. == "Copilot" or . == "copilot-pull-request-reviewer")) | length' 2>/dev/null || echo "0")
               if [ "${copilot_added:-0}" -gt 0 ]; then
                 gh pr comment "$PR" --repo "$REPO" --body "🔁 **AI Factory**: No Copilot/human review found on PR — re-requested **Copilot** review before converging." || true
               else
                 gh pr edit "$PR" --repo "$REPO" --add-label "ai-blocked" || true
-                gh pr comment "$PR" --repo "$REPO" --body "⚠️ **AI Factory**: No Copilot/human review found **and** re-requesting Copilot returned no reviewer (likely a token-permissions issue with \`GITHUB_TOKEN\`). Not marking \`ai-awaiting-owner\`. cc @alvarolobato — please request Copilot review manually or check workflow token." || true
+                gh pr comment "$PR" --repo "$REPO" --body "⚠️ **AI Factory**: No Copilot/human review found **and** re-requesting Copilot returned no reviewer. This happens when \`secrets.COPILOT_PAT\` is missing (GITHUB_TOKEN cannot assign Copilot) or the PAT lacks \`pull_requests: write\`. Not marking \`ai-awaiting-owner\`. cc @alvarolobato — set \`COPILOT_PAT\` or request the review manually." || true
               fi
               return 0
             fi
@@ -408,7 +420,7 @@ jobs:
           if echo ",$LABELS," | grep -q ",ai-phase-copilot,"; then
             if ! echo ",$LABELS," | grep -q ",ai-cp-after-1,"; then
               gh pr edit "$PR" --repo "$REPO" --add-label "ai-cp-after-1" || true
-              POST_OUT=$(gh api "repos/$REPO/pulls/$PR/requested_reviewers" --method POST \
+              POST_OUT=$(GH_TOKEN="$COPILOT_TOKEN" gh api "repos/$REPO/pulls/$PR/requested_reviewers" --method POST \
                 -f 'reviewers[]=copilot-pull-request-reviewer[bot]' 2>&1 || true)
               COPILOT_ADDED=$(printf '%s' "$POST_OUT" \
                 | jq -r '[.requested_reviewers[]?.login] | map(select(. == "Copilot" or . == "copilot-pull-request-reviewer")) | length' 2>/dev/null || echo "0")
@@ -416,7 +428,7 @@ jobs:
                 gh pr comment "$PR" --body "🤖 **AI Factory**: Copilot round **1**/2 addressed — requested **round 2** Copilot review." || true
               else
                 gh pr edit "$PR" --repo "$REPO" --add-label "ai-blocked" || true
-                gh pr comment "$PR" --body "⚠️ **AI Factory**: Tried to request **Copilot round 2** review but the API returned no reviewer (likely \`GITHUB_TOKEN\` permissions). cc @alvarolobato — please request manually." || true
+                gh pr comment "$PR" --body "⚠️ **AI Factory**: Tried to request **Copilot round 2** review but the API returned no reviewer. Check that \`secrets.COPILOT_PAT\` is set and has \`pull_requests: write\`. cc @alvarolobato — please request manually." || true
                 echo "::warning::Copilot round-2 request silently failed on PR #$PR"
               fi
               exit 0

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -145,6 +145,15 @@ jobs:
       - name: Claude PR Review
         if: steps.cap.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
+        env:
+          # Default gh auth for every Claude-side call EXCEPT the Copilot
+          # reviewer POST; the prompt below switches to $COPILOT_PAT only for
+          # that single call.
+          GH_TOKEN: ${{ github.token }}
+          # PAT for assigning copilot-pull-request-reviewer[bot]; GITHUB_TOKEN
+          # silently drops Copilot reviewer requests. Claude must use this
+          # specifically when calling requested_reviewers (see prompt below).
+          COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Headless review: tool approvals stall the run; default cap was 35 turns.
@@ -161,16 +170,18 @@ jobs:
             ## Copilot follow-up (read carefully)
             Run `gh pr view ${{ env.PR_NUMBER }} --json labels -q '.labels[].name'` before you finish.
             - If the PR has label `ai-phase-opus`, do **NOT** request a Copilot review (Opus-only passes; address-feedback is dispatched by CI).
-            - Otherwise, after reviewing, request a Copilot review **and verify the request landed**:
+            - Otherwise, after reviewing, request a Copilot review **and verify the request landed**.
+              GITHUB_TOKEN cannot assign Copilot — prefix the POST with the PAT exposed via `$COPILOT_PAT`:
             ```bash
-            POST_OUT=$(gh api repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/requested_reviewers \
+            POST_OUT=$(GH_TOKEN="${COPILOT_PAT:-$GH_TOKEN}" gh api \
+              repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/requested_reviewers \
               --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]' 2>&1 || true)
             COPILOT_ADDED=$(printf '%s' "$POST_OUT" \
               | jq -r '[.requested_reviewers[]?.login] | map(select(. == "Copilot" or . == "copilot-pull-request-reviewer")) | length' 2>/dev/null || echo "0")
             if [ "${COPILOT_ADDED:-0}" -eq 0 ]; then
-              # GITHUB_TOKEN silently dropped the request — surface it loudly.
+              # PAT missing or lacks pull_requests: write — surface it loudly.
               gh pr comment ${{ env.PR_NUMBER }} \
-                --body "⚠️ **AI Factory**: Requested Copilot review but the API returned no reviewer (likely a token-permissions issue). **Copilot has NOT been requested.** cc @alvarolobato."
+                --body "⚠️ **AI Factory**: Requested Copilot review but the API returned no reviewer. Check that \`secrets.COPILOT_PAT\` is set with \`pull_requests: write\`. cc @alvarolobato."
             fi
             ```
             Do NOT claim Copilot has reviewed the PR unless you can see an actual review from `Copilot` / `copilot-pull-request-reviewer[bot]` in `gh api repos/{owner}/{repo}/pulls/{PR}/reviews`.

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -363,6 +363,11 @@ jobs:
         if: always() && steps.verify.outputs.outcome == 'pr_created'
         env:
           GH_TOKEN: ${{ github.token }}
+          # GITHUB_TOKEN cannot assign copilot-pull-request-reviewer[bot] — the
+          # API returns 200 with an empty requested_reviewers array. Use a PAT
+          # (stored as COPILOT_PAT secret) for the Copilot POST only; fall back
+          # to GITHUB_TOKEN so the rest of the flow still works without a PAT.
+          COPILOT_TOKEN: ${{ secrets.COPILOT_PAT || github.token }}
         run: |
           gh issue edit "$ISSUE_NUMBER" \
             --remove-label "ai-in-progress" || true
@@ -379,11 +384,10 @@ jobs:
 
           gh pr edit "$PR_NUM" --add-label "ai-phase-copilot" || true
 
-          # Request Copilot and verify the request actually landed — GITHUB_TOKEN
-          # sometimes silently drops Copilot reviewer requests (returns 200 but
-          # with an empty requested_reviewers array). We must not claim Copilot
-          # review was requested when the API silently ignored us.
-          POST_OUT=$(gh api "repos/$REPO_NAME/pulls/$PR_NUM/requested_reviewers" \
+          # Request Copilot with the PAT-capable token and verify the request
+          # actually landed. If COPILOT_PAT is unset the fallback GITHUB_TOKEN
+          # fails silently — we still emit the warning so the owner is paged.
+          POST_OUT=$(GH_TOKEN="$COPILOT_TOKEN" gh api "repos/$REPO_NAME/pulls/$PR_NUM/requested_reviewers" \
             --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]' 2>&1 || true)
           COPILOT_ADDED=$(printf '%s' "$POST_OUT" \
             | jq -r '[.requested_reviewers[]?.login] | map(select(. == "Copilot" or . == "copilot-pull-request-reviewer")) | length' 2>/dev/null || echo "0")
@@ -395,7 +399,7 @@ jobs:
             # Silent failure — don't advertise a review cycle that didn't start.
             gh pr edit "$PR_NUM" --add-label "ai-blocked" || true
             gh pr comment "$PR_NUM" \
-              --body "⚠️ **AI Factory**: Requested Copilot review but the API returned no reviewer (likely a permissions issue with \`GITHUB_TOKEN\` — it can't assign Copilot). **Copilot review has NOT started.** cc @alvarolobato — please request Copilot review manually via the PR sidebar or ensure workflows can assign \`copilot-pull-request-reviewer[bot]\`." || true
+              --body "⚠️ **AI Factory**: Requested Copilot review but the API returned no reviewer. This happens when \`secrets.COPILOT_PAT\` is missing (GITHUB_TOKEN cannot assign Copilot) or the PAT lacks \`pull_requests: write\`. **Copilot review has NOT started.** cc @alvarolobato — set \`COPILOT_PAT\` (fine-grained PAT, Pull requests: Read and write) or request the review manually." || true
             echo "::warning::Copilot reviewer request silently failed on PR #$PR_NUM"
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,6 +400,12 @@ git worktree remove ../<repo>-<worktree-name>
     --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
   ```
   Do NOT use `gh pr review --request copilot` (doesn't work) or `gh pr edit --add-reviewer copilot` (can't resolve bot users). The REST API with `copilot-pull-request-reviewer[bot]` is the only working CLI method.
+- **From GitHub Actions**, the default `GITHUB_TOKEN` **cannot** assign `copilot-pull-request-reviewer[bot]` — the API returns 200 but with an empty `requested_reviewers` array. Workflows must use a PAT stored in the repo secret `COPILOT_PAT` (fine-grained PAT, scope `Pull requests: Read and write`). Pattern:
+  ```bash
+  GH_TOKEN="$COPILOT_PAT" gh api repos/{owner}/{repo}/pulls/{PR#}/requested_reviewers \
+    --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
+  ```
+  Always verify the response contains `Copilot` in `requested_reviewers` before claiming the review was requested.
 - Poll for the review result: `gh api repos/{owner}/{repo}/pulls/{PR#}/reviews --jq '[.[] | {state, user: .user.login, body}]'`
 - Address all feedback, reply to each comment, then re-request review.
 - Only merge after Copilot has reviewed and there is no unresolved feedback.


### PR DESCRIPTION
## Summary

- ~40 open PRs are stuck in \`ai-phase-copilot\` because the Copilot review was never actually requested — the ai-worker, ai-pr-review, and ai-address-feedback workflows all hit the silent-drop behaviour where \`GITHUB_TOKEN\` cannot assign \`copilot-pull-request-reviewer[bot]\` (API returns 200, \`requested_reviewers\` stays empty).
- Workflows now read an optional \`COPILOT_PAT\` secret (fine-grained PAT, \`Pull requests: Read and write\`) and use it **only** on the \`requested_reviewers\` POST; every other \`gh\` call still uses \`GITHUB_TOKEN\` so PAT rate-limit spend stays near zero.
- If \`COPILOT_PAT\` is unset, shell steps fall back to \`GITHUB_TOKEN\` (still silent-drops) and emit the existing warning comment — no change in behaviour.
- Updated AGENTS.md "PR and review policy" with the override pattern.

## Action required after merge

**Add a repo secret \`COPILOT_PAT\`** (fine-grained PAT, Pull requests: Read and write) or Copilot review will keep silently failing.

## Changes

- \`.github/workflows/ai-worker.yml\` — Handle success (PR created) step: scoped \`GH_TOKEN=\"\$COPILOT_TOKEN\"\` on the single Copilot POST.
- \`.github/workflows/ai-pr-review.yml\` — Claude PR Review step: added \`COPILOT_PAT\` + \`GH_TOKEN\` to step env, prompt now tells Claude to override \`GH_TOKEN\` for the reviewer POST only.
- \`.github/workflows/ai-address-feedback.yml\` — Address Review Feedback step (Claude) + Route next automated review step (shell) get the same treatment across all 3 \`requested_reviewers\` POST sites.
- \`AGENTS.md\` — documented \`COPILOT_PAT\` and the correct \`GH_TOKEN=\"\$COPILOT_PAT\" gh api ...\` pattern.

## Test plan

- [x] Verified locally that my user PAT's \`gh api .../requested_reviewers\` POST successfully assigns Copilot on PR #313 (returned \`requested_reviewers[].login == \"Copilot\"\`); reproduces the GITHUB_TOKEN silent-drop vs PAT success difference.
- [x] Opus self-review passed (one blocker found + fixed — missing \`GH_TOKEN\` in the ai-pr-review Claude step env, which would have broken the \`\${COPILOT_PAT:-\$GH_TOKEN}\` fallback).
- [ ] After merge: add the \`COPILOT_PAT\` secret, unblock PR #313 by removing \`ai-blocked\`, re-run ai-worker route → Copilot should land.
- [ ] Once verified, unblock all remaining PRs stuck in \`ai-phase-copilot\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)