### PR TITLE
feat(dashboard): chart skeleton + ARIA for bar/line/area/donut

### DIFF
--- a/dashboard/components/widgets/AreaChartWidget.tsx
+++ b/dashboard/components/widgets/AreaChartWidget.tsx
@@ -7,6 +7,7 @@ import { EMPTY_MESSAGE, resolveXY, safeNumber } from "./types";
 import { CHART_COLORS } from "./chart-colors";
 import { applyGlossary } from "@/lib/glossary";
 import { mergeComparisonSeries } from "./BarChartWidget";
+import { WidgetSkeleton } from "./WidgetSkeleton";
 
 interface AreaChartWidgetProps {
   widget: AreaChartWidgetSpec;
@@ -20,9 +21,20 @@ interface AreaChartWidgetProps {
 export function AreaChartWidget({ widget, data, comparisonData, glossary }: AreaChartWidgetProps) {
   const titleNode = applyGlossary(widget.title, glossary);
 
-  if (!data || data.rows.length === 0) {
+  if (data === null) {
     return (
-      <Card className="p-4">
+      <Card className="p-4" aria-live="polite" aria-busy={true}>
+        <h3 className="mb-4 text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
+          {titleNode}
+        </h3>
+        <WidgetSkeleton type="chart" />
+      </Card>
+    );
+  }
+
+  if (data.rows.length === 0) {
+    return (
+      <Card className="p-4" aria-live="polite" aria-busy={false}>
         <h3 className="text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
           {titleNode}
         </h3>
@@ -36,7 +48,7 @@ export function AreaChartWidget({ widget, data, comparisonData, glossary }: Area
   const resolved = resolveXY(data, widget.x, widget.y);
   if (!resolved) {
     return (
-      <Card className="p-4">
+      <Card className="p-4" aria-live="polite" aria-busy={false}>
         <h3 className="text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
           {titleNode}
         </h3>
@@ -62,33 +74,35 @@ export function AreaChartWidget({ widget, data, comparisonData, glossary }: Area
   const categories = hasComparison ? ["Actual", "Anterior"] : [yCol];
 
   return (
-    <Card className="p-4">
+    <Card className="p-4" aria-live="polite" aria-busy={false}>
       <h3 className="mb-4 text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
         {titleNode}
       </h3>
 
-      {/* Mobile: no y-axis to prevent overflow */}
-      <div className="sm:hidden">
-        <AreaChart
-          data={chartData}
-          index={xCol}
-          categories={categories}
-          colors={CHART_COLORS}
-          showYAxis={false}
-          showLegend={hasComparison}
-        />
-      </div>
+      <div role="img" aria-label={`Gráfico de área: ${widget.title}.`}>
+        <span className="sr-only">Gráfico de área.</span>
 
-      {/* Desktop: full y-axis */}
-      <div className="hidden sm:block">
-        <AreaChart
-          data={chartData}
-          index={xCol}
-          categories={categories}
-          colors={CHART_COLORS}
-          yAxisWidth={60}
-          showLegend={hasComparison}
-        />
+        <div className="sm:hidden">
+          <AreaChart
+            data={chartData}
+            index={xCol}
+            categories={categories}
+            colors={CHART_COLORS}
+            showYAxis={false}
+            showLegend={hasComparison}
+          />
+        </div>
+
+        <div className="hidden sm:block">
+          <AreaChart
+            data={chartData}
+            index={xCol}
+            categories={categories}
+            colors={CHART_COLORS}
+            yAxisWidth={60}
+            showLegend={hasComparison}
+          />
+        </div>
       </div>
     </Card>
   );

--- a/dashboard/components/widgets/BarChartWidget.tsx
+++ b/dashboard/components/widgets/BarChartWidget.tsx
@@ -6,6 +6,7 @@ import type { WidgetData } from "./types";
 import { EMPTY_MESSAGE, resolveXY, safeNumber } from "./types";
 import { CHART_COLORS } from "./chart-colors";
 import { applyGlossary } from "@/lib/glossary";
+import { WidgetSkeleton } from "./WidgetSkeleton";
 
 interface BarChartWidgetProps {
   widget: BarChartWidgetSpec;
@@ -43,9 +44,20 @@ export function mergeComparisonSeries(
 export function BarChartWidget({ widget, data, comparisonData, glossary }: BarChartWidgetProps) {
   const titleNode = applyGlossary(widget.title, glossary);
 
-  if (!data || data.rows.length === 0) {
+  if (data === null) {
     return (
-      <Card className="p-4">
+      <Card className="p-4" aria-live="polite" aria-busy={true}>
+        <h3 className="mb-4 text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
+          {titleNode}
+        </h3>
+        <WidgetSkeleton type="chart" />
+      </Card>
+    );
+  }
+
+  if (data.rows.length === 0) {
+    return (
+      <Card className="p-4" aria-live="polite" aria-busy={false}>
         <h3 className="text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
           {titleNode}
         </h3>
@@ -59,7 +71,7 @@ export function BarChartWidget({ widget, data, comparisonData, glossary }: BarCh
   const resolved = resolveXY(data, widget.x, widget.y);
   if (!resolved) {
     return (
-      <Card className="p-4">
+      <Card className="p-4" aria-live="polite" aria-busy={false}>
         <h3 className="text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
           {titleNode}
         </h3>
@@ -85,33 +97,42 @@ export function BarChartWidget({ widget, data, comparisonData, glossary }: BarCh
   const categories = hasComparison ? ["Actual", "Anterior"] : [yCol];
 
   return (
-    <Card className="p-4">
+    <Card className="p-4" aria-live="polite" aria-busy={false}>
       <h3 className="mb-4 text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
         {titleNode}
       </h3>
 
-      {/* Mobile: no y-axis to prevent overflow */}
-      <div className="sm:hidden">
-        <BarChart
-          data={chartData}
-          index={xCol}
-          categories={categories}
-          colors={CHART_COLORS}
-          showYAxis={false}
-          showLegend={hasComparison}
-        />
-      </div>
+      <div
+        role="img"
+        aria-label={`Gráfico de barras: ${widget.title}. ${chartData.length} categorías.`}
+      >
+        <span className="sr-only">
+          Gráfico de barras con {chartData.length} categorías.
+        </span>
 
-      {/* Desktop: full y-axis */}
-      <div className="hidden sm:block">
-        <BarChart
-          data={chartData}
-          index={xCol}
-          categories={categories}
-          colors={CHART_COLORS}
-          yAxisWidth={60}
-          showLegend={hasComparison}
-        />
+        {/* Mobile: no y-axis to prevent overflow */}
+        <div className="sm:hidden">
+          <BarChart
+            data={chartData}
+            index={xCol}
+            categories={categories}
+            colors={CHART_COLORS}
+            showYAxis={false}
+            showLegend={hasComparison}
+          />
+        </div>
+
+        {/* Desktop: full y-axis */}
+        <div className="hidden sm:block">
+          <BarChart
+            data={chartData}
+            index={xCol}
+            categories={categories}
+            colors={CHART_COLORS}
+            yAxisWidth={60}
+            showLegend={hasComparison}
+          />
+        </div>
       </div>
     </Card>
   );

--- a/dashboard/components/widgets/DonutChartWidget.tsx
+++ b/dashboard/components/widgets/DonutChartWidget.tsx
@@ -6,6 +6,7 @@ import type { WidgetData } from "./types";
 import { EMPTY_MESSAGE, resolveXY, safeNumber } from "./types";
 import { CHART_COLORS } from "./chart-colors";
 import { applyGlossary } from "@/lib/glossary";
+import { WidgetSkeleton } from "./WidgetSkeleton";
 
 interface DonutChartWidgetProps {
   widget: DonutChartWidgetSpec;
@@ -19,9 +20,20 @@ interface DonutChartWidgetProps {
 export function DonutChartWidget({ widget, data, comparisonData, glossary }: DonutChartWidgetProps) {
   const titleNode = applyGlossary(widget.title, glossary);
 
-  if (!data || data.rows.length === 0) {
+  if (data === null) {
     return (
-      <Card className="p-4">
+      <Card className="p-4" aria-live="polite" aria-busy={true}>
+        <h3 className="mb-4 text-sm font-medium text-tremor-content dark:text-dark-tremor-content">
+          {titleNode}
+        </h3>
+        <WidgetSkeleton type="chart" />
+      </Card>
+    );
+  }
+
+  if (data.rows.length === 0) {
+    return (
+      <Card className="p-4" aria-live="polite" aria-busy={false}>
         <h3 className="text-sm font-medium text-tremor-content dark:text-dark-tremor-content">{titleNode}</h3>
         <p className="mt-4 text-center text-sm text-tremor-content dark:text-dark-tremor-content-emphasis">
           {EMPTY_MESSAGE}
@@ -33,7 +45,7 @@ export function DonutChartWidget({ widget, data, comparisonData, glossary }: Don
   const resolved = resolveXY(data, widget.x, widget.y);
   if (!resolved) {
     return (
-      <Card className="p-4">
+      <Card className="p-4" aria-live="polite" aria-busy={false}>
         <h3 className="text-sm font-medium text-tremor-content dark:text-dark-tremor-content">{titleNode}</h3>
         <p className="mt-4 text-center text-sm text-tremor-content dark:text-dark-tremor-content-emphasis">
           {EMPTY_MESSAGE}
@@ -50,7 +62,6 @@ export function DonutChartWidget({ widget, data, comparisonData, glossary }: Don
       value: safeNumber(row[yIdx])!,
     }));
 
-  // Compute comparison total for the side-by-side label (simplest Tremor approach for donut comparison)
   let comparisonTotal: number | null = null;
   if (comparisonData && comparisonData.rows.length > 0) {
     const compResolved = resolveXY(comparisonData, widget.x, widget.y);
@@ -67,16 +78,24 @@ export function DonutChartWidget({ widget, data, comparisonData, glossary }: Don
   const currentTotal = chartData.reduce((s, d) => s + d.value, 0);
 
   return (
-    <Card className="p-4">
+    <Card className="p-4" aria-live="polite" aria-busy={false}>
       <h3 className="mb-4 text-sm font-medium text-tremor-content dark:text-dark-tremor-content">{titleNode}</h3>
-      <DonutChart
-        data={chartData}
-        category="value"
-        index="name"
-        colors={CHART_COLORS}
-        showLabel
-        showAnimation
-      />
+
+      <div
+        role="img"
+        aria-label={`Gráfico de donut: ${widget.title}. ${chartData.length} categorías.`}
+      >
+        <span className="sr-only">Gráfico de donut con {chartData.length} categorías.</span>
+        <DonutChart
+          data={chartData}
+          category="value"
+          index="name"
+          colors={CHART_COLORS}
+          showLabel
+          showAnimation
+        />
+      </div>
+
       {comparisonTotal !== null && (
         <div className="mt-3 flex items-center justify-center gap-4 text-xs text-tremor-content dark:text-dark-tremor-content">
           <span className="font-medium">

--- a/dashboard/components/widgets/LineChartWidget.tsx
+++ b/dashboard/components/widgets/LineChartWidget.tsx
@@ -7,6 +7,7 @@ import { EMPTY_MESSAGE, resolveXY, safeNumber } from "./types";
 import { CHART_COLORS } from "./chart-colors";
 import { applyGlossary } from "@/lib/glossary";
 import { mergeComparisonSeries } from "./BarChartWidget";
+import { WidgetSkeleton } from "./WidgetSkeleton";
 
 interface LineChartWidgetProps {
   widget: LineChartWidgetSpec;
@@ -20,9 +21,20 @@ interface LineChartWidgetProps {
 export function LineChartWidget({ widget, data, comparisonData, glossary }: LineChartWidgetProps) {
   const titleNode = applyGlossary(widget.title, glossary);
 
-  if (!data || data.rows.length === 0) {
+  if (data === null) {
     return (
-      <Card className="p-4">
+      <Card className="p-4" aria-live="polite" aria-busy={true}>
+        <h3 className="mb-4 text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
+          {titleNode}
+        </h3>
+        <WidgetSkeleton type="chart" />
+      </Card>
+    );
+  }
+
+  if (data.rows.length === 0) {
+    return (
+      <Card className="p-4" aria-live="polite" aria-busy={false}>
         <h3 className="text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
           {titleNode}
         </h3>
@@ -36,7 +48,7 @@ export function LineChartWidget({ widget, data, comparisonData, glossary }: Line
   const resolved = resolveXY(data, widget.x, widget.y);
   if (!resolved) {
     return (
-      <Card className="p-4">
+      <Card className="p-4" aria-live="polite" aria-busy={false}>
         <h3 className="text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
           {titleNode}
         </h3>
@@ -62,33 +74,35 @@ export function LineChartWidget({ widget, data, comparisonData, glossary }: Line
   const categories = hasComparison ? ["Actual", "Anterior"] : [yCol];
 
   return (
-    <Card className="p-4">
+    <Card className="p-4" aria-live="polite" aria-busy={false}>
       <h3 className="mb-4 text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
         {titleNode}
       </h3>
 
-      {/* Mobile: no y-axis to prevent overflow */}
-      <div className="sm:hidden">
-        <LineChart
-          data={chartData}
-          index={xCol}
-          categories={categories}
-          colors={CHART_COLORS}
-          showYAxis={false}
-          showLegend={hasComparison}
-        />
-      </div>
+      <div role="img" aria-label={`Gráfico de líneas: ${widget.title}.`}>
+        <span className="sr-only">Gráfico de líneas.</span>
 
-      {/* Desktop: full y-axis */}
-      <div className="hidden sm:block">
-        <LineChart
-          data={chartData}
-          index={xCol}
-          categories={categories}
-          colors={CHART_COLORS}
-          yAxisWidth={60}
-          showLegend={hasComparison}
-        />
+        <div className="sm:hidden">
+          <LineChart
+            data={chartData}
+            index={xCol}
+            categories={categories}
+            colors={CHART_COLORS}
+            showYAxis={false}
+            showLegend={hasComparison}
+          />
+        </div>
+
+        <div className="hidden sm:block">
+          <LineChart
+            data={chartData}
+            index={xCol}
+            categories={categories}
+            colors={CHART_COLORS}
+            yAxisWidth={60}
+            showLegend={hasComparison}
+          />
+        </div>
       </div>
     </Card>
   );

--- a/dashboard/components/widgets/__tests__/widgets.test.tsx
+++ b/dashboard/components/widgets/__tests__/widgets.test.tsx
@@ -184,9 +184,9 @@ describe("BarChartWidget", () => {
     expect(screen.getByText("Ventas por Tienda")).toBeInTheDocument();
   });
 
-  it("shows empty message for null data", () => {
+  it("shows skeleton for null data (loading)", () => {
     render(<BarChartWidget widget={widget} data={null} />);
-    expect(screen.getByText("Sin datos")).toBeInTheDocument();
+    expect(screen.getByTestId("widget-skeleton")).toBeInTheDocument();
   });
 
   it("shows empty message for empty rows", () => {
@@ -227,9 +227,9 @@ describe("LineChartWidget", () => {
     expect(screen.getByText("Tendencia")).toBeInTheDocument();
   });
 
-  it("shows empty message for null data", () => {
+  it("shows skeleton for null data (loading)", () => {
     render(<LineChartWidget widget={widget} data={null} />);
-    expect(screen.getByText("Sin datos")).toBeInTheDocument();
+    expect(screen.getByTestId("widget-skeleton")).toBeInTheDocument();
   });
 });
 
@@ -255,9 +255,9 @@ describe("AreaChartWidget", () => {
     expect(screen.getByText("Ingresos")).toBeInTheDocument();
   });
 
-  it("shows empty message for null data", () => {
+  it("shows skeleton for null data (loading)", () => {
     render(<AreaChartWidget widget={widget} data={null} />);
-    expect(screen.getByText("Sin datos")).toBeInTheDocument();
+    expect(screen.getByTestId("widget-skeleton")).toBeInTheDocument();
   });
 });
 
@@ -283,9 +283,9 @@ describe("DonutChartWidget", () => {
     expect(screen.getByText("Mix Familias")).toBeInTheDocument();
   });
 
-  it("shows empty message for null data", () => {
+  it("shows skeleton for null data (loading)", () => {
     render(<DonutChartWidget widget={widget} data={null} />);
-    expect(screen.getByText("Sin datos")).toBeInTheDocument();
+    expect(screen.getByTestId("widget-skeleton")).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
`data === null` → `WidgetSkeleton`; empty rows → Sin datos. Charts wrapped in `role="img"` with Spanish `aria-label` + `sr-only`; `aria-live` / `aria-busy` on cards.

## Issues
Closes #338, closes #252.

## Testing
- `cd dashboard && npm test`

Made with [Cursor](https://cursor.com)