### PR TITLE
fix(admin-usage): Copilot follow-up from #379

### DIFF
--- a/dashboard/app/admin/usage/page.tsx
+++ b/dashboard/app/admin/usage/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { getLlmUsageAggregates } from "@/lib/llm-usage-stats";
+import { getDashboardLlmModel } from "@/lib/llm-model-config";
 import {
   formatIntegerEs,
   formatTokensWithCompact,
@@ -14,6 +15,7 @@ export const dynamic = "force-dynamic";
 
 export default async function AdminUsagePage() {
   const u = await getLlmUsageAggregates();
+  const modelId = getDashboardLlmModel();
 
   return (
     <div className="space-y-6">
@@ -70,8 +72,9 @@ export default async function AdminUsagePage() {
         <p className="mt-1 leading-relaxed">
           Cada llamada guarda tokens de entrada y salida. El importe en USD es una{" "}
           <strong>estimación interna</strong>: se multiplica cada tipo de token por un precio
-          fijo por millón definido en el código del servidor (alineado con la tarifa de lista del
-          modelo configurado, hoy <code className="rounded bg-black/5 px-1 dark:bg-white/10">anthropic/claude-sonnet-4</code>
+          fijo por millón definido en el código del servidor (tabla de tarifas alineada con la
+          tarifa de lista del modelo que usa el dashboard:{" "}
+          <code className="rounded bg-black/5 px-1 dark:bg-white/10">{modelId}</code>
           ). <strong>No</strong> se consulta la facturación ni la API de costes de OpenRouter, así
           que puede diferir del cargo real (descuentos, caché, redondeos, cambios de tarifa).
         </p>

--- a/dashboard/lib/__tests__/llm-model-config.test.ts
+++ b/dashboard/lib/__tests__/llm-model-config.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { getDashboardLlmModel } from "@/lib/llm-model-config";
+
+describe("getDashboardLlmModel", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns env override when set", () => {
+    vi.stubEnv("DASHBOARD_LLM_MODEL", "openai/gpt-4o");
+    expect(getDashboardLlmModel()).toBe("openai/gpt-4o");
+  });
+
+  it("returns default when env unset", () => {
+    delete process.env.DASHBOARD_LLM_MODEL;
+    expect(getDashboardLlmModel()).toBe("anthropic/claude-sonnet-4");
+  });
+});

--- a/dashboard/lib/llm-model-config.ts
+++ b/dashboard/lib/llm-model-config.ts
@@ -1,0 +1,10 @@
+/**
+ * Dashboard LLM model id (OpenRouter). Kept in a tiny module so admin pages can
+ * display the effective model without importing the full OpenAI client stack.
+ */
+
+const DEFAULT_MODEL = "anthropic/claude-sonnet-4";
+
+export function getDashboardLlmModel(): string {
+  return process.env.DASHBOARD_LLM_MODEL || DEFAULT_MODEL;
+}

--- a/dashboard/lib/llm.ts
+++ b/dashboard/lib/llm.ts
@@ -12,6 +12,7 @@ import { buildAnalyzePrompt, buildSuggestionPrompt } from "./analyze-prompts";
 import type { ReviewContent } from "./review-prompts";
 import { logUsage, checkDailyBudget } from "./llm-usage";
 import { callWithCircuitBreaker } from "./llm-circuit-breaker";
+import { getDashboardLlmModel } from "./llm-model-config";
 
 export { BudgetExceededError } from "./llm-usage";
 export { CircuitBreakerOpenError } from "./llm-circuit-breaker";
@@ -24,8 +25,6 @@ const EMPTY_USAGE = {
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 
-const DEFAULT_MODEL = "anthropic/claude-sonnet-4";
-
 function getApiKey(): string {
   const key = process.env.OPENROUTER_API_KEY;
   if (!key) {
@@ -37,7 +36,7 @@ function getApiKey(): string {
 }
 
 function getModel(): string {
-  return process.env.DASHBOARD_LLM_MODEL || DEFAULT_MODEL;
+  return getDashboardLlmModel();
 }
 
 // ─── Retry helpers ───────────────────────────────────────────────────────────

--- a/dashboard/lib/usage-number-format.ts
+++ b/dashboard/lib/usage-number-format.ts
@@ -25,7 +25,10 @@ export function formatIntegerEs(n: number): string {
   return intFmt.format(Math.round(n));
 }
 
-/** Compact form (e.g. 1,2 M, 345 k). */
+/**
+ * Compact form via `Intl` for `es-ES` (e.g. millions as "1,2 M"; thousands often as "12 mil",
+ * not a literal "k" — exact string depends on the runtime's Spanish compact rules).
+ */
 export function formatCompactEs(n: number): string {
   if (!Number.isFinite(n)) return "—";
   return compactFmt.format(n);
@@ -33,7 +36,7 @@ export function formatCompactEs(n: number): string {
 
 /**
  * Primary full integer + compact suffix for dense UI.
- * Example: primary "1.234.567", compact "1,2 M"
+ * Example: primary "1.234.567", compact might be "1,2 M" (millions) or "12 mil" (thousands).
  */
 export function formatTokensWithCompact(n: number): { primary: string; compact: string } {
   return {


### PR DESCRIPTION
Follow-up to #379 (Copilot inline feedback): correct compact-notation JSDoc for `es-ES`, and show the effective `DASHBOARD_LLM_MODEL` in the admin cost methodology via `lib/llm-model-config.ts` (avoids importing the full LLM client in the admin page).

Tests: `npm test -- --run`

Made with [Cursor](https://cursor.com)