### PR TITLE
feat(ai-factory): simplify review to 1 Copilot + 1 Opus

### DIFF
--- a/.github/ai-factory/config.yml
+++ b/.github/ai-factory/config.yml
@@ -47,12 +47,10 @@ labels:
 
   # AI Factory — phased PR review (see ai-worker / ai-pr-review / ai-address-feedback)
   review_phases:
-    - "ai-phase-copilot"   # Awaiting / in Copilot rounds (before Opus)
-    - "ai-cp-after-1"      # Addressed feedback after Copilot round 1
-    - "ai-cp-after-2"      # Addressed feedback after Copilot round 2
-    - "ai-phase-opus"      # In Opus review passes (max 2)
-    - "ai-o-after-1"       # Addressed after Opus pass 1
-    - "ai-o-after-2"       # Addressed after Opus pass 2 (terminal for AI review)
+    - "ai-phase-copilot"   # Awaiting / in Copilot review (before Opus)
+    - "ai-cp-after-1"      # Addressed feedback after Copilot review
+    - "ai-phase-opus"      # In Opus review pass
+    - "ai-o-after-1"       # Addressed after Opus review (terminal for AI review)
     - "ai-legacy-opus-1"   # Legacy PRs: first Opus pass recorded
     - "ai-legacy-opus-2"   # Legacy PRs: second Opus pass — further Opus runs skipped
 

--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -418,29 +418,46 @@ jobs:
 
           # Phased: 1× Copilot then 1× Opus — see ai-worker.yml / ai-pr-review.yml
           if echo ",$LABELS," | grep -q ",ai-phase-copilot,"; then
-            if ! echo ",$LABELS," | grep -q ",ai-cp-after-1,"; then
+            if echo ",$LABELS," | grep -q ",ai-cp-after-1,"; then
+              # Self-heal: a prior transition partially applied (both labels present).
+              # Complete the label move without re-dispatching Opus review.
               gh pr edit "$PR" --repo "$REPO" \
-                --add-label "ai-cp-after-1" \
                 --remove-label "ai-phase-copilot" \
                 --add-label "ai-phase-opus" \
                 --add-label "ai-ready-for-review" || true
-              gh workflow run ai-pr-review.yml --repo "$REPO" --field pr_number="$PR" || true
-              gh pr comment "$PR" --body "🤖 **AI Factory**: Copilot review addressed — starting **Opus** review." || true
+              gh pr comment "$PR" --body "🤖 **AI Factory**: Self-healed partial phase transition — cleared \`ai-phase-copilot\`." || true
               exit 0
             fi
+            gh pr edit "$PR" --repo "$REPO" \
+              --add-label "ai-cp-after-1" \
+              --remove-label "ai-phase-copilot" \
+              --add-label "ai-phase-opus" \
+              --add-label "ai-ready-for-review" || true
+            gh workflow run ai-pr-review.yml --repo "$REPO" --field pr_number="$PR" || true
+            gh pr comment "$PR" --body "🤖 **AI Factory**: Copilot review addressed — starting **Opus** review." || true
+            exit 0
           fi
 
           if echo ",$LABELS," | grep -q ",ai-phase-opus,"; then
-            if ! echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
+            if echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
+              # Self-heal: prior handoff partially applied. Finish clearing phase labels
+              # and re-run the handoff gate — it's idempotent (label + comment only).
               gh pr edit "$PR" --repo "$REPO" \
-                --add-label "ai-o-after-1" \
                 --remove-label "ai-phase-opus" \
                 --remove-label "ai-ready-for-review" \
                 --remove-label "ai-blocked" \
                 --remove-label "ai-auto-retry" || true
-              owner_handoff_or_ci_gate "✅ **AI Factory**: Automated reviews complete (Copilot + Opus). PR is ready for human merge decision."
+              owner_handoff_or_ci_gate "✅ **AI Factory**: Self-healed partial phase transition — automated reviews complete (Copilot + Opus). PR is ready for human merge decision."
               exit 0
             fi
+            gh pr edit "$PR" --repo "$REPO" \
+              --add-label "ai-o-after-1" \
+              --remove-label "ai-phase-opus" \
+              --remove-label "ai-ready-for-review" \
+              --remove-label "ai-blocked" \
+              --remove-label "ai-auto-retry" || true
+            owner_handoff_or_ci_gate "✅ **AI Factory**: Automated reviews complete (Copilot + Opus). PR is ready for human merge decision."
+            exit 0
           fi
 
           # Legacy PRs (no phased labels): same as before — re-dispatch Opus review (capped via ai-legacy-opus-* in ai-pr-review).

