### PR TITLE
feat(dashboard): wire LLM circuit breaker into OpenRouter calls

### DIFF
--- a/dashboard/app/api/dashboard/generate/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/generate/__tests__/route.test.ts
@@ -5,6 +5,7 @@ vi.mock("@/lib/llm", async () => {
   const actual = await vi.importActual<typeof import("@/lib/llm")>("@/lib/llm");
   return {
     BudgetExceededError: actual.BudgetExceededError,
+    CircuitBreakerOpenError: actual.CircuitBreakerOpenError,
     generateDashboard: vi.fn(),
   };
 });
@@ -18,7 +19,11 @@ vi.mock("@/lib/schema", async () => {
 });
 
 import { POST } from "../route";
-import { generateDashboard, BudgetExceededError } from "@/lib/llm";
+import {
+  generateDashboard,
+  BudgetExceededError,
+  CircuitBreakerOpenError,
+} from "@/lib/llm";
 
 const mockGenerate = vi.mocked(generateDashboard);
 
@@ -145,6 +150,17 @@ describe("POST /api/dashboard/generate", () => {
     expect(res.status).toBe(429);
     expect(json.code).toBe("LLM_BUDGET_EXCEEDED");
     expect(json.error).toContain("Límite diario");
+  });
+
+  it("returns 503 with LLM_CIRCUIT_OPEN when the LLM circuit is open", async () => {
+    mockGenerate.mockRejectedValue(new CircuitBreakerOpenError());
+
+    const res = await POST(makeRequest({ prompt: "Ventas del mes" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(json.code).toBe("LLM_CIRCUIT_OPEN");
+    expect(json.error).toMatch(/no disponible|Inténtelo/i);
   });
 
   it("returns 500 when LLM throws a generic error", async () => {

--- a/dashboard/app/api/dashboard/generate/route.ts
+++ b/dashboard/app/api/dashboard/generate/route.ts
@@ -9,7 +9,11 @@
  */
 
 import { NextResponse } from "next/server";
-import { generateDashboard, BudgetExceededError } from "@/lib/llm";
+import {
+  generateDashboard,
+  BudgetExceededError,
+  CircuitBreakerOpenError,
+} from "@/lib/llm";
 import { validateSpec } from "@/lib/schema";
 import { ZodError } from "zod";
 import {
@@ -93,6 +97,12 @@ export async function POST(request: Request): Promise<NextResponse> {
       return NextResponse.json(
         formatApiError(err.message, "LLM_BUDGET_EXCEEDED", undefined, requestId),
         { status: 429 },
+      );
+    }
+    if (err instanceof CircuitBreakerOpenError) {
+      return NextResponse.json(
+        formatApiError(err.message, "LLM_CIRCUIT_OPEN", undefined, requestId),
+        { status: 503 },
       );
     }
     const message = err instanceof Error ? err.message : String(err);

--- a/dashboard/app/api/dashboard/modify/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/modify/__tests__/route.test.ts
@@ -10,12 +10,13 @@ vi.mock("@/lib/llm", async () => {
   const actual = await vi.importActual<typeof import("@/lib/llm")>("@/lib/llm");
   return {
     BudgetExceededError: actual.BudgetExceededError,
+    CircuitBreakerOpenError: actual.CircuitBreakerOpenError,
     modifyDashboard: mockModifyDashboard,
   };
 });
 
 import { POST } from "../route";
-import { BudgetExceededError } from "@/lib/llm";
+import { BudgetExceededError, CircuitBreakerOpenError } from "@/lib/llm";
 
 // --- Helpers ----------------------------------------------------------------
 
@@ -175,6 +176,17 @@ describe("POST /api/dashboard/modify", () => {
     const json = await res.json();
     expect(json.code).toBe("LLM_BUDGET_EXCEEDED");
     expect(json.error).toContain("Límite diario");
+  });
+
+  it("returns 503 with LLM_CIRCUIT_OPEN when the LLM circuit is open", async () => {
+    mockModifyDashboard.mockRejectedValue(new CircuitBreakerOpenError());
+
+    const res = await POST(makeRequest({ spec: validSpec, prompt: "Añade algo" }));
+
+    expect(res.status).toBe(503);
+    const json = await res.json();
+    expect(json.code).toBe("LLM_CIRCUIT_OPEN");
+    expect(json.error).toMatch(/no disponible|Inténtelo/i);
   });
 
   it("returns 400 when LLM returns invalid JSON", async () => {

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -8,7 +8,11 @@
  * Response: 200 with updated DashboardSpec, or 400/429/500 on error.
  */
 import { NextResponse } from "next/server";
-import { modifyDashboard, BudgetExceededError } from "@/lib/llm";
+import {
+  modifyDashboard,
+  BudgetExceededError,
+  CircuitBreakerOpenError,
+} from "@/lib/llm";
 import { validateSpec, DashboardSpecSchema, type DashboardSpec } from "@/lib/schema";
 import {
   formatApiError,
@@ -102,11 +106,17 @@ export async function POST(request: Request) {
       JSON.stringify(specParse.data),
       prompt.trim(),
     );
-  } catch (err) {
+  } catch (err: unknown) {
     if (err instanceof BudgetExceededError) {
       return NextResponse.json(
         formatApiError(err.message, "LLM_BUDGET_EXCEEDED", undefined, requestId),
         { status: 429 },
+      );
+    }
+    if (err instanceof CircuitBreakerOpenError) {
+      return NextResponse.json(
+        formatApiError(err.message, "LLM_CIRCUIT_OPEN", undefined, requestId),
+        { status: 503 },
       );
     }
     const message = err instanceof Error ? err.message : String(err);

--- a/dashboard/app/api/health/__tests__/route.test.ts
+++ b/dashboard/app/api/health/__tests__/route.test.ts
@@ -7,6 +7,7 @@ describe("GET /api/health", () => {
     expect(response.status).toBe(200);
 
     const body = await response.json();
-    expect(body).toEqual({ status: "ok" });
+    expect(body.status).toBe("ok");
+    expect(["closed", "open", "half-open"]).toContain(body.llm_circuit);
   });
 });

--- a/dashboard/app/api/health/route.ts
+++ b/dashboard/app/api/health/route.ts
@@ -1,10 +1,12 @@
 /**
  * GET /api/health — Liveness check for Docker healthcheck.
  *
- * Returns 200 with `{status: "ok"}`.
+ * Returns 200 with `{ status: "ok", llm_circuit: ... }` where `llm_circuit` is the
+ * dashboard LLM circuit breaker state (`closed` | `open` | `half-open`).
  */
 import { NextResponse } from "next/server";
+import { getCircuitState } from "@/lib/llm-circuit-breaker";
 
 export async function GET(): Promise<NextResponse> {
-  return NextResponse.json({ status: "ok" });
+  return NextResponse.json({ status: "ok", llm_circuit: getCircuitState() });
 }

--- a/dashboard/lib/__tests__/llm.test.ts
+++ b/dashboard/lib/__tests__/llm.test.ts
@@ -29,10 +29,12 @@ vi.mock("../llm-usage", () => ({
   },
 }));
 
+import { _resetCircuitBreaker } from "../llm-circuit-breaker";
 import { generateDashboard, modifyDashboard, resetClient } from "../llm";
 
 describe("llm", () => {
   beforeEach(() => {
+    _resetCircuitBreaker();
     vi.stubEnv("OPENROUTER_API_KEY", "test-key-123");
     resetClient();
     mockCreate.mockReset();
@@ -41,6 +43,7 @@ describe("llm", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     resetClient();
+    _resetCircuitBreaker();
   });
 
   describe("generateDashboard", () => {

--- a/dashboard/lib/llm.ts
+++ b/dashboard/lib/llm.ts
@@ -11,8 +11,10 @@ import { buildSuggestPrompt, buildGapAnalysisPrompt } from "./creation-prompts";
 import { buildAnalyzePrompt, buildSuggestionPrompt } from "./analyze-prompts";
 import type { ReviewContent } from "./review-prompts";
 import { logUsage, checkDailyBudget } from "./llm-usage";
+import { callWithCircuitBreaker } from "./llm-circuit-breaker";
 
 export { BudgetExceededError } from "./llm-usage";
+export { CircuitBreakerOpenError } from "./llm-circuit-breaker";
 
 const EMPTY_USAGE = {
   prompt_tokens: 0,
@@ -146,16 +148,18 @@ export async function generateDashboard(userPrompt: string): Promise<string> {
 
   await checkDailyBudget();
 
-  const response = await withRetry(() =>
-    client.chat.completions.create({
-      model: getModel(),
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userPrompt },
-      ],
-      temperature: 0.2,
-      max_tokens: 8192,
-    }),
+  const response = await callWithCircuitBreaker(() =>
+    withRetry(() =>
+      client.chat.completions.create({
+        model: getModel(),
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+        temperature: 0.2,
+        max_tokens: 8192,
+      }),
+    ),
   );
 
   void logUsage("generateDashboard", getModel(), response.usage ?? EMPTY_USAGE);
@@ -181,16 +185,18 @@ export async function modifyDashboard(
 
   await checkDailyBudget();
 
-  const response = await withRetry(() =>
-    client.chat.completions.create({
-      model: getModel(),
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userPrompt },
-      ],
-      temperature: 0.2,
-      max_tokens: 8192,
-    }),
+  const response = await callWithCircuitBreaker(() =>
+    withRetry(() =>
+      client.chat.completions.create({
+        model: getModel(),
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+        temperature: 0.2,
+        max_tokens: 8192,
+      }),
+    ),
   );
 
   void logUsage("modifyDashboard", getModel(), response.usage ?? EMPTY_USAGE);
@@ -216,18 +222,22 @@ export async function suggestDashboards(
 
   await checkDailyBudget();
 
-  const response = await client.chat.completions.create({
-    model: getModel(),
-    messages: [
-      { role: "system", content: systemPrompt },
-      {
-        role: "user",
-        content: `Sugiere 3-4 dashboards útiles para el rol: ${role}`,
-      },
-    ],
-    temperature: 0.2,
-    max_tokens: 8192,
-  });
+  const response = await callWithCircuitBreaker(() =>
+    withRetry(() =>
+      client.chat.completions.create({
+        model: getModel(),
+        messages: [
+          { role: "system", content: systemPrompt },
+          {
+            role: "user",
+            content: `Sugiere 3-4 dashboards útiles para el rol: ${role}`,
+          },
+        ],
+        temperature: 0.2,
+        max_tokens: 8192,
+      }),
+    ),
+  );
 
   void logUsage("suggestDashboards", getModel(), response.usage ?? EMPTY_USAGE);
 
@@ -255,19 +265,23 @@ export async function analyzeGaps(
 
   await checkDailyBudget();
 
-  const response = await client.chat.completions.create({
-    model: getModel(),
-    messages: [
-      { role: "system", content: systemPrompt },
-      {
-        role: "user",
-        content:
-          "Analiza los dashboards existentes e identifica las áreas de negocio importantes que no están cubiertas.",
-      },
-    ],
-    temperature: 0.2,
-    max_tokens: 8192,
-  });
+  const response = await callWithCircuitBreaker(() =>
+    withRetry(() =>
+      client.chat.completions.create({
+        model: getModel(),
+        messages: [
+          { role: "system", content: systemPrompt },
+          {
+            role: "user",
+            content:
+              "Analiza los dashboards existentes e identifica las áreas de negocio importantes que no están cubiertas.",
+          },
+        ],
+        temperature: 0.2,
+        max_tokens: 8192,
+      }),
+    ),
+  );
 
   void logUsage("analyzeGaps", getModel(), response.usage ?? EMPTY_USAGE);
 
@@ -293,15 +307,19 @@ export async function analyzeDashboard(
 
   await checkDailyBudget();
 
-  const response = await client.chat.completions.create({
-    model: getModel(),
-    messages: [
-      { role: "system", content: systemPrompt },
-      { role: "user", content: userPrompt },
-    ],
-    temperature: 0.3,
-    max_tokens: 4096,
-  });
+  const response = await callWithCircuitBreaker(() =>
+    withRetry(() =>
+      client.chat.completions.create({
+        model: getModel(),
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+        temperature: 0.3,
+        max_tokens: 4096,
+      }),
+    ),
+  );
 
   void logUsage("analyzeDashboard", getModel(), response.usage ?? EMPTY_USAGE);
 
@@ -325,14 +343,16 @@ export async function generateReview(
 
   await checkDailyBudget();
 
-  const response = await client.chat.completions.create({
-    model: getModel(),
-    messages: [
-      { role: "system", content: systemPrompt },
-    ],
-    temperature: 0.2,
-    max_tokens: 4096,
-  });
+  const response = await callWithCircuitBreaker(() =>
+    withRetry(() =>
+      client.chat.completions.create({
+        model: getModel(),
+        messages: [{ role: "system", content: systemPrompt }],
+        temperature: 0.2,
+        max_tokens: 4096,
+      }),
+    ),
+  );
 
   void logUsage("generateReview", getModel(), response.usage ?? EMPTY_USAGE);
 
@@ -410,12 +430,16 @@ export async function generateSuggestions(
     const client = getClient();
     const prompt = buildSuggestionPrompt(serializedData, lastExchange);
 
-    const response = await client.chat.completions.create({
-      model: getModel(),
-      messages: [{ role: "user", content: prompt }],
-      temperature: 0.5,
-      max_tokens: 512,
-    });
+    const response = await callWithCircuitBreaker(() =>
+      withRetry(() =>
+        client.chat.completions.create({
+          model: getModel(),
+          messages: [{ role: "user", content: prompt }],
+          temperature: 0.5,
+          max_tokens: 512,
+        }),
+      ),
+    );
 
     void logUsage("generateSuggestions", getModel(), response.usage ?? EMPTY_USAGE);
 


### PR DESCRIPTION
## Summary
Completes the half-implemented circuit breaker work: all `chat.completions.create` paths in `dashboard/lib/llm.ts` run inside `callWithCircuitBreaker` (outside `withRetry`). `GET /api/health` now includes `llm_circuit` state.

## Issues
Closes #340, closes #256.

## Testing
- `cd dashboard && npm test` (Vitest) — llm + health suites.

Made with [Cursor](https://cursor.com)