### PR TITLE
fix(etl): schema init before 4D; pytest-cov in CI; prod Hub default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@
 ETL_VERSION=latest
 DASHBOARD_VERSION=latest
 # Override if you publish to a different Docker Hub namespace.
-# DOCKERHUB_NAMESPACE=alvarolobato264
+# DOCKERHUB_NAMESPACE=alobato
 
 # Interface to bind host ports on. 0.0.0.0 = reachable on every network
 # interface (LAN). 127.0.0.1 = loopback only (useful behind a reverse proxy).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         if: always()
         with:
           name: etl-coverage
-          path: etl/coverage.xml
+          path: coverage.xml
 
   dashboard-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,16 @@ jobs:
         with:
           python-version: '3.12'
       - run: pip install -r etl/requirements-dev.txt
-      - run: pytest etl/tests/ -x --tb=short -q
+      - run: pytest etl/tests/ -x --tb=short -q --cov=etl --cov-report=term-missing --cov-report=xml
         env:
           # Tests that need live connections will skip gracefully
           P4D_HOST: ""
           POSTGRES_DSN: ""
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: etl-coverage
+          path: etl/coverage.xml
 
   dashboard-test:
     runs-on: ubuntu-latest

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,7 +52,7 @@ services:
   # For a one-off sync: docker compose run --rm etl python -m etl.main --once
   # ---------------------------------------------------------------------------
   etl:
-    image: ${DOCKERHUB_NAMESPACE:-alvarolobato264}/powershop-etl:${ETL_VERSION:-latest}
+    image: ${DOCKERHUB_NAMESPACE:-alobato}/powershop-etl:${ETL_VERSION:-latest}
     restart: unless-stopped
     environment:
       P4D_HOST: ${P4D_HOST:-}
@@ -209,7 +209,7 @@ services:
   # Dashboard App — AI-generated dashboards (Next.js + Tremor, port 4000)
   # ---------------------------------------------------------------------------
   dashboard:
-    image: ${DOCKERHUB_NAMESPACE:-alvarolobato264}/powershop-dashboard:${DASHBOARD_VERSION:-latest}
+    image: ${DOCKERHUB_NAMESPACE:-alobato}/powershop-dashboard:${DASHBOARD_VERSION:-latest}
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}

--- a/etl/main.py
+++ b/etl/main.py
@@ -399,42 +399,6 @@ def run_full_sync(
 
 
 # ---------------------------------------------------------------------------
-# Connection test
-# ---------------------------------------------------------------------------
-
-
-def _test_connections(config) -> tuple:
-    """Attempt to connect to both 4D and PostgreSQL.  Exit(1) on failure.
-
-    Returns (conn_4d, conn_pg) on success.
-    """
-    from etl.db import fourd, postgres
-
-    conn_4d = None
-    conn_pg = None
-
-    logger.info("Testing 4D connection to %s:%d ...", config.p4d_host, config.p4d_port)
-    try:
-        conn_4d = fourd.get_connection(config)
-        logger.info("4D connection OK")
-    except Exception as exc:
-        logger.error("Cannot connect to 4D: %s", exc)
-        sys.exit(1)
-
-    logger.info("Testing PostgreSQL connection ...")
-    try:
-        conn_pg = postgres.get_connection(config)
-        logger.info("PostgreSQL connection OK")
-    except Exception as exc:
-        logger.error("Cannot connect to PostgreSQL: %s", exc)
-        if conn_4d is not None:
-            conn_4d.close()
-        sys.exit(1)
-
-    return conn_4d, conn_pg
-
-
-# ---------------------------------------------------------------------------
 # Scheduler loop (extracted for testability)
 # ---------------------------------------------------------------------------
 
@@ -493,11 +457,39 @@ def main() -> None:
 
     cron_hour = int(os.environ.get("ETL_CRON_HOUR", "2"))
 
-    conn_4d, conn_pg = _test_connections(config)
+    from etl.db import fourd, postgres
+
+    logger.info("Connecting to PostgreSQL ...")
+    try:
+        conn_pg = postgres.get_connection(config)
+        logger.info("PostgreSQL connection OK")
+    except Exception as exc:
+        logger.error("Cannot connect to PostgreSQL: %s", exc)
+        sys.exit(1)
 
     try:
         _init_schema(conn_pg)
+    except Exception:
+        logger.exception("Schema initialisation failed")
+        try:
+            conn_pg.close()
+        except Exception:
+            pass
+        sys.exit(1)
 
+    logger.info("Testing 4D connection to %s:%d ...", config.p4d_host, config.p4d_port)
+    try:
+        conn_4d = fourd.get_connection(config)
+        logger.info("4D connection OK")
+    except Exception as exc:
+        logger.error("Cannot connect to 4D: %s", exc)
+        try:
+            conn_pg.close()
+        except Exception:
+            pass
+        sys.exit(1)
+
+    try:
         if args.once:
             run_full_sync(conn_4d, conn_pg, trigger="cli")
         else:


### PR DESCRIPTION
## Summary
- ETL connects to PostgreSQL, runs `init.sql`, then probes 4D — dashboard tables exist even when 4D is unreachable.
- CI: `pytest --cov=etl` + `coverage.xml` artifact.
- `docker-compose.prod.yml` default `DOCKERHUB_NAMESPACE` → `alobato`; .env.example comment.

## Issues
Closes #299, closes #230, closes #201.

## Testing
- `pytest etl/tests/test_main.py etl/tests/test_trigger.py etl/tests/test_scheduler.py`

Made with [Cursor](https://cursor.com)