--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -417,6 +417,14 @@ jobs:
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 
           # Phased: 1× Copilot then 1× Opus — see ai-worker.yml / ai-pr-review.yml
+          # Ensure phase/handoff labels exist; if any are missing, the single
+          # multi-label `gh pr edit` below would fail and leave the PR stuck.
+          gh label create "ai-phase-copilot" --color "0052cc" --description "AI Factory: Copilot review in progress" 2>/dev/null || true
+          gh label create "ai-phase-opus" --color "6f42c1" --description "AI Factory: Opus review in progress" 2>/dev/null || true
+          gh label create "ai-cp-after-1" --color "0e8a16" --description "AI Factory: addressed Copilot review" 2>/dev/null || true
+          gh label create "ai-o-after-1" --color "0e8a16" --description "AI Factory: addressed Opus review" 2>/dev/null || true
+          gh label create "ai-ready-for-review" --color "fbca04" --description "AI Factory: PR ready for automated review" 2>/dev/null || true
+
           if echo ",$LABELS," | grep -q ",ai-phase-copilot,"; then
             if echo ",$LABELS," | grep -q ",ai-cp-after-1,"; then
               # Self-heal: a prior transition partially applied (both labels present).

--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -468,6 +468,14 @@ jobs:
             exit 0
           fi
 
+          # Post-terminal guard: if this PR already finished its automated
+          # cycle (ai-o-after-1 set by the Opus branch above), don't fall
+          # through to the legacy path and re-dispatch Opus review.
+          if echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
+            echo "PR #$PR already completed automated review (ai-o-after-1 present) — skipping legacy dispatch."
+            exit 0
+          fi
+
           # Legacy PRs (no phased labels): same as before — re-dispatch Opus review (capped via ai-legacy-opus-* in ai-pr-review).
           gh pr edit "$PR" --repo "$REPO" --add-label "ai-ready-for-review" || true
           gh workflow run ai-pr-review.yml --repo "$REPO" --field pr_number="$PR" || true

--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -416,50 +416,29 @@ jobs:
           echo "Commits pushed ($INITIAL_SHA → $CURRENT_SHA)."
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 
-          # Phased: 2× Copilot (cheap) then 2× Opus — see ai-worker.yml / ai-pr-review.yml
+          # Phased: 1× Copilot then 1× Opus — see ai-worker.yml / ai-pr-review.yml
           if echo ",$LABELS," | grep -q ",ai-phase-copilot,"; then
             if ! echo ",$LABELS," | grep -q ",ai-cp-after-1,"; then
-              gh pr edit "$PR" --repo "$REPO" --add-label "ai-cp-after-1" || true
-              POST_OUT=$(GH_TOKEN="$COPILOT_TOKEN" gh api "repos/$REPO/pulls/$PR/requested_reviewers" --method POST \
-                -f 'reviewers[]=copilot-pull-request-reviewer[bot]' 2>&1 || true)
-              COPILOT_ADDED=$(printf '%s' "$POST_OUT" \
-                | jq -r '[.requested_reviewers[]?.login] | map(select(. == "Copilot" or . == "copilot-pull-request-reviewer")) | length' 2>/dev/null || echo "0")
-              if [ "${COPILOT_ADDED:-0}" -gt 0 ]; then
-                gh pr comment "$PR" --body "🤖 **AI Factory**: Copilot round **1**/2 addressed — requested **round 2** Copilot review." || true
-              else
-                gh pr edit "$PR" --repo "$REPO" --add-label "ai-blocked" || true
-                gh pr comment "$PR" --body "⚠️ **AI Factory**: Tried to request **Copilot round 2** review but the API returned no reviewer. Check that \`secrets.COPILOT_PAT\` is set and has \`pull_requests: write\`. cc @alvarolobato — please request manually." || true
-                echo "::warning::Copilot round-2 request silently failed on PR #$PR"
-              fi
-              exit 0
-            fi
-            if ! echo ",$LABELS," | grep -q ",ai-cp-after-2,"; then
               gh pr edit "$PR" --repo "$REPO" \
-                --add-label "ai-cp-after-2" \
+                --add-label "ai-cp-after-1" \
                 --remove-label "ai-phase-copilot" \
                 --add-label "ai-phase-opus" \
                 --add-label "ai-ready-for-review" || true
               gh workflow run ai-pr-review.yml --repo "$REPO" --field pr_number="$PR" || true
