### PR TITLE
fix(ai-factory): break infinite watchdog retry loop

### DIFF
--- a/.github/workflows/ai-auto-release.yml
+++ b/.github/workflows/ai-auto-release.yml
@@ -121,12 +121,17 @@ jobs:
           echo "" >> /tmp/changelog.md
 
           echo "### Other Changes" >> /tmp/changelog.md
-          # Exclude PRs already listed under Features or Bug Fixes
+          # PRs without enhancement/ai-idea/bug/ai-bug labels are listed here.
+          # NOTE: gh's --jq is a single-string flag and cannot accept jq's
+          # `--arg` / `--argjson` directly. We previously passed
+          # `--jq --argjson listed [...] '<expr>'`, which made "--argjson"
+          # the value of --jq and silently broke the call (so this section
+          # was empty in every release). The label `select` already excludes
+          # the feature/bug PRs, so the number-based exclusion isn't needed.
           gh pr list --state merged --base main \
             --search "merged:>=${SINCE_DATE}" \
             --json number,title,labels \
-            --jq --argjson listed "[$(echo "${LISTED_NUMBERS}" | tr ',' '\n' | grep -v '^$' | tr '\n' ',' | sed 's/,$//')]" \
-            '.[] | select(.labels | map(.name) | all(. != "enhancement" and . != "ai-idea" and . != "bug" and . != "ai-bug")) | "- \(.title) (#\(.number))"' \
+            --jq '.[] | select(.labels | map(.name) | all(. != "enhancement" and . != "ai-idea" and . != "bug" and . != "ai-bug")) | "- \(.title) (#\(.number))"' \
             >> /tmp/changelog.md 2>/dev/null || true
           echo "" >> /tmp/changelog.md
 

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -566,9 +566,17 @@ jobs:
             # Count failure comments and get timestamp of last one.
             # Use last-failure-comment time (not updatedAt) so label changes
             # don't reset the clock and cause us to skip valid retries.
