### PR TITLE
Fix default dashboard SQL failures, optional query cost guard, ps_gc_albaranes.abono

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,10 @@ DASHBOARD_LLM_MODEL=anthropic/claude-sonnet-4
 # Optional daily spend cap for LLM calls in USD (e.g. 5.00); unset = no limit
 # LLM_DAILY_BUDGET_USD=5.00
 
+# Optional: reject dashboard /api/query requests when EXPLAIN total cost exceeds
+# this positive integer. Unset or zero = no cost-based rejection (recommended for local use).
+# QUERY_COST_LIMIT=500000
+
 # -----------------------------------------------------------------------------
 # Docker Hub (used by GitHub Actions to push ETL images)
 # -----------------------------------------------------------------------------

--- a/dashboard/lib/__tests__/date-params-templates.test.ts
+++ b/dashboard/lib/__tests__/date-params-templates.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { substituteDateParams } from "../date-params";
+import { TEMPLATES } from "../templates";
+
+describe("substituteDateParams on built-in templates", () => {
+  const ranges = {
+    curr: {
+      from: new Date(Date.UTC(2026, 2, 1)),
+      to: new Date(Date.UTC(2026, 2, 31)),
+    },
+  };
+
+  it("Retail YoY KPI SQL stays valid PostgreSQL after token substitution", () => {
+    const general = TEMPLATES.find((t) => t.slug === "general");
+    const kpi = general!.spec.widgets.find((w) => w.id === "general-kpis");
+    expect(kpi?.type).toBe("kpi_row");
+    if (kpi?.type !== "kpi_row") {
+      throw new Error("expected general-kpis to be kpi_row");
+    }
+    const raw = kpi.items.find((i) => i.label === "Retail YoY %")!.sql;
+    const sql = substituteDateParams(raw, ranges);
+    expect(sql).not.toMatch(/:curr_from|:curr_to/);
+    expect(sql).toMatch(/'2026-03-01'::date\s*-\s*INTERVAL\s+'1 year'/);
+    expect(sql).toMatch(/'2026-03-31'::date\s*-\s*INTERVAL\s+'1 year'/);
+  });
+});

