### PR TITLE
fix(ai-factory): prevent planner from producing mangled sub-issue bodies

### DIFF
--- a/.github/workflows/ai-plan.yml
+++ b/.github/workflows/ai-plan.yml
@@ -105,15 +105,29 @@ jobs:
             Check if the comment was `/plan --full`. If YES, create sub-issues AND kick off
             implementation:
 
+            ### Body integrity rules — MUST follow
+
+            Issue bodies have repeatedly been corrupted by stripping JSX
+            components and TypeScript generics inside backticks (e.g.
+            `` `<Foo />` `` and `` `Promise<void>` `` arrived as empty
+            `` `` `` and `` `Promise` ``). Always:
+            1. Write the body to a temp file first, then use
+               `gh issue create --body-file <path>`. Never inline-construct
+               via `--body "$(cat <<…)"`.
+            2. Keep JSX, HTML tags, and TypeScript generics literal inside
+               backticks. Do not abbreviate.
+            3. After creating each sub-issue, re-read the body with
+               `gh issue view <NUM> --json body --jq .body` and abort if
+               it contains `` `` `` (empty inline code span).
+
             For EACH task in the sub-tasks table:
             IMPORTANT: create the issue WITHOUT labels first, then add labels
             in a separate command — this is required for GitHub to fire the
             `labeled` event that triggers the implementation workflow.
 
             ```bash
-            SUB_ISSUE=$(gh issue create \
-              --title "PARENT_TITLE — Task N: TASK_TITLE" \
-              --body "$(cat <<'BODY'
+            TMP_BODY=$(mktemp --suffix=.md)
+            cat > "$TMP_BODY" <<'BODY'
             ## Parent issue
             Closes #PARENT_NUMBER
 
@@ -129,7 +143,18 @@ jobs:
             ## Context
             See parent issue #PARENT_NUMBER for full plan.
             BODY
-            )" | grep -o '[0-9]*$')
+
+            SUB_ISSUE=$(gh issue create \
+              --title "PARENT_TITLE — Task N: TASK_TITLE" \
+              --body-file "$TMP_BODY" | grep -o '[0-9]*$')
+            rm -f "$TMP_BODY"
+
+            # Verify the body is intact — fail loudly if mangled.
+            if gh issue view "$SUB_ISSUE" --json body --jq .body | grep -q '``'; then
+              echo "::error::Sub-issue #$SUB_ISSUE body contains empty inline code spans — JSX/generics likely stripped."
+              gh issue edit "$SUB_ISSUE" --add-label "ai-needs-rewrite" || true
+              exit 1
+            fi
 
             # Add labels separately so the labeled event fires reliably
             gh issue edit $SUB_ISSUE --add-label "ai-task"

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -126,10 +126,38 @@ jobs:
             in a separate command — this is required for GitHub to fire the
             `labeled` event that triggers the implementation workflow.
 
+            ### Body integrity rules — MUST follow
+
+            Issue bodies have repeatedly been corrupted by stripping JSX
+            components and TypeScript generics inside backticks (e.g. `` `<Foo />` ``
+            and `` `Promise<void>` `` arrived as empty `` `` `` and `` `Promise` ``).
+            Two known causes: (1) the shell interpreting `<Component>` as
+            I/O redirection when bodies are passed inline; (2) the LLM
+            eliding repetitive technical fragments mid-generation.
+
+            To prevent both:
+
+            1. **Always write the body to a temp file first**, then use
+               `gh issue create --body-file <path>`. Never use `--body
+               "$(cat <<…)"` or any inline construction — those can be
+               re-parsed by the shell or your own quoting layer.
+            2. **Write JSX, HTML tags, and TypeScript generics literally**
+               inside backticks. Do not abbreviate. `` `<DateRangePicker />` ``
+               must stay as `` `<DateRangePicker />` ``, not `` `` ``.
+               `` `Promise<void>` `` must stay as `` `Promise<void>` ``,
+               not `` `Promise` ``.
+            3. **After each `gh issue create`, immediately re-read the
+               issue body** with `gh issue view <NUM> --json body --jq .body`
+               and verify it does not contain `` `` `` (two adjacent backticks
+               with nothing between). If it does, the body was mangled —
+               delete the issue and re-create it.
+
+            ### Template
+
             ```bash
-            SUB_ISSUE=$(gh issue create \
-              --title "PARENT_TITLE — Task N: TASK_TITLE" \
-              --body "$(cat <<'BODY'
+            # 1. Write body to a temp file (quoted heredoc — no shell expansion).
+            TMP_BODY=$(mktemp --suffix=.md)
+            cat > "$TMP_BODY" <<'BODY'
             ## Parent issue
             Closes #${{ env.ISSUE_NUMBER }}
 
@@ -145,9 +173,21 @@ jobs:
             ## Context
             See parent issue #${{ env.ISSUE_NUMBER }} for full plan.
             BODY
-            )" | grep -o '[0-9]*$')
 