-            FAILURE_COMMENTS=$(gh api "repos/$REPO_FULL/issues/$NUM/comments" \
-              --paginate \
-              --jq --arg cutoff "$FAILURE_CUTOFF" '[.[] | select(
+            #
+            # NOTE: gh api's --jq is a single-string flag. Passing
+            # `--jq --arg cutoff X 'expr'` makes "--arg" the value of --jq
+            # and the rest positional args, so the call silently fails and
+            # the `|| echo '[]'` fallback hides it — that bug let the
+            # watchdog retry every cron tick because RETRY_COUNT was always 0
+            # and LAST_FAILURE_AT was always empty. Pipe to standalone jq.
+            ALL_COMMENTS=$(gh api "repos/$REPO_FULL/issues/$NUM/comments?per_page=100" \
+              --paginate 2>/dev/null || echo '[]')
+            FAILURE_COMMENTS=$(echo "$ALL_COMMENTS" | jq --arg cutoff "$FAILURE_CUTOFF" '
+              [.[] | select(
                 (.user.login == "github-actions[bot]" or .user.login == "claude[bot]") and
                 (.body | test("❌|⚠️.*AI (Worker|Planner)")) and
                 (.created_at >= $cutoff)
@@ -576,6 +584,15 @@ jobs:
 
             RETRY_COUNT=$(echo "$FAILURE_COMMENTS" | jq 'length')
             LAST_FAILURE_AT=$(echo "$FAILURE_COMMENTS" | jq -r 'last | .updated_at // empty')
+
+            # Hard circuit breaker: count the watchdog's OWN auto-retry comments.
+            # This survives any future regression in the failure-detection regex —
+            # if we've already retried MAX_RETRIES times, stop, no matter what.
+            WATCHDOG_RETRY_COUNT=$(echo "$ALL_COMMENTS" | jq '
+              [.[] | select(
+                .user.login == "github-actions[bot]" and
+                (.body | test("AI Factory watchdog: auto-retrying"))
+              )] | length' 2>/dev/null || echo "0")
 
             # Rate-limit marker: the failing workflow's Handle failure step can
             # embed "Rate limit reset at <ISO>" in the comment body when the
@@ -607,15 +624,22 @@ jobs:
             NOW=$(date -u +%s)
             AGE=$(( NOW - LAST_FAILURE_TS ))
 
-            echo "Issue #$NUM: retry_count=$RETRY_COUNT age_since_last_failure=${AGE}s labels=$LABELS reset=${RESET_ISO:-none}"
+            echo "Issue #$NUM: retry_count=$RETRY_COUNT watchdog_retries=$WATCHDOG_RETRY_COUNT age_since_last_failure=${AGE}s labels=$LABELS reset=${RESET_ISO:-none}"
 
-            if [ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
+            # Take the higher of the two counts so the hard circuit breaker
+            # always wins.
+            EFFECTIVE_RETRY_COUNT="$RETRY_COUNT"
+            if [ "$WATCHDOG_RETRY_COUNT" -gt "$EFFECTIVE_RETRY_COUNT" ]; then
+              EFFECTIVE_RETRY_COUNT="$WATCHDOG_RETRY_COUNT"
+            fi
+
+            if [ "$EFFECTIVE_RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
               # Exhausted retries — remove ai-auto-retry and ping human
               echo "Issue #$NUM has hit max retries ($MAX_RETRIES) — escalating to human."
               gh issue edit "$NUM" --repo "$REPO_FULL" \
                 --remove-label "ai-auto-retry" || true
               gh issue comment "$NUM" --repo "$REPO_FULL" \
-                --body "🚨 @$OWNER_HANDLE — AI Factory watchdog: issue #$NUM has failed $RETRY_COUNT times and will NOT be retried automatically. Please investigate and either fix the underlying problem or re-label with \`ai-work\` when ready." || true
+                --body "🚨 @$OWNER_HANDLE — AI Factory watchdog: issue #$NUM has failed $EFFECTIVE_RETRY_COUNT times and will NOT be retried automatically. Please investigate and either fix the underlying problem or re-label with \`ai-work\` when ready." || true
               continue
             fi
 
@@ -633,11 +657,12 @@ jobs:
             # GITHUB_TOKEN label changes do NOT fire webhook events (GitHub
             # loop-prevention), so adding `ai-work` alone would never trigger
             # ai-worker.yml. We must call `gh workflow run` explicitly.
-            echo "Retrying issue #$NUM ($TITLE) — attempt $(( RETRY_COUNT + 1 )) of $MAX_RETRIES"
+            ATTEMPT=$(( EFFECTIVE_RETRY_COUNT + 1 ))
+            echo "Retrying issue #$NUM ($TITLE) — attempt $ATTEMPT of $MAX_RETRIES"
             gh issue edit "$NUM" --repo "$REPO_FULL" \
               --remove-label "ai-blocked" --remove-label "ai-auto-retry" || true
             gh issue comment "$NUM" --repo "$REPO_FULL" \
-              --body "🔄 AI Factory watchdog: auto-retrying (attempt $(( RETRY_COUNT + 1 )) of $MAX_RETRIES) after transient failure. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})." || true
+              --body "🔄 AI Factory watchdog: auto-retrying (attempt $ATTEMPT of $MAX_RETRIES) after transient failure. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})." || true
 
             # Determine phase: sub-tasks (ai-task) → implement, parents → plan
             if echo ",$LABELS," | grep -q ",ai-task,"; then


### PR DESCRIPTION
## Summary

Six issues (#249, #251, #252, #256, #257, #268) were stuck in an infinite watchdog retry loop, each accumulating 100+ identical bot comments since 2026-04-18. Every retry comment said `attempt 1 of 10` — the `MAX_RETRIES=10` circuit breaker never tripped. I've already removed `ai-blocked` + `ai-auto-retry` from those issues to stop the bleeding; this PR fixes the underlying bug so it doesn't recur.

## Root cause

In `.github/workflows/ai-watchdog.yml`, the "Auto-retry transient failures" step counted past failures with:

```bash
gh api "repos/$REPO_FULL/issues/$NUM/comments" \
  --paginate \
  --jq --arg cutoff "$FAILURE_CUTOFF" '[.[] | select(...)]' \
  2>/dev/null || echo '[]'
```

`gh`'s `--jq` is a single-string flag (see `gh api --help` → `-q, --jq string`). So `--arg` was eaten as the value of `--jq`, and `cutoff`, `$FAILURE_CUTOFF`, and the actual jq expression became positional args. The call failed, the `2>/dev/null || echo '[]'` swallowed the error, and `FAILURE_COMMENTS` was always `[]`. That made:

- `RETRY_COUNT = 0` → no circuit breaker trip, ever
- `LAST_FAILURE_AT = ""` → fell into the `LAST_FAILURE_TS=NOW-MIN_WAIT_SECS-1` branch → wait check trivially passed → retry every 15 minutes regardless of `MIN_WAIT_SECS=5400`

Same `--jq --argjson` mistake exists in `ai-auto-release.yml:128` (the `--argjson listed` was also unused in the jq expression — the "Other Changes" section of every release was silently empty).

## Changes

- **`ai-watchdog.yml`**: pipe `gh api` to standalone `jq` so `--arg` works as intended; add a `WATCHDOG_RETRY_COUNT` hard circuit breaker that counts the watchdog's own `auto-retrying` comments — bulletproof against future regressions in the failure-detection regex.
- **`ai-auto-release.yml`**: drop the broken `--argjson listed` (label-based `select` already excludes feature/bug PRs); restores the "Other Changes" section in releases.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` — YAML parses
- [x] Verified the regex itself was correct in isolation (`echo '[…]' | jq '[.[] | select(.body | test("❌|⚠️.*AI (Worker|Planner)"))] | length'` → `2`), confirming the bug was in the gh argument parsing rather than the regex
- [ ] Watch the next watchdog cron run (every 15 min) and confirm no new auto-retry comments are posted on the cleaned-up issues
- [ ] On a future genuinely transient failure, confirm the attempt counter increments correctly and the circuit breaker trips at 10

## Affected issues already cleaned

Removed `ai-blocked` + `ai-auto-retry` from #249, #251, #252, #256, #257, #268. They each have 90–100+ stale loop comments — consider closing and re-filing the actual feature requests once you've reviewed.