-              gh pr comment "$PR" --body "🤖 **AI Factory**: Copilot rounds **complete** — starting **Opus** review (pass 1 of 2)." || true
+              gh pr comment "$PR" --body "🤖 **AI Factory**: Copilot review addressed — starting **Opus** review." || true
               exit 0
             fi
           fi
 
           if echo ",$LABELS," | grep -q ",ai-phase-opus,"; then
             if ! echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
-              gh pr edit "$PR" --repo "$REPO" --add-label "ai-o-after-1" --add-label "ai-ready-for-review" || true
-              gh workflow run ai-pr-review.yml --repo "$REPO" --field pr_number="$PR" || true
-              gh pr comment "$PR" --body "🤖 **AI Factory**: Opus pass **1**/2 addressed — running **Opus** pass 2." || true
-              exit 0
-            fi
-            if ! echo ",$LABELS," | grep -q ",ai-o-after-2,"; then
               gh pr edit "$PR" --repo "$REPO" \
-                --add-label "ai-o-after-2" \
+                --add-label "ai-o-after-1" \
                 --remove-label "ai-phase-opus" \
                 --remove-label "ai-ready-for-review" \
                 --remove-label "ai-blocked" \
                 --remove-label "ai-auto-retry" || true
-              owner_handoff_or_ci_gate "✅ **AI Factory**: Automated **Opus** passes complete (**2**/2). PR is ready for human merge decision."
+              owner_handoff_or_ci_gate "✅ **AI Factory**: Automated reviews complete (Copilot + Opus). PR is ready for human merge decision."
               exit 0
             fi
           fi

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -381,7 +381,7 @@ jobs:
             --remove-label "ai-in-progress" || true
           gh issue comment "$ISSUE_NUMBER" \
             --body "✅ AI Worker completed. See PR #${{ steps.verify.outputs.pr_number }}."
-          # Automated review: two Copilot rounds first (cheaper), then up to two Opus PR reviews.
+          # Automated review: Copilot first (cheaper), then Opus. One pass each.
           # Do not dispatch Opus immediately — avoids rate limits and reduces token spend.
           PR_NUM="${{ steps.verify.outputs.pr_number }}"
           REPO_NAME="${{ github.repository }}"
@@ -402,7 +402,7 @@ jobs:
 
           if [ "${COPILOT_ADDED:-0}" -gt 0 ]; then
             gh pr comment "$PR_NUM" \
-              --body "🤖 **AI Factory**: Automated review starts with **Copilot** (round 1 of 2), then Copilot round 2, then up to **two Opus** code reviews. Labels: \`ai-phase-copilot\` → \`ai-phase-opus\`." || true
+              --body "🤖 **AI Factory**: Automated review starts with **Copilot**, then **Opus** (one pass each). Labels: \`ai-phase-copilot\` → \`ai-phase-opus\`." || true
           else
             # Silent failure — don't advertise a review cycle that didn't start.
             gh pr edit "$PR_NUM" --add-label "ai-blocked" || true


### PR DESCRIPTION
## Summary
- Collapse the phased PR review state machine from **2 Copilot + 2 Opus** rounds to **1 Copilot + 1 Opus**.
- New flow: `ai-phase-copilot` → address Copilot feedback → `ai-phase-opus` → address Opus feedback → owner handoff.
- Removes `ai-cp-after-2` and `ai-o-after-2` from the known label set (kept `ai-legacy-opus-*` for legacy PRs).

## Files changed
- `.github/workflows/ai-address-feedback.yml` — collapse 4-step state machine to 2 steps.
- `.github/workflows/ai-worker.yml` — update comments/user-facing text to reflect one pass each.
- `.github/ai-factory/config.yml` — drop `ai-cp-after-2` and `ai-o-after-2` from `review_phases`.

Diff: 3 files changed, 11 insertions(+), 34 deletions(-).

## Note on self-review
This PR touches `.github/workflows/*`. `ai-pr-review.yml` skips the Claude review in that case (OIDC app-token exchange guard), so self-review via AI Factory is not possible. Requesting Copilot review; owner merges after independent verification.

## Test plan
- [ ] Copilot review posts (confirms `COPILOT_PAT` wiring from #360 still works).
- [ ] Verify new PRs created after merge get only `ai-phase-copilot` → `ai-phase-opus` progression.
- [ ] Confirm no workflow references `ai-cp-after-2` / `ai-o-after-2` (grep clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)