### PR TITLE
fix(dashboard): default comparison, precio1 sync, weekly review closed week

### DIFF
--- a/dashboard/app/__tests__/review-prompts.test.ts
+++ b/dashboard/app/__tests__/review-prompts.test.ts
@@ -3,39 +3,42 @@ import { buildReviewPrompt } from "@/lib/review-prompts";
 import { INSTRUCTIONS } from "@/lib/knowledge";
 
 describe("buildReviewPrompt", () => {
-  const sampleResults = `ventas_semana_actual:
+  const reviewedWeekCtx =
+    "Semana ISO cerrada del 2026-04-06 al 2026-04-12 (la semana en curso no se incluye).";
+
+  const sampleResults = `ventas_semana_cerrada:
 ventas_netas | num_tickets | ticket_medio
 ------------ | ----------- | ------------
 12345.00     | 150         | 82.30
 
-ventas_semana_anterior:
+ventas_semana_previa:
 ventas_netas | num_tickets | ticket_medio
 ------------ | ----------- | ------------
 11000.00     | 140         | 78.57`;
 
   it("returns a non-empty string", () => {
-    const prompt = buildReviewPrompt(sampleResults);
+    const prompt = buildReviewPrompt(sampleResults, reviewedWeekCtx);
     expect(typeof prompt).toBe("string");
     expect(prompt.length).toBeGreaterThan(100);
   });
 
   it("contains 'revisión semanal' (Spanish, case-insensitive)", () => {
-    const prompt = buildReviewPrompt(sampleResults);
+    const prompt = buildReviewPrompt(sampleResults, reviewedWeekCtx);
     expect(prompt.toLowerCase()).toContain("revisión semanal");
   });
 
   it("contains 'Resumen Ejecutivo' (expected output section)", () => {
-    const prompt = buildReviewPrompt(sampleResults);
+    const prompt = buildReviewPrompt(sampleResults, reviewedWeekCtx);
     expect(prompt).toContain("Resumen Ejecutivo");
   });
 
   it("contains 'JSON' to specify output format", () => {
-    const prompt = buildReviewPrompt(sampleResults);
+    const prompt = buildReviewPrompt(sampleResults, reviewedWeekCtx);
     expect(prompt).toContain("JSON");
   });
 
   it("includes the 4 expected section titles in the output spec", () => {
-    const prompt = buildReviewPrompt(sampleResults);
+    const prompt = buildReviewPrompt(sampleResults, reviewedWeekCtx);
     expect(prompt).toContain("Ventas Retail");
     expect(prompt).toContain("Canal Mayorista");
     expect(prompt).toContain("Stock y Logística");
@@ -43,7 +46,7 @@ ventas_netas | num_tickets | ticket_medio
   });
 
   it("includes business instructions from INSTRUCTIONS", () => {
-    const prompt = buildReviewPrompt(sampleResults);
+    const prompt = buildReviewPrompt(sampleResults, reviewedWeekCtx);
     // Check that at least one instruction text appears in the prompt
     expect(INSTRUCTIONS.length).toBeGreaterThan(0);
     const firstInstruction = INSTRUCTIONS[0].instruction;
@@ -52,23 +55,24 @@ ventas_netas | num_tickets | ticket_medio
   });
 
   it("includes the query results data in the prompt", () => {
-    const prompt = buildReviewPrompt(sampleResults);
-    expect(prompt).toContain("ventas_semana_actual");
+    const prompt = buildReviewPrompt(sampleResults, reviewedWeekCtx);
+    expect(prompt).toContain("ventas_semana_cerrada");
+    expect(prompt).toContain(reviewedWeekCtx);
     expect(prompt).toContain("12345.00");
   });
 
   it("specifies action_items field in the output structure", () => {
-    const prompt = buildReviewPrompt(sampleResults);
+    const prompt = buildReviewPrompt(sampleResults, reviewedWeekCtx);
     expect(prompt).toContain("action_items");
   });
 
   it("specifies generated_at field in the output structure", () => {
-    const prompt = buildReviewPrompt(sampleResults);
+    const prompt = buildReviewPrompt(sampleResults, reviewedWeekCtx);
     expect(prompt).toContain("generated_at");
   });
 
   it("instructs to return only JSON (no markdown fences)", () => {
-    const prompt = buildReviewPrompt(sampleResults);
+    const prompt = buildReviewPrompt(sampleResults, reviewedWeekCtx);
     // Should mention not to use markdown fences
     expect(prompt.toLowerCase()).toMatch(/sin|only|únicamente|solo/);
   });

--- a/dashboard/app/__tests__/review-queries.test.ts
+++ b/dashboard/app/__tests__/review-queries.test.ts
@@ -62,6 +62,9 @@ describe("REVIEW_QUERIES", () => {
 
 // ─── executeReviewQueries ─────────────────────────────────────────────────────
 
+const SAMPLE_WEEK_START = "2026-04-06";
+const SAMPLE_WEEK_END_EXCL = "2026-04-13";
+
 describe("executeReviewQueries", () => {
   it("returns results for all queries when all succeed", async () => {
     const mockQueryFn = vi.fn().mockResolvedValue({
@@ -69,7 +72,11 @@ describe("executeReviewQueries", () => {
       rows: [[1, "test"]],
     });
 
-    const results = await executeReviewQueries(mockQueryFn);
+    const results = await executeReviewQueries(
+      mockQueryFn,
+      SAMPLE_WEEK_START,
+      SAMPLE_WEEK_END_EXCL,
+    );
 
     expect(results).toHaveLength(REVIEW_QUERIES.length);
     expect(mockQueryFn).toHaveBeenCalledTimes(REVIEW_QUERIES.length);
@@ -91,7 +98,11 @@ describe("executeReviewQueries", () => {
       return Promise.resolve({ columns: ["value"], rows: [[42]] });
     });
 
-    const results = await executeReviewQueries(mockQueryFn);
+    const results = await executeReviewQueries(
+      mockQueryFn,
+      SAMPLE_WEEK_START,
+      SAMPLE_WEEK_END_EXCL,
+    );
 
     // All queries attempted
     expect(results).toHaveLength(REVIEW_QUERIES.length);
@@ -108,7 +119,11 @@ describe("executeReviewQueries", () => {
 
   it("returns correct query metadata for each result", async () => {
     const mockQueryFn = vi.fn().mockResolvedValue({ columns: [], rows: [] });
-    const results = await executeReviewQueries(mockQueryFn);
+    const results = await executeReviewQueries(
+      mockQueryFn,
+      SAMPLE_WEEK_START,
+      SAMPLE_WEEK_END_EXCL,
+    );
 
     // Each result references the correct query
     for (let i = 0; i < REVIEW_QUERIES.length; i++) {
@@ -117,12 +132,12 @@ describe("executeReviewQueries", () => {
     }
   });
 
-  it("calls the query function with the SQL of each query", async () => {
+  it("calls the query function with the SQL of each query and week bounds", async () => {
     const mockQueryFn = vi.fn().mockResolvedValue({ columns: [], rows: [] });
-    await executeReviewQueries(mockQueryFn);
+    await executeReviewQueries(mockQueryFn, SAMPLE_WEEK_START, SAMPLE_WEEK_END_EXCL);
 
     for (const q of REVIEW_QUERIES) {
-      expect(mockQueryFn).toHaveBeenCalledWith(q.sql);
+      expect(mockQueryFn).toHaveBeenCalledWith(q.sql, [SAMPLE_WEEK_START, SAMPLE_WEEK_END_EXCL]);
     }
   });
 });
@@ -132,11 +147,11 @@ describe("executeReviewQueries", () => {
 describe("formatQueryResultAsText", () => {
   it("produces a readable text table with name header", () => {
     const result = formatQueryResultAsText(
-      "ventas_semana_actual",
+      "ventas_semana_cerrada",
       ["ventas_netas", "num_tickets"],
       [[12345.67, 100]]
     );
-    expect(result).toContain("ventas_semana_actual");
+    expect(result).toContain("ventas_semana_cerrada");
     expect(result).toContain("ventas_netas");
     expect(result).toContain("num_tickets");
   });

--- a/dashboard/app/api/review/generate/route.ts
+++ b/dashboard/app/api/review/generate/route.ts
@@ -2,15 +2,16 @@
  * POST /api/review/generate
  *
  * Orchestration route for the automated weekly business review:
- * 1. Execute all predefined SQL queries
- * 2. Format results as text
- * 3. Build LLM prompt
- * 4. Call OpenRouter LLM (Claude)
+ * 1. Resolve the **last completed ISO week** (Mon–Sun before the current week)
+ * 2. Skip with 409 if a review for that week_start already exists
+ * 3. Execute all predefined SQL queries for that window ($1/$2 bounds)
+ * 4. Format results as text, build LLM prompt, call OpenRouter
  * 5. Parse and validate the structured review
  * 6. Persist to weekly_reviews table
  * 7. Return the full review with its DB id
  *
  * Error codes:
+ *   409 — Review already stored for that closed week
  *   503 — Database connection error
  *   502 — LLM error
  *   500 — Unexpected error
@@ -35,16 +36,68 @@ export async function POST(): Promise<NextResponse> {
   const requestId = generateRequestId();
 
   try {
-    // 1. Execute all predefined SQL queries (partial failures are tolerated)
-    const queryResults = await executeReviewQueries(query);
+    // 1. Last **completed** ISO week: Monday = DATE_TRUNC('week', today) - 7 days
+    const boundsRes = await query(
+      `SELECT
+         TO_CHAR((DATE_TRUNC('week', CURRENT_DATE::timestamp) - INTERVAL '7 days')::date, 'YYYY-MM-DD') AS week_start,
+         TO_CHAR((DATE_TRUNC('week', CURRENT_DATE::timestamp) - INTERVAL '1 day')::date, 'YYYY-MM-DD') AS week_end_sunday,
+         TO_CHAR(DATE_TRUNC('week', CURRENT_DATE::timestamp)::date, 'YYYY-MM-DD') AS week_end_exclusive`
+    );
+    const weekStartStr = String(boundsRes.rows[0]?.[0] ?? "");
+    const weekEndSundayStr = String(boundsRes.rows[0]?.[1] ?? "");
+    const weekEndExclusiveStr = String(boundsRes.rows[0]?.[2] ?? "");
+    if (!weekStartStr || !weekEndExclusiveStr) {
+      return NextResponse.json(
+        formatApiError(
+          "No se pudo calcular la semana de análisis.",
+          "UNKNOWN",
+          undefined,
+          requestId,
+        ),
+        { status: 500 },
+      );
+    }
 
-    // 2. Format query results as text for the LLM
+    // 2. Do not regenerate if this closed week was already analyzed
+    const existingRes = await query(
+      `SELECT id FROM weekly_reviews WHERE week_start = $1::date ORDER BY id DESC LIMIT 1`,
+      [weekStartStr],
+    );
+    const existingId = existingRes.rows[0]?.[0];
+    if (existingId != null && existingId !== undefined) {
+      return NextResponse.json(
+        {
+          ...formatApiError(
+            "Ya existe una revisión para la última semana cerrada. Ábrala desde el historial; no se volverá a generar hasta una nueva semana completa.",
+            "REVIEW_EXISTS",
+            undefined,
+            requestId,
+          ),
+          existing_id: Number(existingId),
+          week_start: weekStartStr,
+        },
+        { status: 409 },
+      );
+    }
+
+    // 3. Execute all predefined SQL queries (partial failures are tolerated)
+    const queryResults = await executeReviewQueries(
+      (sql, params) => query(sql, params),
+      weekStartStr,
+      weekEndExclusiveStr,
+    );
+
+    // 4. Format query results as text for the LLM
     const formattedResults = formatAllResults(queryResults);
 
-    // 3. Build the LLM prompt
-    const systemPrompt = buildReviewPrompt(formattedResults);
+    const reviewedWeekDescription =
+      `Los resultados corresponden a la **semana ISO cerrada** del **${weekStartStr}** (lunes) al **${weekEndSundayStr}** (domingo). ` +
+      `La semana en curso no se incluye (sigue en progreso).`;
 
-    // 4. Call the LLM
+    // 5. Build the LLM prompt
+    const systemPrompt = buildReviewPrompt(formattedResults, reviewedWeekDescription);
+
+    // 6. Call the LLM
     let reviewContent;
     try {
       reviewContent = await generateReview(systemPrompt);
@@ -71,13 +124,6 @@ export async function POST(): Promise<NextResponse> {
     if (!reviewContent.generated_at) {
       reviewContent.generated_at = new Date().toISOString();
     }
-
-    // 5. Determine the Monday of the current week using PostgreSQL
-    // (avoids timezone mismatches between Node.js and the DB)
-    const weekStartResult = await query(
-      `SELECT TO_CHAR(DATE_TRUNC('week', CURRENT_DATE)::date, 'YYYY-MM-DD') AS week_start`
-    );
-    const weekStartStr = (weekStartResult.rows[0]?.[0] as string | undefined) ?? new Date().toISOString().split("T")[0];
 
     let reviewId: number;
     try {

--- a/dashboard/app/dashboard/[id]/page.tsx
+++ b/dashboard/app/dashboard/[id]/page.tsx
@@ -7,7 +7,7 @@ import type { WidgetState } from "@/components/DashboardRenderer";
 import { DataFreshnessBanner } from "@/components/DataFreshnessBanner";
 import ChatSidebar from "@/components/ChatSidebar";
 import type { ChatMessage } from "@/components/ChatSidebar";
-import { DateRangePicker } from "@/components/DateRangePicker";
+import { DateRangePicker, computeComparisonRange } from "@/components/DateRangePicker";
 import type { DateRange, ComparisonRange } from "@/components/DateRangePicker";
 import { GlossaryPanel } from "@/components/GlossaryPanel";
 import { ErrorDisplay } from "@/components/ErrorDisplay";
@@ -35,6 +35,29 @@ interface DashboardRecord {
 
 const REFRESH_INTERVALS = [5, 15, 30] as const;
 type RefreshInterval = (typeof REFRESH_INTERVALS)[number];
+
+function getDefaultDashboardDateRange(): DateRange {
+  const today = new Date();
+  const from = new Date(today.getFullYear(), today.getMonth(), 1, 0, 0, 0, 0);
+  const to = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+    23,
+    59,
+    59,
+    999,
+  );
+  return { from, to };
+}
+
+function defaultComparisonRangeFor(
+  primary: DateRange,
+): ComparisonRange | undefined {
+  const r = computeComparisonRange(primary, "previous_period");
+  if (!r) return undefined;
+  return { type: "previous_period", ...r };
+}
 
 // ---------------------------------------------------------------------------
 // Helper: format widget data as text for clipboard copy
@@ -91,14 +114,11 @@ export default function ViewDashboard() {
   const autoRefreshRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Date range filter state — default to current month (1st to end of today)
-  const [dateRange, setDateRange] = useState<DateRange>(() => {
-    const today = new Date();
-    const from = new Date(today.getFullYear(), today.getMonth(), 1, 0, 0, 0, 0);
-    const to = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
-    return { from, to };
-  });
-  const [comparisonRange, setComparisonRange] = useState<ComparisonRange | undefined>(undefined);
+  // Date range filter — default current month; comparison — default same-length period immediately before
+  const [dateRange, setDateRange] = useState<DateRange>(() => getDefaultDashboardDateRange());
+  const [comparisonRange, setComparisonRange] = useState<ComparisonRange | undefined>(() =>
+    defaultComparisonRangeFor(getDefaultDashboardDateRange()),
+  );
 
   // When date range changes, store the range and re-run all widget queries.
   // The date range is displayed in the picker for context; actual SQL filtering

--- a/dashboard/app/review/page.tsx
+++ b/dashboard/app/review/page.tsx
@@ -147,38 +147,8 @@ export default function ReviewPage() {
     fetchPastReviews();
   }, [fetchPastReviews]);
 
-  // Generate a new review
-  const handleGenerate = async () => {
-    setView("loading");
-    setReviewError(null);
-    setCurrentReview(null);
-    try {
-      const res = await fetch("/api/review/generate", { method: "POST" });
-      if (!res.ok) {
-        const errBody = await res.json().catch(() => null);
-        setReviewError(
-          isApiErrorResponse(errBody)
-            ? errBody
-            : (errBody?.error as string) || "Error al generar la revisión"
-        );
-        setView("error");
-        return;
-      }
-      const data = await res.json();
-      setCurrentReview(data.review as FullReview);
-      setView("review");
-      // Refresh the past reviews list in background
-      fetchPastReviews();
-    } catch (err) {
-      setReviewError(
-        err instanceof Error ? err.message : "Error al generar la revisión"
-      );
-      setView("error");
-    }
-  };
-
-  // Load a past review by ID
-  const handleLoadReview = async (id: number) => {
+  // Load a past review by ID (used by list and by "Generar" when the closed week already exists)
+  const handleLoadReview = useCallback(async (id: number) => {
     setView("loading");
     setReviewError(null);
     setCurrentReview(null);
@@ -204,7 +174,46 @@ export default function ReviewPage() {
       );
       setView("error");
     }
-  };
+  }, []);
+
+  // Generate a new review (last closed ISO week only; 409 opens existing row)
+  const handleGenerate = useCallback(async () => {
+    setView("loading");
+    setReviewError(null);
+    setCurrentReview(null);
+    try {
+      const res = await fetch("/api/review/generate", { method: "POST" });
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => null);
+        if (
+          res.status === 409 &&
+          isApiErrorResponse(errBody) &&
+          errBody.code === "REVIEW_EXISTS" &&
+          typeof errBody.existing_id === "number"
+        ) {
+          await handleLoadReview(errBody.existing_id);
+          void fetchPastReviews();
+          return;
+        }
+        setReviewError(
+          isApiErrorResponse(errBody)
+            ? errBody
+            : (errBody?.error as string) || "Error al generar la revisión"
+        );
+        setView("error");
+        return;
+      }
+      const data = await res.json();
+      setCurrentReview(data.review as FullReview);
+      setView("review");
+      void fetchPastReviews();
+    } catch (err) {
+      setReviewError(
+        err instanceof Error ? err.message : "Error al generar la revisión"
+      );
+      setView("error");
+    }
+  }, [fetchPastReviews, handleLoadReview]);
 
   const handleBackToList = () => {
     setCurrentReview(null);

--- a/dashboard/components/DateRangePicker.tsx
+++ b/dashboard/components/DateRangePicker.tsx
@@ -595,7 +595,8 @@ export function DateRangePicker({ value, onChange }: DateRangePickerProps) {
   const [preferQuarterForLabel, setPreferQuarterForLabel] = useState(false);
   const [customFrom, setCustomFrom] = useState(toDateInputValue(value.from));
   const [customTo, setCustomTo] = useState(toDateInputValue(value.to));
-  const [comparisonType, setComparisonType] = useState<ComparisonType>("none");
+  /** Default to previous calendar period so comparison_sql charts work without extra UX steps. */
+  const [comparisonType, setComparisonType] = useState<ComparisonType>("previous_period");
   const [compCustomFrom, setCompCustomFrom] = useState("");
   const [compCustomTo, setCompCustomTo] = useState("");
   const containerRef = useRef<HTMLDivElement>(null);

--- a/dashboard/lib/errors.ts
+++ b/dashboard/lib/errors.ts
@@ -24,6 +24,7 @@ export type ErrorCode =
   | "NOT_FOUND"
   | "TIMEOUT"
   | "COST_LIMIT"
+  | "REVIEW_EXISTS"
   | "UNKNOWN";
 
 // ---------------------------------------------------------------------------
@@ -41,6 +42,10 @@ export interface ApiErrorResponse {
   timestamp: string;
   /** Correlation ID for matching frontend error to server log. */
   requestId: string;
+  /** When code is REVIEW_EXISTS — id of the saved review for that week. */
+  existing_id?: number;
+  /** When code is REVIEW_EXISTS — Monday (YYYY-MM-DD) of the reviewed week. */
+  week_start?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -106,7 +111,9 @@ export function isApiErrorResponse(value: unknown): value is ApiErrorResponse {
     typeof v.timestamp === "string" &&
     typeof v.requestId === "string" &&
     // details must be absent or a string (never an object/array)
-    (v.details === undefined || typeof v.details === "string")
+    (v.details === undefined || typeof v.details === "string") &&
+    (v.existing_id === undefined || typeof v.existing_id === "number") &&
+    (v.week_start === undefined || typeof v.week_start === "string")
   );
 }
 

--- a/dashboard/lib/review-prompts.ts
+++ b/dashboard/lib/review-prompts.ts
@@ -35,14 +35,22 @@ function formatInstructions(instructions: Instruction[]): string {
  * Build the system prompt for the weekly review LLM call.
  *
  * @param queryResults - Text representation of all SQL query results
+ * @param reviewedWeekDescription - One or two sentences: which closed ISO week the data covers
  * @returns System prompt string
  */
-export function buildReviewPrompt(queryResults: string): string {
+export function buildReviewPrompt(
+  queryResults: string,
+  reviewedWeekDescription: string,
+): string {
   const instructionsText = formatInstructions(INSTRUCTIONS);
 
   return `Eres un analista de negocio experto en retail y moda que prepara la revisión semanal del negocio.
 
-Tu misión: analizar los datos de la semana actual de PowerShop Analytics y redactar una revisión semanal completa, concisa y orientada a la acción, escrita en español.
+Tu misión: analizar los datos de PowerShop Analytics y redactar una revisión semanal completa, concisa y orientada a la acción, escrita en español.
+
+**Ventana temporal:** ${reviewedWeekDescription}
+
+No asumas datos de la semana en curso si no aparecen en las consultas: el sistema solo agrega la **última semana ISO ya cerrada** (lunes 00:00 a domingo 23:59) para evitar cifras parciales. Usa la consulta "ventas_semana_previa" (y análogas) como referencia de la semana inmediatamente anterior a la analizada.
 
 ## Reglas de negocio
 
@@ -61,7 +69,7 @@ El JSON tiene los campos: executive_summary (Resumen Ejecutivo de la semana), se
   "sections": [
     {
       "title": "Ventas Retail",
-      "content": "<2-4 párrafos analizando las ventas retail de la semana, comparando con la semana anterior, destacando tiendas destacadas y artículos más vendidos>"
+      "content": "<2-4 párrafos analizando las ventas retail de la semana cerrada, comparando con la semana previa (consulta ventas_semana_previa), destacando tiendas y artículos más vendidos>"
     },
     {
       "title": "Canal Mayorista",
@@ -73,7 +81,7 @@ El JSON tiene los campos: executive_summary (Resumen Ejecutivo de la semana), se
     },
     {
       "title": "Compras",
-      "content": "<2-4 párrafos sobre pedidos de compra de la semana comparados con la semana anterior>"
+      "content": "<2-4 párrafos sobre pedidos de compra de la semana cerrada comparados con la semana previa (compras_semana_previa)>"
     }
   ],
   "action_items": [
@@ -83,7 +91,7 @@ El JSON tiene los campos: executive_summary (Resumen Ejecutivo de la semana), se
   "generated_at": "<ISO 8601 timestamp>"
 }
 
-## Datos de la semana
+## Datos analizados
 
 A continuación se presentan los resultados de las consultas ejecutadas contra la base de datos:
 

--- a/dashboard/lib/review-queries.ts
+++ b/dashboard/lib/review-queries.ts
@@ -72,11 +72,16 @@ export function formatQueryResultAsText(
 
 // ─── Queries ─────────────────────────────────────────────────────────────────
 
+/**
+ * Weekly review SQL uses $1 = Monday of the **closed** ISO week under analysis (inclusive)
+ * and $2 = Monday of the following week (exclusive upper bound). The API sets these to the
+ * last completed calendar week — never the in-progress current week.
+ */
 export const REVIEW_QUERIES: ReviewQuery[] = [
   // ── Ventas Retail ──────────────────────────────────────────────────────────
 
   {
-    name: "ventas_semana_actual",
+    name: "ventas_semana_cerrada",
     domain: "ventas_retail",
     sql: `SELECT
   COALESCE(SUM(total_si), 0) AS ventas_netas,
@@ -85,10 +90,11 @@ export const REVIEW_QUERIES: ReviewQuery[] = [
 FROM ps_ventas
 WHERE entrada = true
   AND tienda <> '99'
-  AND fecha_creacion >= DATE_TRUNC('week', CURRENT_DATE)`,
+  AND fecha_creacion >= $1::date
+  AND fecha_creacion < $2::date`,
   },
   {
-    name: "ventas_semana_anterior",
+    name: "ventas_semana_previa",
     domain: "ventas_retail",
     sql: `SELECT
   COALESCE(SUM(total_si), 0) AS ventas_netas,
@@ -97,11 +103,11 @@ WHERE entrada = true
 FROM ps_ventas
 WHERE entrada = true
   AND tienda <> '99'
-  AND fecha_creacion >= DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '7 days'
-  AND fecha_creacion < DATE_TRUNC('week', CURRENT_DATE)`,
+  AND fecha_creacion >= ($1::date - INTERVAL '7 days')
+  AND fecha_creacion < $1::date`,
   },
   {
-    name: "top3_tiendas_semana",
+    name: "top3_tiendas_semana_cerrada",
     domain: "ventas_retail",
     sql: `SELECT
   tienda,
@@ -110,13 +116,14 @@ WHERE entrada = true
 FROM ps_ventas
 WHERE entrada = true
   AND tienda <> '99'
-  AND fecha_creacion >= DATE_TRUNC('week', CURRENT_DATE)
+  AND fecha_creacion >= $1::date
+  AND fecha_creacion < $2::date
 GROUP BY tienda
 ORDER BY ventas_netas DESC
 LIMIT 3`,
   },
   {
-    name: "bottom3_tiendas_semana",
+    name: "bottom3_tiendas_semana_cerrada",
     domain: "ventas_retail",
     sql: `SELECT
   tienda,
@@ -125,13 +132,14 @@ LIMIT 3`,
 FROM ps_ventas
 WHERE entrada = true
   AND tienda <> '99'
-  AND fecha_creacion >= DATE_TRUNC('week', CURRENT_DATE)
+  AND fecha_creacion >= $1::date
+  AND fecha_creacion < $2::date
 GROUP BY tienda
 ORDER BY ventas_netas ASC
 LIMIT 3`,
   },
   {
-    name: "top5_articulos_unidades_semana",
+    name: "top5_articulos_unidades_semana_cerrada",
     domain: "ventas_retail",
     sql: `SELECT
   lv.codigo,
@@ -144,14 +152,15 @@ JOIN ps_ventas v ON v.reg_ventas = lv.num_ventas
 LEFT JOIN ps_articulos a ON a.codigo = lv.codigo
 WHERE v.entrada = true
   AND lv.tienda <> '99'
-  AND lv.fecha_creacion >= DATE_TRUNC('week', CURRENT_DATE)
+  AND lv.fecha_creacion >= $1::date
+  AND lv.fecha_creacion < $2::date
   AND lv.unidades > 0
 GROUP BY lv.codigo, a.ccrefejofacm, a.descripcion
 ORDER BY unidades_vendidas DESC
 LIMIT 5`,
   },
   {
-    name: "tasa_devolucion_semana",
+    name: "tasa_devolucion_semana_cerrada",
     domain: "ventas_retail",
     sql: `SELECT
   COALESCE(SUM(CASE WHEN entrada = true THEN total_si ELSE 0 END), 0) AS ventas_brutas_si,
@@ -165,23 +174,25 @@ LIMIT 5`,
   ) AS tasa_devolucion_pct
 FROM ps_ventas
 WHERE tienda <> '99'
-  AND fecha_creacion >= DATE_TRUNC('week', CURRENT_DATE)`,
+  AND fecha_creacion >= $1::date
+  AND fecha_creacion < $2::date`,
   },
 
   // ── Canal Mayorista ────────────────────────────────────────────────────────
 
   {
-    name: "facturacion_mayorista_semana",
+    name: "facturacion_mayorista_semana_cerrada",
     domain: "canal_mayorista",
     sql: `SELECT
   COALESCE(SUM(base1 + base2 + base3), 0) AS facturacion_neta,
   COUNT(*) AS num_facturas
 FROM ps_gc_facturas
 WHERE abono = false
-  AND fecha_factura >= DATE_TRUNC('week', CURRENT_DATE)`,
+  AND fecha_factura >= $1::date
+  AND fecha_factura < $2::date`,
   },
   {
-    name: "top3_clientes_mayorista_semana",
+    name: "top3_clientes_mayorista_semana_cerrada",
     domain: "canal_mayorista",
     sql: `SELECT
   f.num_cliente,
@@ -191,7 +202,8 @@ WHERE abono = false
 FROM ps_gc_facturas f
 LEFT JOIN ps_clientes c ON c.num_cliente = f.num_cliente
 WHERE f.abono = false
-  AND f.fecha_factura >= DATE_TRUNC('week', CURRENT_DATE)
+  AND f.fecha_factura >= $1::date
+  AND f.fecha_factura < $2::date
 GROUP BY f.num_cliente, c.nombre
 ORDER BY facturacion_neta DESC
 LIMIT 3`,
@@ -208,7 +220,8 @@ WHERE NOT EXISTS (
       AND f.fecha_factura >= a.fecha_envio
       AND f.fecha_factura < a.fecha_envio + INTERVAL '30 days'
   )
-  AND a.fecha_envio >= DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '30 days'`,
+  AND a.fecha_envio >= $1::date - INTERVAL '30 days'
+  AND a.fecha_envio < $2::date`,
   },
 
   // ── Stock ──────────────────────────────────────────────────────────────────
@@ -237,35 +250,36 @@ ORDER BY stock_total ASC
 LIMIT 20`,
   },
   {
-    name: "traspasos_semana",
+    name: "traspasos_semana_cerrada",
     domain: "stock",
     sql: `SELECT
   COUNT(DISTINCT reg_traspaso) AS num_traspasos,
   COALESCE(SUM(unidades_s), 0) AS unidades_enviadas,
   COALESCE(SUM(unidades_e), 0) AS unidades_recibidas
 FROM ps_traspasos
-WHERE fecha_s >= DATE_TRUNC('week', CURRENT_DATE)
-   OR fecha_e >= DATE_TRUNC('week', CURRENT_DATE)`,
+WHERE (fecha_s >= $1::date AND fecha_s < $2::date)
+   OR (fecha_e >= $1::date AND fecha_e < $2::date)`,
   },
 
   // ── Compras ────────────────────────────────────────────────────────────────
 
   {
-    name: "compras_semana_actual",
+    name: "compras_semana_cerrada",
     domain: "compras",
     sql: `SELECT
   COUNT(*) AS num_pedidos
 FROM ps_compras
-WHERE fecha_pedido >= DATE_TRUNC('week', CURRENT_DATE)`,
+WHERE fecha_pedido >= $1::date
+  AND fecha_pedido < $2::date`,
   },
   {
-    name: "compras_semana_anterior",
+    name: "compras_semana_previa",
     domain: "compras",
     sql: `SELECT
   COUNT(*) AS num_pedidos
 FROM ps_compras
-WHERE fecha_pedido >= DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '7 days'
-  AND fecha_pedido < DATE_TRUNC('week', CURRENT_DATE)`,
+WHERE fecha_pedido >= ($1::date - INTERVAL '7 days')
+  AND fecha_pedido < $1::date`,
   },
 ];
 
@@ -282,14 +296,19 @@ WHERE fecha_pedido >= DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '7 days'
  * is re-thrown immediately so the API route can return a 503 without incurring
  * LLM cost.
  *
- * @param queryFn - Function that accepts SQL and returns a QueryResult promise
+ * @param queryFn - Function that accepts SQL and optional `$1,$2` params (week bounds)
+ * @param weekStart - Monday of the closed review week (YYYY-MM-DD), inclusive
+ * @param weekEndExclusive - Monday after the review week (YYYY-MM-DD), exclusive upper bound
  * @returns Array of ReviewQueryResult (success or error per query)
  */
 export async function executeReviewQueries(
-  queryFn: (sql: string) => Promise<QueryResult>
+  queryFn: (sql: string, params?: unknown[]) => Promise<QueryResult>,
+  weekStart: string,
+  weekEndExclusive: string,
 ): Promise<ReviewQueryResult[]> {
+  const weekParams = [weekStart, weekEndExclusive];
   const results = await Promise.allSettled(
-    REVIEW_QUERIES.map((q) => queryFn(q.sql))
+    REVIEW_QUERIES.map((q) => queryFn(q.sql, weekParams))
   );
 
   return REVIEW_QUERIES.map((q, i) => {

--- a/etl/schema/init.sql
+++ b/etl/schema/init.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS ps_articulos (
     num_marca        NUMERIC(20,3),
     num_proveedor    NUMERIC(20,3),
     precio_coste     NUMERIC(15,2),
+    precio1          NUMERIC(15,2),  -- PVP tarifa 1 (4D Articulos.Precio1)
     pr_coste_ne      NUMERIC(15,2),
     p_iva            NUMERIC(5,2),
     anulado          BOOLEAN,

--- a/etl/sync/articulos.py
+++ b/etl/sync/articulos.py
@@ -42,6 +42,7 @@ _NUMERIC_FIELDS = {
     "nummarca",
     "numproveedor",
     "preciocoste",
+    "precio1",
     "prcostene",
     "piva",
     # ps_familias
@@ -124,6 +125,7 @@ _ARTICULOS_MAPPING: dict[str, str] = {
     "nummarca": "num_marca",
     "numproveedor": "num_proveedor",
     "preciocoste": "precio_coste",
+    "precio1": "precio1",
     "prcostene": "pr_coste_ne",
     "piva": "p_iva",
     "anulado": "anulado",
@@ -190,7 +192,7 @@ _MARCAS_MAPPING: dict[str, str] = {
 _SQL_ARTICULOS = (
     "SELECT RegArticulo, Codigo, CCRefeJOFACM, Descripcion, CodigoBarra,"
     " NumFamilia, NumDepartament, NumColor, NumTemporada, NumMarca, NumProveedor,"
-    " PrecioCoste, PrCosteNe, PIva, Anulado, FechaCreacion, FechaModifica,"
+    " PrecioCoste, Precio1, PrCosteNe, PIva, Anulado, FechaCreacion, FechaModifica,"
     " Color, ClaveTemporada, Modelo, Sexo"
     " FROM Articulos"
     " WHERE CCRefeJOFACM IS NULL OR LEFT(CCRefeJOFACM, 2) <> 'MA'"

--- a/scripts/add-ps-articulos-precio1.sql
+++ b/scripts/add-ps-articulos-precio1.sql
@@ -1,0 +1,12 @@
+-- One-time patch: add PVP tarifa 1 from 4D Articulos.Precio1 for mirrors created earlier.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'ps_articulos'
+  ) THEN
+    ALTER TABLE ps_articulos ADD COLUMN IF NOT EXISTS precio1 NUMERIC(15, 2);
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Default dashboard loads with **previous period** comparison so KPI/comparison widgets work without extra UI steps.
- **Weekly review** generates only for the **last completed ISO week**; returns **409 REVIEW_EXISTS** if already stored; the review page **opens the existing review** instead of showing an error.
- Review SQL uses bounded date parameters (`$1`/`$2`).
- **`precio1`**: ETL + `init.sql` + `scripts/add-ps-articulos-precio1.sql` for existing mirrors.

## Testing
- `cd dashboard && npm test -- --run` (956 tests)

Fixes #375

Made with [Cursor](https://cursor.com)