### PR TITLE
fix(dashboard): don't gate main widget fetch on :comp_* tokens in trend_sql/anomaly_sql

### DIFF
--- a/dashboard/components/DashboardRenderer.tsx
+++ b/dashboard/components/DashboardRenderer.tsx
@@ -94,12 +94,12 @@ function hasCompTokens(sql: string): boolean {
   );
 }
 
-/** Collects all SQL strings from a widget (main, trend, anomaly for kpi_row). */
+/** Collects the MAIN SQL strings from a widget (item.sql for kpi_row, widget.sql otherwise).
+ *  trend_sql and anomaly_sql are deliberately excluded: the fetch pipeline skips them
+ *  gracefully when comparisonRange is unset, so they must not gate the main widget fetch. */
 function collectWidgetSqls(widget: Widget): string[] {
   if (widget.type === "kpi_row") {
-    return widget.items.flatMap((item) =>
-      [item.sql, item.trend_sql, item.anomaly_sql].filter((s): s is string => typeof s === "string" && s.length > 0)
-    );
+    return widget.items.map((item) => item.sql);
   }
   return [widget.sql];
 }

--- a/dashboard/components/__tests__/DashboardRenderer.test.tsx
+++ b/dashboard/components/__tests__/DashboardRenderer.test.tsx
@@ -814,8 +814,9 @@ describe("DashboardRenderer", () => {
       expect(fetch).not.toHaveBeenCalled();
     });
 
-    it("shows friendly error when kpi_row item trend_sql has :comp_from but no comparisonRange", async () => {
-      vi.stubGlobal("fetch", vi.fn());
+    it("fetches main sql and silently skips trend_sql when only trend_sql has :comp_from but no comparisonRange", async () => {
+      const fetchMock = mockFetchSuccess({ columns: ["sum"], rows: [[500]] });
+      vi.stubGlobal("fetch", fetchMock);
 
       const compTrendSpec: DashboardSpec = {
         title: "KPI Trend Comparativa",
@@ -837,10 +838,16 @@ describe("DashboardRenderer", () => {
       render(<DashboardRenderer spec={compTrendSpec} dateRange={dateRange} />);
 
       await waitFor(() => {
-        expect(screen.getByText("Este panel requiere seleccionar un período de comparación")).toBeInTheDocument();
+        expect(fetchMock).toHaveBeenCalled();
       });
 
-      expect(fetch).not.toHaveBeenCalled();
+      const bodies = fetchMock.mock.calls.map((c: unknown[]) =>
+        JSON.parse((c[1] as { body: string }).body)
+      );
+      const hasCompToken = bodies.some(
+        (b: { sql: string }) => b.sql.includes(":comp_from") || b.sql.includes(":comp_to")
+      );
+      expect(hasCompToken).toBe(false);
     });
 
     const compSqlSpec: DashboardSpec = {


### PR DESCRIPTION
## Summary

`main` is red because `DashboardRenderer.test.tsx > skips trend_sql fetch when comparisonRange is undefined — no :comp_* tokens sent to PG` times out: the main item.sql fetch is never issued, so the `waitFor(() => expect(fetchMock).toHaveBeenCalled())` never resolves.

Root cause: PR #349 made the fetch pipeline silently skip `trend_sql` when `comparisonRange` is unset, but the pre-flight `COMP_MISSING_ERROR` guard was still calling `collectWidgetSqls()` which folded in `trend_sql` and `anomaly_sql`. So any kpi_row whose trend_sql contained literal `:comp_*` tripped the guard and blocked the entire widget — including the main item.sql.

## Changes

- `dashboard/components/DashboardRenderer.tsx`: scope `collectWidgetSqls()` to MAIN sqls only (`item.sql` for `kpi_row`, `widget.sql` otherwise). trend_sql and anomaly_sql fetches are already handled gracefully downstream.
- `dashboard/components/__tests__/DashboardRenderer.test.tsx`: replace the now-obsolete "shows friendly error when trend_sql has :comp_from but no comparisonRange" test with one asserting the main sql is fetched and no `:comp_*` tokens are sent to PostgreSQL — matching PR #349 intent.

## Test Results

```
Test Files  54 passed (54)
     Tests  826 passed (826)
```

Coverage thresholds still satisfied (statements 74.81%, branches 66.08%, functions 76.83%, lines 76.55%).
`ruff check etl/` and `ruff format --check etl/` clean.