--- a/dashboard/lib/__tests__/query-validator.test.ts
+++ b/dashboard/lib/__tests__/query-validator.test.ts
@@ -129,7 +129,22 @@ describe("validateQueryCost", () => {
     const cost = await validateQueryCost("SELECT 1");
     expect(cost).toBe(50000);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Invalid or zero QUERY_COST_LIMIT")
+      expect.stringContaining("Invalid QUERY_COST_LIMIT")
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("disables cost guard for partially numeric strings (no silent parseInt truncation)", async () => {
+    process.env.QUERY_COST_LIMIT = "100000foo";
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockQuery.mockResolvedValueOnce({
+      columns: ["QUERY PLAN"],
+      rows: [[makePlan(500_000)]],
+    });
+    const cost = await validateQueryCost("SELECT 1");
+    expect(cost).toBe(500_000);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid QUERY_COST_LIMIT")
     );
     warnSpy.mockRestore();
   });

--- a/dashboard/lib/__tests__/query-validator.test.ts
+++ b/dashboard/lib/__tests__/query-validator.test.ts
@@ -69,17 +69,17 @@ describe("validateQueryCost", () => {
     expect(cost).toBe(500);
   });
 
-  it("throws QueryTooExpensiveError when cost exceeds default limit (100000)", async () => {
+  it("does not throw when QUERY_COST_LIMIT is unset even for very high planner cost", async () => {
     mockQuery.mockResolvedValueOnce({
       columns: ["QUERY PLAN"],
-      rows: [[makePlan(200000)]],
+      rows: [[makePlan(9_000_000)]],
     });
-    await expect(validateQueryCost("SELECT * FROM ps_stock_tienda")).rejects.toThrow(
-      QueryTooExpensiveError
-    );
+    const cost = await validateQueryCost("SELECT * FROM ps_stock_tienda");
+    expect(cost).toBe(9_000_000);
   });
 
-  it("QueryTooExpensiveError has cost, limit properties and fixed Spanish message", async () => {
+  it("QueryTooExpensiveError has cost, limit properties and fixed Spanish message when limit is enforced", async () => {
+    process.env.QUERY_COST_LIMIT = "100000";
     mockQuery.mockResolvedValueOnce({
       columns: ["QUERY PLAN"],
       rows: [[makePlan(150000)]],
@@ -119,7 +119,7 @@ describe("validateQueryCost", () => {
     expect(cost).toBe(50000);
   });
 
-  it("falls back to default limit when QUERY_COST_LIMIT is non-numeric", async () => {
+  it("disables cost guard and warns when QUERY_COST_LIMIT is non-numeric", async () => {
     process.env.QUERY_COST_LIMIT = "notanumber";
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     mockQuery.mockResolvedValueOnce({
@@ -129,23 +129,22 @@ describe("validateQueryCost", () => {
     const cost = await validateQueryCost("SELECT 1");
     expect(cost).toBe(50000);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Invalid QUERY_COST_LIMIT")
+      expect.stringContaining("Invalid or zero QUERY_COST_LIMIT")
     );
     warnSpy.mockRestore();
   });
 
-  it("falls back to default limit and blocks when QUERY_COST_LIMIT is zero", async () => {
+  it("disables cost guard and warns when QUERY_COST_LIMIT is zero", async () => {
     process.env.QUERY_COST_LIMIT = "0";
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     mockQuery.mockResolvedValueOnce({
       columns: ["QUERY PLAN"],
       rows: [[makePlan(150000)]],
     });
-    await expect(validateQueryCost("SELECT * FROM ps_ventas")).rejects.toThrow(
-      QueryTooExpensiveError
-    );
+    const cost = await validateQueryCost("SELECT * FROM ps_ventas");
+    expect(cost).toBe(150000);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Invalid QUERY_COST_LIMIT")
+      expect.stringContaining("Invalid or zero QUERY_COST_LIMIT")
     );
     warnSpy.mockRestore();
   });
@@ -253,7 +252,8 @@ describe("validateQueryCost", () => {
     expect(cost).toBe(500);
   });
 
-  it("throws QueryTooExpensiveError with pre-parsed plan when cost exceeds limit", async () => {
+  it("throws QueryTooExpensiveError with pre-parsed plan when cost exceeds enforced limit", async () => {
+    process.env.QUERY_COST_LIMIT = "100000";
     mockQuery.mockResolvedValueOnce({
       columns: ["QUERY PLAN"],
       rows: [[makeParsedPlan(200000)]],

--- a/dashboard/lib/__tests__/templates.test.ts
+++ b/dashboard/lib/__tests__/templates.test.ts
@@ -149,4 +149,19 @@ describe("SQL rule compliance across all templates", () => {
       }
     }
   });
+
+  it("YoY-style SQL uses :curr_*::date before INTERVAL (avoids PG 'invalid input syntax for type interval')", () => {
+    const general = TEMPLATES.find((t) => t.slug === "general");
+    expect(general).toBeDefined();
+    const kpi = general!.spec.widgets.find((w) => w.id === "general-kpis");
+    expect(kpi?.type).toBe("kpi_row");
+    if (kpi?.type !== "kpi_row") {
+      expect.fail("general-kpis must be kpi_row");
+    }
+    const yoyItem = kpi.items.find((i) => i.label === "Retail YoY %");
+    expect(yoyItem).toBeDefined();
+    const sql = yoyItem!.sql;
+    expect(sql).toMatch(/:curr_from::date\s*-\s*INTERVAL\s+'1 year'/);
+    expect(sql).toMatch(/:curr_to::date\s*-\s*INTERVAL\s+'1 year'/);
+  });
 });

--- a/dashboard/lib/query-validator.ts
+++ b/dashboard/lib/query-validator.ts
@@ -83,26 +83,25 @@ export async function validateQueryCost(
     const rootPlan = plan[0].Plan;
     const cost = rootPlan["Total Cost"] ?? 0;
 
-    const defaultLimit = 100000;
-    const rawLimit = process.env.QUERY_COST_LIMIT;
-    const parsedLimit =
-      rawLimit === undefined ? defaultLimit : parseInt(rawLimit, 10);
-    const limit =
-      Number.isFinite(parsedLimit) && parsedLimit > 0
-        ? parsedLimit
-        : defaultLimit;
-    if (
-      rawLimit !== undefined &&
-      limit === defaultLimit &&
-      parsedLimit !== defaultLimit
-    ) {
-      console.warn(
-        `[query-validator] Invalid QUERY_COST_LIMIT="${rawLimit}", using default ${defaultLimit}`
-      );
+    // Cost rejection is opt-in: set QUERY_COST_LIMIT to a positive integer to
+    // block queries whose planner total cost exceeds that threshold. When unset
+    // (or invalid / zero), we still run EXPLAIN for seq-scan warnings below but
+    // never reject on cost — large default dashboards must not fail here.
+    const rawLimit = process.env.QUERY_COST_LIMIT?.trim();
+    let enforcedLimit: number | undefined;
+    if (rawLimit !== undefined && rawLimit !== "") {
+      const parsed = parseInt(rawLimit, 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        enforcedLimit = parsed;
+      } else {
+        console.warn(
+          `[query-validator] Invalid or zero QUERY_COST_LIMIT="${rawLimit}" — cost guard disabled`
+        );
+      }
     }
 
-    if (cost > limit) {
-      throw new QueryTooExpensiveError(cost, limit);
+    if (enforcedLimit !== undefined && cost > enforcedLimit) {
+      throw new QueryTooExpensiveError(cost, enforcedLimit);
     }
 
     const seqScans = extractSeqScansOnLargeTables(rootPlan);

--- a/dashboard/lib/query-validator.ts
+++ b/dashboard/lib/query-validator.ts
@@ -90,13 +90,20 @@ export async function validateQueryCost(
     const rawLimit = process.env.QUERY_COST_LIMIT?.trim();
     let enforcedLimit: number | undefined;
     if (rawLimit !== undefined && rawLimit !== "") {
-      const parsed = parseInt(rawLimit, 10);
-      if (Number.isFinite(parsed) && parsed > 0) {
-        enforcedLimit = parsed;
-      } else {
+      // Strict parse: reject partial numbers like "100000foo" (parseInt would not).
+      if (!/^\d+$/.test(rawLimit)) {
         console.warn(
-          `[query-validator] Invalid or zero QUERY_COST_LIMIT="${rawLimit}" — cost guard disabled`
+          `[query-validator] Invalid QUERY_COST_LIMIT="${rawLimit}" — cost guard disabled`
         );
+      } else {
+        const parsed = parseInt(rawLimit, 10);
+        if (parsed > 0) {
+          enforcedLimit = parsed;
+        } else {
+          console.warn(
+            `[query-validator] Invalid or zero QUERY_COST_LIMIT="${rawLimit}" — cost guard disabled`
+          );
+        }
       }
     }
 

--- a/etl/schema/init.sql
+++ b/etl/schema/init.sql
@@ -254,7 +254,8 @@ CREATE TABLE IF NOT EXISTS ps_gc_albaranes (
     entregadas      NUMERIC(10,2),
     transportista   TEXT,
     num_comercial   NUMERIC(20,3),
-    temporada       TEXT
+    temporada       TEXT,
+    abono           BOOLEAN
 );
 
 CREATE TABLE IF NOT EXISTS ps_gc_lin_albarane (

--- a/etl/sync/mayorista.py
+++ b/etl/sync/mayorista.py
@@ -132,6 +132,7 @@ _ALBARANES_MAPPING: dict[str, str] = {
     "transportista": "transportista",
     "numcomercial": "num_comercial",
     "temporada": "temporada",
+    "abono": "abono",
 }
 
 _LIN_ALBARANE_MAPPING: dict[str, str] = {
@@ -224,7 +225,7 @@ _LIN_PEDIDOS_MAPPING: dict[str, str] = {
 _SQL_ALBARANES_DELTA = (
     "SELECT RegAlbaran, NAlbaran, NumCliente, FechaEnvio, FechaValor,"
     " Modifica, Base1, Base2, Base3, Unidades, Transportista,"
-    " NumComercial, Temporada"
+    " NumComercial, Temporada, Abono"
     " FROM GCAlbaranes"
     " WHERE Modifica > {since}"
 )
@@ -232,7 +233,7 @@ _SQL_ALBARANES_DELTA = (
 _SQL_ALBARANES_ALL = (
     "SELECT RegAlbaran, NAlbaran, NumCliente, FechaEnvio, FechaValor,"
     " Modifica, Base1, Base2, Base3, Unidades, Transportista,"
-    " NumComercial, Temporada"
+    " NumComercial, Temporada, Abono"
     " FROM GCAlbaranes"
 )
 

--- a/scripts/add-ps-gc-albaranes-abono.sql
+++ b/scripts/add-ps-gc-albaranes-abono.sql
@@ -1,3 +1,13 @@
 -- One-time patch for mirrors created before ps_gc_albaranes.abono existed.
--- Safe to run multiple times.
-ALTER TABLE ps_gc_albaranes ADD COLUMN IF NOT EXISTS abono BOOLEAN;
+-- Idempotent: skips quietly when the table is missing (e.g. wrong database).
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'ps_gc_albaranes'
+  ) THEN
+    ALTER TABLE ps_gc_albaranes ADD COLUMN IF NOT EXISTS abono BOOLEAN;
+  END IF;
+END $$;

--- a/scripts/add-ps-gc-albaranes-abono.sql
+++ b/scripts/add-ps-gc-albaranes-abono.sql
@@ -1,0 +1,3 @@
+-- One-time patch for mirrors created before ps_gc_albaranes.abono existed.
+-- Safe to run multiple times.
+ALTER TABLE ps_gc_albaranes ADD COLUMN IF NOT EXISTS abono BOOLEAN;


### PR DESCRIPTION
## Summary
This pull request resolves failing widgets on the built-in dashboard templates observed in local logs, addresses the overly strict planner cost rejection, and closes the testing gap that allowed schema drift.

## Changes
- **Mirror / ETL**: Add missing `abono` column to `ps_gc_albaranes` (4D `GCAlbaranes.Abono`), extend the ETL SELECT and row mapping, and ship `scripts/add-ps-gc-albaranes-abono.sql` for existing PostgreSQL data directories (`ALTER TABLE ... ADD COLUMN IF NOT EXISTS`).
- **Dashboard API**: `QUERY_COST_LIMIT` is now **opt-in**. When unset or invalid, `/api/query` no longer returns 422 for high planner cost; EXPLAIN-based seq-scan warnings remain. Documented in `.env.example`.
- **Regression tests**: Director General YoY KPI must keep `:curr_*::date` before `INTERVAL '1 year'` (prevents PostgreSQL treating the date literal as an `INTERVAL` operand). Added `date-params-templates` test for substituted SQL shape.

## Why tests did not catch this
Template tests validated structure and heuristics but did not assert that referenced columns exist on mirrored tables, and CI does not run PostgreSQL EXPLAIN against the full stack. New tests lock in the YoY date arithmetic pattern; column alignment still depends on ETL/schema staying in sync with template SQL.

## Deployment notes
After pulling, run on existing mirrors:
```bash
docker compose exec -T postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f scripts/add-ps-gc-albaranes-abono.sql
```
Then run ETL (or wait for the nightly job) so `abono` is populated from 4D.

Closes #373

Made with [Cursor](https://cursor.com)