### PR TITLE
feat(admin): LLM usage legibility, endpoint descriptions, cost methodology

### DIFF
--- a/dashboard/app/admin/usage/page.tsx
+++ b/dashboard/app/admin/usage/page.tsx
@@ -1,5 +1,10 @@
 import Link from "next/link";
 import { getLlmUsageAggregates } from "@/lib/llm-usage-stats";
+import {
+  formatIntegerEs,
+  formatTokensWithCompact,
+  formatUsdEs,
+} from "@/lib/usage-number-format";
 
 export const metadata = {
   title: "Uso LLM — Admin",
@@ -27,48 +32,99 @@ export default async function AdminUsagePage() {
       </div>
 
       <section className="grid gap-4 sm:grid-cols-3">
-        {(["today", "week", "month"] as const).map((period) => (
-          <div
-            key={period}
-            className="rounded-lg border border-tremor-border dark:border-dark-tremor-border p-4"
-          >
-            <h2 className="text-sm font-medium capitalize text-tremor-content dark:text-dark-tremor-content">
-              {period === "today" ? "Hoy" : period === "week" ? "7 días" : "30 días"}
-            </h2>
-            <p className="mt-2 text-2xl font-semibold">{u[period].total_tokens}</p>
-            <p className="text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
-              tokens · {u[period].estimated_cost_usd} USD est.
-            </p>
-          </div>
-        ))}
+        {(["today", "week", "month"] as const).map((period) => {
+          const p = u[period];
+          const tokens = formatTokensWithCompact(p.total_tokens);
+          return (
+            <div
+              key={period}
+              className="rounded-lg border border-tremor-border dark:border-dark-tremor-border p-4"
+            >
+              <h2 className="text-sm font-medium capitalize text-tremor-content dark:text-dark-tremor-content">
+                {period === "today" ? "Hoy" : period === "week" ? "7 días" : "30 días"}
+              </h2>
+              <p className="mt-2 text-2xl font-semibold tracking-tight">{tokens.primary}</p>
+              <p className="text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                ≈ {tokens.compact} tokens (compacto)
+              </p>
+              <p className="mt-1 text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                Entrada {formatIntegerEs(p.prompt_tokens)} · Salida{" "}
+                {formatIntegerEs(p.completion_tokens)}
+              </p>
+              <p className="mt-2 text-sm font-medium text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                {formatUsdEs(p.estimated_cost_usd)}{" "}
+                <span className="text-xs font-normal text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                  coste estimado
+                </span>
+              </p>
+            </div>
+          );
+        })}
+      </section>
+
+      <section
+        className="rounded-lg border border-amber-200/80 bg-amber-50/80 p-4 text-sm text-amber-950 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-100"
+        role="note"
+      >
+        <p className="font-medium">Cómo se calcula el coste</p>
+        <p className="mt-1 leading-relaxed">
+          Cada llamada guarda tokens de entrada y salida. El importe en USD es una{" "}
+          <strong>estimación interna</strong>: se multiplica cada tipo de token por un precio
+          fijo por millón definido en el código del servidor (alineado con la tarifa de lista del
+          modelo configurado, hoy <code className="rounded bg-black/5 px-1 dark:bg-white/10">anthropic/claude-sonnet-4</code>
+          ). <strong>No</strong> se consulta la facturación ni la API de costes de OpenRouter, así
+          que puede diferir del cargo real (descuentos, caché, redondeos, cambios de tarifa).
+        </p>
       </section>
 
       <section>
         <h2 className="mb-2 text-sm font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-          Por endpoint
+          Por función
         </h2>
+        <p className="mb-3 text-xs text-tremor-content dark:text-dark-tremor-content">
+          La columna «Clave» es el identificador técnico enviado a la base de datos; la
+          descripción resume qué pantalla o flujo del dashboard disparó la petición al modelo.
+        </p>
         <div className="overflow-x-auto rounded-lg border border-tremor-border dark:border-dark-tremor-border">
           <table className="min-w-full text-left text-sm">
             <thead className="bg-tremor-background-muted dark:bg-dark-tremor-background-muted">
               <tr>
-                <th className="px-3 py-2 font-medium">Endpoint</th>
+                <th className="px-3 py-2 font-medium">Función</th>
+                <th className="px-3 py-2 font-medium">Descripción</th>
+                <th className="px-3 py-2 font-medium">Clave</th>
                 <th className="px-3 py-2 font-medium">Llamadas</th>
                 <th className="px-3 py-2 font-medium">Tokens</th>
-                <th className="px-3 py-2 font-medium">Coste USD</th>
+                <th className="px-3 py-2 font-medium">Coste est.</th>
               </tr>
             </thead>
             <tbody>
-              {u.by_endpoint.map((row) => (
-                <tr
-                  key={row.endpoint}
-                  className="border-t border-tremor-border dark:border-dark-tremor-border"
-                >
-                  <td className="px-3 py-2 font-mono text-xs">{row.endpoint}</td>
-                  <td className="px-3 py-2">{row.calls}</td>
-                  <td className="px-3 py-2">{row.total_tokens}</td>
-                  <td className="px-3 py-2">{row.estimated_cost_usd}</td>
-                </tr>
-              ))}
+              {u.by_endpoint.map((row) => {
+                const tok = formatTokensWithCompact(row.total_tokens);
+                return (
+                  <tr
+                    key={row.endpoint}
+                    className="border-t border-tremor-border dark:border-dark-tremor-border align-top"
+                  >
+                    <td className="px-3 py-2 font-medium text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                      {row.endpoint_label_es}
+                    </td>
+                    <td className="max-w-md px-3 py-2 text-xs text-tremor-content dark:text-dark-tremor-content">
+                      {row.endpoint_detail_es}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                      {row.endpoint}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2">{formatIntegerEs(row.calls)}</td>
+                    <td className="px-3 py-2">
+                      <span className="whitespace-nowrap font-medium">{tok.primary}</span>
+                      <span className="mt-0.5 block text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                        ≈ {tok.compact}
+                      </span>
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2">{formatUsdEs(row.estimated_cost_usd)}</td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/dashboard/app/api/usage/__tests__/route.test.ts
+++ b/dashboard/app/api/usage/__tests__/route.test.ts
@@ -110,6 +110,8 @@ describe("GET /api/usage", () => {
     expect(data.by_endpoint).toHaveLength(1);
     expect(data.by_endpoint[0]).toEqual({
       endpoint: "generateDashboard",
+      endpoint_label_es: "Generar dashboard",
+      endpoint_detail_es: expect.stringContaining("lenguaje natural"),
       calls: 3,
       total_tokens: 1200,
       estimated_cost_usd: "0.018000",
@@ -129,7 +131,7 @@ describe("GET /api/usage", () => {
     expect(data.by_endpoint).toEqual([]);
   });
 
-  it("by_endpoint list has all four required keys per entry", async () => {
+  it("by_endpoint list has all required keys per entry", async () => {
     mockSql
       .mockResolvedValueOnce([
         {
@@ -157,6 +159,8 @@ describe("GET /api/usage", () => {
 
     for (const entry of data.by_endpoint) {
       expect(entry).toHaveProperty("endpoint");
+      expect(entry).toHaveProperty("endpoint_label_es");
+      expect(entry).toHaveProperty("endpoint_detail_es");
       expect(entry).toHaveProperty("calls");
       expect(entry).toHaveProperty("total_tokens");
       expect(entry).toHaveProperty("estimated_cost_usd");

--- a/dashboard/app/api/usage/route.ts
+++ b/dashboard/app/api/usage/route.ts
@@ -2,6 +2,9 @@
  * GET /api/usage — LLM usage aggregates from llm_usage table.
  *
  * Returns HTTP 200 always. Returns zero-shape when table is empty or DB unreachable.
+ *
+ * `by_endpoint[]` includes `endpoint_label_es` and `endpoint_detail_es` (stable copy for
+ * known `logUsage` keys in `lib/llm.ts`); unknown keys still return a generic label/detail.
  */
 
 import { NextResponse } from "next/server";

--- a/dashboard/lib/__tests__/llm-endpoint-meta.test.ts
+++ b/dashboard/lib/__tests__/llm-endpoint-meta.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { getLlmEndpointMetaEs } from "@/lib/llm-endpoint-meta";
+
+describe("getLlmEndpointMetaEs", () => {
+  it("returns Spanish copy for known endpoints", () => {
+    const g = getLlmEndpointMetaEs("generateDashboard");
+    expect(g.label.length).toBeGreaterThan(3);
+    expect(g.detail.toLowerCase()).toContain("cuadro");
+  });
+
+  it("falls back for unknown keys and mentions the technical name", () => {
+    const u = getLlmEndpointMetaEs("futureEndpoint");
+    expect(u.detail).toContain("futureEndpoint");
+  });
+});

--- a/dashboard/lib/__tests__/usage-number-format.test.ts
+++ b/dashboard/lib/__tests__/usage-number-format.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatCompactEs,
+  formatIntegerEs,
+  formatTokensWithCompact,
+  formatUsdEs,
+} from "@/lib/usage-number-format";
+
+describe("usage-number-format", () => {
+  it("formatIntegerEs uses Spanish grouping", () => {
+    expect(formatIntegerEs(1234567)).toMatch(/1.*234.*567/);
+    expect(formatIntegerEs(0)).toBe("0");
+  });
+
+  it("formatCompactEs returns a short string for large values", () => {
+    const s = formatCompactEs(1_500_000);
+    expect(s.length).toBeLessThan(12);
+    expect(s).toMatch(/\d/);
+  });
+
+  it("formatTokensWithCompact returns primary and compact", () => {
+    const { primary, compact } = formatTokensWithCompact(10_000);
+    expect(primary).toBeTruthy();
+    expect(compact).toBeTruthy();
+  });
+
+  it("formatUsdEs formats dollar amounts", () => {
+    expect(formatUsdEs("0.018")).toContain("0");
+    expect(formatUsdEs(12.345678)).toContain("12");
+  });
+
+  it("handles non-finite as em dash", () => {
+    expect(formatIntegerEs(Number.NaN)).toBe("—");
+    expect(formatCompactEs(Number.POSITIVE_INFINITY)).toBe("—");
+    expect(formatUsdEs("not-a-number")).toBe("—");
+  });
+});

--- a/dashboard/lib/llm-endpoint-meta.ts
+++ b/dashboard/lib/llm-endpoint-meta.ts
@@ -1,0 +1,63 @@
+/**
+ * Spanish labels for `llm_usage.endpoint` keys (see `logUsage` in `lib/llm.ts`).
+ * Used in admin usage UI and API aggregates so historical rows stay readable.
+ */
+
+export interface LlmEndpointMetaEs {
+  /** Short title for tables and cards */
+  label: string;
+  /** One or two sentences: what triggered the LLM call */
+  detail: string;
+}
+
+const DEFAULT_META: LlmEndpointMetaEs = {
+  label: "Otro",
+  detail: "Uso del modelo registrado con una clave no catalogada.",
+};
+
+const MAP: Record<string, LlmEndpointMetaEs> = {
+  generateDashboard: {
+    label: "Generar dashboard",
+    detail:
+      "Construye un cuadro de mandos nuevo desde lenguaje natural: tareas predefinidas, sugerencias por rol, huecos de cobertura o descripción libre.",
+  },
+  modifyDashboard: {
+    label: "Modificar dashboard",
+    detail:
+      "Aplica cambios al JSON del dashboard existente según instrucciones del usuario (editor de cuadro de mando).",
+  },
+  suggestDashboards: {
+    label: "Sugerir dashboards por rol",
+    detail:
+      "Propone varios paneles útiles para un rol concreto, evitando solaparse con los dashboards que ya existen.",
+  },
+  analyzeGaps: {
+    label: "Analizar huecos de cobertura",
+    detail:
+      "Revisa los dashboards guardados (títulos y widgets) e identifica áreas de negocio que faltan o están poco cubiertas.",
+  },
+  analyzeDashboard: {
+    label: "Analizar datos del dashboard",
+    detail:
+      "Responde en lenguaje natural a preguntas sobre los datos ya cargados en los widgets del cuadro de mando.",
+  },
+  generateReview: {
+    label: "Revisión semanal (IA)",
+    detail:
+      "Genera el informe semanal de negocio a partir de los resultados de las consultas SQL de revisión.",
+  },
+  generateSuggestions: {
+    label: "Sugerencias de seguimiento",
+    detail:
+      "Propone preguntas cortas de seguimiento en el chat de análisis del dashboard, a partir del último intercambio.",
+  },
+};
+
+export function getLlmEndpointMetaEs(endpoint: string): LlmEndpointMetaEs {
+  const m = MAP[endpoint];
+  if (m) return m;
+  return {
+    label: DEFAULT_META.label,
+    detail: `${DEFAULT_META.detail} Clave técnica: ${endpoint}.`,
+  };
+}

--- a/dashboard/lib/llm-usage-stats.ts
+++ b/dashboard/lib/llm-usage-stats.ts
@@ -1,4 +1,5 @@
 import { sql } from "@/lib/db-write";
+import { getLlmEndpointMetaEs } from "@/lib/llm-endpoint-meta";
 
 export interface PeriodStats {
   prompt_tokens: number;
@@ -9,6 +10,10 @@ export interface PeriodStats {
 
 export interface EndpointStats {
   endpoint: string;
+  /** Human-readable name in Spanish (stable for known `logUsage` keys). */
+  endpoint_label_es: string;
+  /** What triggered this usage row (Spanish). */
+  endpoint_detail_es: string;
   calls: number;
   total_tokens: number;
   estimated_cost_usd: string;
@@ -95,12 +100,18 @@ export async function getLlmUsageAggregates(): Promise<LlmUsageAggregates> {
       estimated_cost_usd: r.month_cost,
     });
 
-    const by_endpoint: EndpointStats[] = endpointRows.map((row) => ({
-      endpoint: String(row.endpoint),
-      calls: Number(row.calls) || 0,
-      total_tokens: Number(row.total_tokens) || 0,
-      estimated_cost_usd: (Number(row.estimated_cost_usd) || 0).toFixed(6),
-    }));
+    const by_endpoint: EndpointStats[] = endpointRows.map((row) => {
+      const endpoint = String(row.endpoint);
+      const meta = getLlmEndpointMetaEs(endpoint);
+      return {
+        endpoint,
+        endpoint_label_es: meta.label,
+        endpoint_detail_es: meta.detail,
+        calls: Number(row.calls) || 0,
+        total_tokens: Number(row.total_tokens) || 0,
+        estimated_cost_usd: (Number(row.estimated_cost_usd) || 0).toFixed(6),
+      };
+    });
 
     return { today, week, month, by_endpoint };
   } catch (err) {

--- a/dashboard/lib/llm-usage.ts
+++ b/dashboard/lib/llm-usage.ts
@@ -1,7 +1,14 @@
 import { sql } from "@/lib/db-write";
 import { query } from "@/lib/db";
 
-// Rate table: USD per token (easy to update when OpenRouter pricing changes)
+/**
+ * Rate table: **estimated** USD per token used only for `llm_usage.estimated_cost_usd`.
+ *
+ * - Values follow public list pricing for the configured model (today: Claude Sonnet 4).
+ * - OpenRouter may apply discounts, caching, or rounding; this app does **not** read
+ *   OpenRouter’s billing API, so displayed costs are **indicative**, not invoice-accurate.
+ * - Unknown models fall back to `DEFAULT_RATE` (same as Sonnet 4) with a console warning.
+ */
 const RATES: Record<string, { prompt: number; completion: number }> = {
   "anthropic/claude-sonnet-4": {
     prompt: 3.0 / 1_000_000,

--- a/dashboard/lib/usage-number-format.ts
+++ b/dashboard/lib/usage-number-format.ts
@@ -1,0 +1,50 @@
+/**
+ * Locale-aware display helpers for admin usage / token metrics (Spanish).
+ */
+
+const intFmt = new Intl.NumberFormat("es-ES", {
+  maximumFractionDigits: 0,
+});
+
+const compactFmt = new Intl.NumberFormat("es-ES", {
+  notation: "compact",
+  compactDisplay: "short",
+  maximumFractionDigits: 1,
+});
+
+const usdFmt = new Intl.NumberFormat("es-ES", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 6,
+});
+
+/** Integer with thousands separators (e.g. 1.234.567). */
+export function formatIntegerEs(n: number): string {
+  if (!Number.isFinite(n)) return "—";
+  return intFmt.format(Math.round(n));
+}
+
+/** Compact form (e.g. 1,2 M, 345 k). */
+export function formatCompactEs(n: number): string {
+  if (!Number.isFinite(n)) return "—";
+  return compactFmt.format(n);
+}
+
+/**
+ * Primary full integer + compact suffix for dense UI.
+ * Example: primary "1.234.567", compact "1,2 M"
+ */
+export function formatTokensWithCompact(n: number): { primary: string; compact: string } {
+  return {
+    primary: formatIntegerEs(n),
+    compact: formatCompactEs(n),
+  };
+}
+
+/** USD with grouping; suitable next to a "USD" legend. */
+export function formatUsdEs(amount: string | number): string {
+  const num = typeof amount === "string" ? Number.parseFloat(amount) : amount;
+  if (!Number.isFinite(num)) return "—";
+  return usdFmt.format(num);
+}


### PR DESCRIPTION
## Summary
- **Coste**: Aclaración explícita de que `estimated_cost_usd` es **estimación interna** (precio fijo por token en `dashboard/lib/llm-usage.ts`), **no** el cargo real de OpenRouter; comentario ampliado en código.
- **Números**: Formato `es-ES` con separadores de miles, línea compacta k/M para tokens, importes en USD legibles.
- **Por petición**: Cada fila incluye **función** (título ES), **descripción** (qué flujo del producto disparó la llamada) y la **clave técnica** (`logUsage` key). Los mismos metadatos van en `GET /api/usage` → `endpoint_label_es`, `endpoint_detail_es`.

## Testing
`cd dashboard && npm test -- --run` (963 tests)

Fixes #378

Related analysis (separate issue, sin cambios de código en este PR): #377

Made with [Cursor](https://cursor.com)