-            # Add labels separately so the labeled event fires reliably
+            # 2. Create the issue from the file (no inline shell parsing).
+            SUB_ISSUE=$(gh issue create \
+              --title "PARENT_TITLE — Task N: TASK_TITLE" \
+              --body-file "$TMP_BODY" | grep -o '[0-9]*$')
+            rm -f "$TMP_BODY"
+
+            # 3. Verify the body is intact — fail loudly if anything was mangled.
+            if gh issue view "$SUB_ISSUE" --json body --jq .body | grep -q '``'; then
+              echo "::error::Sub-issue #$SUB_ISSUE body contains empty inline code spans (\`\`) — likely JSX/generics were stripped. Investigate before continuing."
+              gh issue edit "$SUB_ISSUE" --add-label "ai-needs-rewrite" || true
+              exit 1
+            fi
+
+            # 4. Add labels separately so the labeled event fires reliably.
             gh issue edit $SUB_ISSUE --add-label "ai-task"
             gh issue edit $SUB_ISSUE --add-label "ai-work"
             ```
@@ -197,6 +237,30 @@ jobs:
           else
             echo "status=incomplete" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Detect mangled sub-issue bodies
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Defense-in-depth: even when the planner follows the per-issue
+          # verify step, Claude may forget. Scan all open sub-issues that
+          # reference this parent ("Closes #N") for empty inline code spans
+          # — the signature of stripped JSX/generics. Flag them with
+          # `ai-needs-rewrite` so a human (or a follow-up worker) can repair
+          # the body before the implementation phase tries to act on it.
+          SUB_ISSUES=$(gh issue list --repo "${{ github.repository }}" \
+            --state open --limit 50 \
+            --search "Closes #${ISSUE_NUMBER} in:body" \
+            --json number,body --jq '.[]' || true)
+
+          echo "$SUB_ISSUES" | jq -c 'select(.body | test("``"))' 2>/dev/null | while read -r row; do
+            NUM=$(echo "$row" | jq -r '.number')
+            echo "Sub-issue #$NUM body contains empty backticks — flagging."
+            gh issue edit "$NUM" --add-label "ai-needs-rewrite" || true
+            gh issue comment "$NUM" --body "⚠️ AI Worker: this sub-issue body contains empty inline code spans (\`\`) — likely JSX components or TypeScript generics were stripped during creation. The implementation phase will not run on it until the body is repaired and \`ai-needs-rewrite\` is removed." || true
+          done
 
       - name: Flag incomplete plan
         if: always() && steps.verify_plan.outputs.status == 'incomplete'


### PR DESCRIPTION
## Summary

Six issues spawned by the planner (#249, #251, #252, #256, #257, #268) had JSX components and TypeScript generics stripped from inside backticks — `` `<DateRangePicker />` `` arrived as empty `` `` ``, `` `Promise<void>` `` arrived as `` `Promise` ``. The planner couldn't make sense of empty code spans, the plan phase failed every time, and the watchdog retry loop fed those issues until #362 fixed the upstream gh-CLI bug.

Two known causes for the body corruption:
1. **Shell parsing**: inline `gh issue create --body "$(cat <<…)"` lets the shell — or any wrapping quoting layer — re-parse `<Component>` as I/O redirection, silently dropping the content.
2. **LLM elision**: the model abbreviates repetitive technical fragments (JSX, generics) during long structured generation when content is constructed inline.

## Changes

**`ai-worker.yml` (plan phase) and `ai-plan.yml`** — same prompt template lives in both:
- Replace inline body construction with `mktemp` + `--body-file <path>`. No shell re-parsing of the body content.
- Explicit prompt instructions: keep JSX, HTML tags, and TS generics literal inside backticks; do not abbreviate.
- Per-issue verify step: after each `gh issue create`, re-read the body with `gh issue view --json body --jq .body` and abort the planner if it contains `` `` `` (empty inline code span).

**`ai-worker.yml`** — new `Detect mangled sub-issue bodies` step in the plan job that runs after the planner regardless of outcome. Scans all open sub-issues linked to the parent (`Closes #N` in body) for empty backticks and, if found:
- adds an `ai-needs-rewrite` label
- posts a comment explaining the body needs repair before implementation can run

This is the defense-in-depth backstop in case Claude forgets the per-issue verify.

## Already cleaned

I manually repaired the bodies of #249, #252, #256, #257, #268 (#251 was unaffected) so the planner can re-run on them without re-tripping. They're ready to receive `ai-work` again.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` — both YAMLs parse
- [ ] Next time `ai-work` is added to a parent issue, confirm sub-issues are created via `--body-file` (check the workflow run logs) and that bodies contain literal JSX
- [ ] Inject a deliberately mangled body (e.g. via direct API), add `ai-work` to a parent, and confirm the new "Detect mangled sub-issue bodies" step labels it `ai-needs-rewrite`