### PR TITLE
feat(dashboard): pestañas y guía en Nuevo dashboard (#377)

### DIFF
--- a/dashboard/app/__tests__/new-page.test.tsx
+++ b/dashboard/app/__tests__/new-page.test.tsx
@@ -50,6 +50,7 @@ describe("NewDashboard page", () => {
 
   it("renders prompt textarea and generate button", () => {
     render(<NewDashboard />);
+    fireEvent.click(screen.getByTestId("creation-tab-free"));
 
     expect(
       screen.getByPlaceholderText("Describe el dashboard que necesitas..."),
@@ -59,6 +60,7 @@ describe("NewDashboard page", () => {
 
   it("disables generate button when prompt is empty", () => {
     render(<NewDashboard />);
+    fireEvent.click(screen.getByTestId("creation-tab-free"));
 
     const btn = screen.getByText("Generar Dashboard");
     expect(btn).toBeDisabled();
@@ -66,6 +68,7 @@ describe("NewDashboard page", () => {
 
   it("enables generate button when prompt has text", async () => {
     render(<NewDashboard />);
+    fireEvent.click(screen.getByTestId("creation-tab-free"));
 
     const textarea = screen.getByPlaceholderText(
       "Describe el dashboard que necesitas...",
@@ -108,6 +111,9 @@ describe("NewDashboard page", () => {
     globalThis.fetch = fetchMock;
 
     render(<NewDashboard />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("creation-tab-free"));
+    });
 
     const textarea = screen.getByPlaceholderText(
       "Describe el dashboard que necesitas...",
@@ -144,6 +150,9 @@ describe("NewDashboard page", () => {
     globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
 
     render(<NewDashboard />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("creation-tab-free"));
+    });
 
     await act(async () => {
       fireEvent.change(
@@ -167,6 +176,9 @@ describe("NewDashboard page", () => {
     });
 
     render(<NewDashboard />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("creation-tab-free"));
+    });
 
     await act(async () => {
       fireEvent.change(

--- a/dashboard/app/__tests__/smart-creation.test.tsx
+++ b/dashboard/app/__tests__/smart-creation.test.tsx
@@ -53,7 +53,14 @@ describe("NewDashboard page — smart creation sections", () => {
     globalThis.fetch = originalFetch;
   });
 
-  // ── Task cards section ──────────────────────────────────────────────────
+  // ── Tabs & task cards section ───────────────────────────────────────────
+
+  it("renders creation mode tabs", () => {
+    render(<NewDashboard />);
+    expect(screen.getByTestId("creation-tab-templates")).toBeInTheDocument();
+    expect(screen.getByTestId("creation-tab-assistant")).toBeInTheDocument();
+    expect(screen.getByTestId("creation-tab-free")).toBeInTheDocument();
+  });
 
   it("renders the task cards section heading", () => {
     render(<NewDashboard />);
@@ -379,6 +386,7 @@ describe("NewDashboard page — smart creation sections", () => {
 
   it("still renders free-form prompt textarea", () => {
     render(<NewDashboard />);
+    fireEvent.click(screen.getByTestId("creation-tab-free"));
     expect(
       screen.getByPlaceholderText("Describe el dashboard que necesitas...")
     ).toBeInTheDocument();
@@ -387,6 +395,7 @@ describe("NewDashboard page — smart creation sections", () => {
 
   it("still renders template cards section", () => {
     render(<NewDashboard />);
+    fireEvent.click(screen.getByTestId("creation-tab-templates"));
     expect(screen.getByText("Plantillas predefinidas")).toBeInTheDocument();
   });
 

--- a/dashboard/app/dashboard/new/page.tsx
+++ b/dashboard/app/dashboard/new/page.tsx
@@ -36,45 +36,56 @@ interface Gap {
   suggestedPrompt: string;
 }
 
+type CreationTab = "templates" | "assistant" | "free";
+
 // ─── Role options ─────────────────────────────────────────────────────────────
 
-// Use the shared role list so the page and suggest route stay in sync
 const ROLES = DASHBOARD_ROLES;
+
+// ─── Badges (IA vs plantilla) ───────────────────────────────────────────────
+
+function BadgeUsesAi() {
+  return (
+    <span className="mb-2 inline-block rounded-full bg-violet-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-violet-800 dark:bg-violet-400/20 dark:text-violet-100">
+      Usa IA
+    </span>
+  );
+}
+
+function BadgeNoAi() {
+  return (
+    <span className="mb-2 inline-block rounded-full bg-emerald-600/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-900 dark:bg-emerald-400/15 dark:text-emerald-100">
+      Sin IA · instantáneo
+    </span>
+  );
+}
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export default function NewDashboard() {
   const router = useRouter();
+  const [tab, setTab] = useState<CreationTab>("assistant");
 
   // Free-form generation state
   const [prompt, setPrompt] = useState("");
   const [loading, setLoading] = useState(false);
   const [loadingTemplate, setLoadingTemplate] = useState<string | null>(null);
   const [error, setError] = useState<ApiErrorResponse | string | null>(null);
-  // "generate" = free-form textarea (inline retry below textarea with retry button)
-  // "task"     = task card click (generation error shown in global banner at top)
-  // "template" = template card click (generation error shown in global banner at top)
-  // Note: role suggestion errors → `suggestError`; gap analysis errors → `gapsError` (inline per section)
-  const [lastErrorSource, setLastErrorSource] = useState<"generate" | "task" | "template" | null>(null);
+  const [lastErrorSource, setLastErrorSource] = useState<"generate" | "task" | "template" | null>(
+    null,
+  );
 
-  // Cached dashboard list — fetched once per page session to avoid repeated calls
   const [cachedDashboardList, setCachedDashboardList] = useState<DashboardListItem[] | null>(null);
 
-  // Role suggestion state
   const [selectedRole, setSelectedRole] = useState<string | null>(null);
   const [loadingSuggestions, setLoadingSuggestions] = useState(false);
   const [suggestions, setSuggestions] = useState<Suggestion[] | null>(null);
   const [suggestError, setSuggestError] = useState<string | null>(null);
 
-  // Gap analysis state
   const [loadingGaps, setLoadingGaps] = useState(false);
   const [gaps, setGaps] = useState<Gap[] | null>(null);
   const [gapsError, setGapsError] = useState<string | null>(null);
 
-  /**
-   * Fetch the dashboard list, caching the result for the page session.
-   * Subsequent calls return the cached list without a network request.
-   */
   const getDashboardList = async (): Promise<DashboardListItem[]> => {
     if (cachedDashboardList !== null) {
       return cachedDashboardList;
@@ -91,7 +102,6 @@ export default function NewDashboard() {
     return data;
   };
 
-  /** Save a spec to the database and redirect to its view page. */
   const saveAndRedirect = async (
     name: string,
     description: string | null,
@@ -115,12 +125,6 @@ export default function NewDashboard() {
     router.push(`/dashboard/${saved.id}`);
   };
 
-  /** Generate a dashboard from a prompt string and save it.
-   *
-   * @param promptText - The generation prompt
-   * @param source - Where the call originated: "generate" for free-form textarea
-   *   (shows retry inline), "task" for task cards/suggestions/gaps (shows in global banner)
-   */
   const generateFromPrompt = async (
     promptText: string,
     source: "generate" | "task" = "task",
@@ -195,7 +199,6 @@ export default function NewDashboard() {
     }
   };
 
-  /** Fetch dashboard list then request role suggestions from the LLM. */
   const handleRoleSelect = async (role: string) => {
     if (isDisabled) return;
 
@@ -205,7 +208,6 @@ export default function NewDashboard() {
     setLoadingSuggestions(true);
 
     try {
-      // Fetch existing dashboards (cached for the page session) to avoid overlap
       const listData = await getDashboardList();
 
       const existingDashboards = listData.map((d) => ({
@@ -213,7 +215,6 @@ export default function NewDashboard() {
         description: d.description || "",
       }));
 
-      // Request suggestions
       const suggestRes = await fetch("/api/dashboard/suggest", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -238,7 +239,6 @@ export default function NewDashboard() {
     }
   };
 
-  /** Fetch all dashboard specs then request gap analysis from the LLM. */
   const handleAnalyzeGaps = async () => {
     if (isDisabled) return;
 
@@ -247,11 +247,8 @@ export default function NewDashboard() {
     setLoadingGaps(true);
 
     try {
-      // Fetch dashboard list (cached for the page session)
       const listData = await getDashboardList();
 
-      // Fetch specs for each dashboard to extract widget titles.
-      // Cap to 30 to match the API's own limit and avoid excess parallel fetches.
       const dashboardsWithSpecs: {
         title: string;
         description: string;
@@ -304,12 +301,16 @@ export default function NewDashboard() {
 
   const isDisabled = loading || loadingTemplate !== null || loadingSuggestions || loadingGaps;
 
+  const tabDefs: { id: CreationTab; label: string; hint: string }[] = [
+    { id: "templates", label: "Plantillas", hint: "Sin IA, inmediato" },
+    { id: "assistant", label: "Asistente IA", hint: "Tareas, rol y cobertura" },
+    { id: "free", label: "Descripción libre", hint: "Prompt a medida" },
+  ];
+
   return (
-    <div className="space-y-10">
-      {/* Data freshness banner — shown so users know if underlying data is stale */}
+    <div className="space-y-8">
       <DataFreshnessBanner />
 
-      {/* Header */}
       <div>
         <h1 className="text-2xl font-bold text-tremor-content-strong dark:text-dark-tremor-content-strong">
           Nuevo Dashboard
@@ -319,277 +320,365 @@ export default function NewDashboard() {
         </p>
       </div>
 
-      {/* Global error banner — shown only for task-generation and template errors.
-          Suggestion/gap fetch errors and free-form prompt errors are shown inline in their respective sections. */}
       {error && (lastErrorSource === "task" || lastErrorSource === "template") && (
         <ErrorDisplay error={error} />
       )}
 
-      {/* Section 1: Task-oriented prompts */}
-      <div>
-        <h2 className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-          ¿Qué necesitas hacer?
+      {/* Mapa mental — issue #377 */}
+      <section
+        className="rounded-lg border border-tremor-border bg-tremor-background-subtle p-4 text-sm text-tremor-content dark:border-dark-tremor-border dark:bg-dark-tremor-background-subtle dark:text-dark-tremor-content"
+        aria-labelledby="new-dash-how-heading"
+      >
+        <h2
+          id="new-dash-how-heading"
+          className="font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong"
+        >
+          Tres formas de crear tu cuadro de mando
         </h2>
-        <p className="mt-1 text-sm text-tremor-content dark:text-dark-tremor-content">
-          Selecciona la tarea y generamos el panel de decisión adecuado
-        </p>
+        <ul className="mt-2 list-disc space-y-1.5 pl-5 leading-relaxed">
+          <li>
+            <strong>Plantillas</strong>: partimos de un panel ya montado; se guarda al instante{" "}
+            <em>sin</em> llamar al modelo de IA.
+          </li>
+          <li>
+            <strong>Asistente IA</strong>: tareas de negocio listas, sugerencias según tu rol y
+            análisis de huecos en tus paneles actuales. Todo usa el modelo (puede tardar unos
+            segundos y consume presupuesto de uso).
+          </li>
+          <li>
+            <strong>Descripción libre</strong>: escribes lo que necesitas y generamos el panel con
+            IA.
+          </li>
+        </ul>
+      </section>
 
-        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {TASK_PROMPTS.map((task) => (
-            <button
-              key={task.id}
-              onClick={() => generateFromPrompt(task.prompt)}
-              disabled={isDisabled}
-              data-testid={`task-card-${task.id}`}
-              className="flex flex-col items-start rounded-lg border border-tremor-border dark:border-dark-tremor-border bg-tremor-background-subtle dark:bg-dark-tremor-background-subtle p-5 text-left shadow-sm hover:border-blue-400 hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed transition-all"
-            >
-              <span className="text-2xl" aria-hidden="true">{task.icon}</span>
-              <h3 className="mt-2 text-sm font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-                {task.title}
-              </h3>
-              <p className="mt-1 text-xs text-tremor-content dark:text-dark-tremor-content line-clamp-2">
-                {task.description}
-              </p>
-              <span className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-blue-400">
-                Crear panel
-              </span>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Section 2: Role-based suggestions */}
       <div>
-        <h2 className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-          Recomendado para ti
-        </h2>
-        <p className="mt-1 text-sm text-tremor-content dark:text-dark-tremor-content">
-          Selecciona tu rol y te sugerimos los paneles más útiles para ti
+        <p id="creation-tabs-label" className="sr-only">
+          Modo de creación
         </p>
-
-        {/* Role pill buttons */}
-        <div className="mt-3 flex flex-wrap gap-2">
-          {ROLES.map((role) => (
-            <button
-              key={role}
-              onClick={() => handleRoleSelect(role)}
-              disabled={isDisabled || loadingSuggestions}
-              data-testid={`role-pill-${role}`}
-              className={`rounded-full border px-4 py-1.5 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed ${
-                selectedRole === role
-                  ? "border-blue-500 bg-blue-500 text-white"
-                  : "border-tremor-border dark:border-dark-tremor-border text-tremor-content dark:text-dark-tremor-content hover:border-blue-400 hover:text-blue-400"
-              }`}
-            >
-              {role}
-            </button>
-          ))}
-        </div>
-
-        {/* Loading state */}
-        {loadingSuggestions && (
-          <div className="mt-4 flex items-center gap-2 text-sm text-tremor-content dark:text-dark-tremor-content">
-            <span
-              className="h-4 w-4 animate-spin rounded-full border-2 border-blue-400 border-t-transparent"
-              role="status"
-              aria-label="Cargando sugerencias"
-            />
-            Analizando tu perfil...
-          </div>
-        )}
-
-        {/* Error state */}
-        {suggestError && (
-          <p className="mt-4 text-sm text-red-400">{suggestError}</p>
-        )}
-
-        {/* Suggestions */}
-        {suggestions && suggestions.length > 0 && (
-          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {suggestions.map((s, i) => (
-              <div
-                key={`${s.name}-${i}`}
-                className="flex flex-col items-start rounded-lg border border-tremor-border dark:border-dark-tremor-border bg-tremor-background-subtle dark:bg-dark-tremor-background-subtle p-5 shadow-sm"
+        <div
+          role="tablist"
+          aria-labelledby="creation-tabs-label"
+          className="flex flex-wrap gap-1 border-b border-tremor-border dark:border-dark-tremor-border"
+        >
+          {tabDefs.map((t) => {
+            const selected = tab === t.id;
+            return (
+              <button
+                key={t.id}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                id={`creation-tab-${t.id}-btn`}
+                aria-controls={`creation-tab-panel-${t.id}`}
+                data-testid={`creation-tab-${t.id}`}
+                onClick={() => setTab(t.id)}
+                className={`relative -mb-px rounded-t-md border border-b-0 px-4 py-2.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                  selected
+                    ? "border-tremor-border bg-tremor-background text-blue-600 dark:border-dark-tremor-border dark:bg-dark-tremor-background dark:text-blue-400"
+                    : "border-transparent text-tremor-content hover:text-blue-500 dark:text-dark-tremor-content dark:hover:text-blue-400"
+                }`}
               >
-                <h3 className="text-sm font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-                  {s.name}
-                </h3>
-                <p className="mt-1 text-xs text-tremor-content dark:text-dark-tremor-content line-clamp-3">
-                  {s.description}
-                </p>
-                <button
-                  onClick={() => generateFromPrompt(s.prompt)}
-                  disabled={isDisabled}
-                  className="mt-3 inline-flex items-center gap-1 rounded-md bg-blue-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                >
-                  Crear
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
+                <span>{t.label}</span>
+                <span className="mt-0.5 block text-[10px] font-normal opacity-80">{t.hint}</span>
+              </button>
+            );
+          })}
+        </div>
 
-        {suggestions && suggestions.length === 0 && (
-          <p className="mt-4 text-sm text-tremor-content dark:text-dark-tremor-content">
-            No se encontraron sugerencias para este rol.
-          </p>
-        )}
-      </div>
-
-      {/* Section 3: Gap analysis */}
-      <div>
-        <h2 className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-          ¿Qué me falta?
-        </h2>
-        <p className="mt-1 text-sm text-tremor-content dark:text-dark-tremor-content">
-          Analiza tus paneles actuales y descubre qué áreas de negocio no están cubiertas
-        </p>
-
-        <div className="mt-3">
-          <button
-            onClick={handleAnalyzeGaps}
-            disabled={isDisabled || loadingGaps}
-            data-testid="analyze-gaps-button"
-            className="inline-flex items-center gap-2 rounded-lg border border-tremor-border dark:border-dark-tremor-border bg-tremor-background-subtle dark:bg-dark-tremor-background-subtle px-4 py-2 text-sm font-medium text-tremor-content-strong dark:text-dark-tremor-content-strong hover:border-blue-400 hover:text-blue-400 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+        {/* ─── Plantillas ─────────────────────────────────────────────────── */}
+        {tab === "templates" && (
+          <div
+            id="creation-tab-panel-templates"
+            role="tabpanel"
+            aria-labelledby="creation-tab-templates-btn"
+            className="pt-8"
           >
-            {loadingGaps ? (
-              <>
-                <span
-                  className="h-4 w-4 animate-spin rounded-full border-2 border-blue-400 border-t-transparent"
-                  role="status"
-                  aria-label="Analizando cobertura"
-                />
-                Analizando...
-              </>
-            ) : (
-              "Analizar cobertura"
-            )}
-          </button>
-        </div>
+            <div>
+              <h2 className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                Plantillas predefinidas
+              </h2>
+              <p className="mt-1 text-sm text-tremor-content dark:text-dark-tremor-content">
+                Usa una plantilla para empezar con un dashboard listo al instante (sin generación
+                por IA).
+              </p>
 
-        {/* Error state */}
-        {gapsError && (
-          <p className="mt-4 text-sm text-red-400">{gapsError}</p>
+              <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {TEMPLATES.map((template) => (
+                  <button
+                    key={template.slug}
+                    type="button"
+                    onClick={() => handleUseTemplate(template)}
+                    disabled={isDisabled}
+                    data-testid={`template-card-${template.slug}`}
+                    className="flex flex-col items-start rounded-lg border border-emerald-500/25 bg-tremor-background-subtle p-5 text-left shadow-sm hover:border-emerald-500/50 hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed dark:border-emerald-500/20 dark:bg-dark-tremor-background-subtle dark:hover:border-emerald-500/40"
+                  >
+                    <BadgeNoAi />
+                    <h3 className="text-sm font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                      {template.name}
+                    </h3>
+                    <p className="mt-1 text-xs text-tremor-content dark:text-dark-tremor-content line-clamp-2">
+                      {template.description}
+                    </p>
+                    <span className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-emerald-700 dark:text-emerald-300">
+                      {loadingTemplate === template.slug ? (
+                        <>
+                          <span
+                            className="h-3 w-3 animate-spin rounded-full border-2 border-emerald-600 border-t-transparent"
+                            role="status"
+                            aria-label="Cargando plantilla"
+                          />
+                          Creando...
+                        </>
+                      ) : (
+                        "Usar plantilla"
+                      )}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
         )}
 
-        {/* Gap cards */}
-        {gaps && gaps.length > 0 && (
-          <div className="mt-4 space-y-3">
-            {gaps.map((g, i) => (
-              <div
-                key={`${g.area}-${i}`}
-                className="flex items-start justify-between gap-4 rounded-lg border border-tremor-border dark:border-dark-tremor-border bg-tremor-background-subtle dark:bg-dark-tremor-background-subtle p-4 shadow-sm"
-              >
-                <div className="flex-1">
-                  <h3 className="text-sm font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-                    {g.area}
-                  </h3>
-                  <p className="mt-1 text-xs text-tremor-content dark:text-dark-tremor-content">
-                    {g.description}
-                  </p>
+        {/* ─── Asistente IA ───────────────────────────────────────────────── */}
+        {tab === "assistant" && (
+          <div
+            id="creation-tab-panel-assistant"
+            role="tabpanel"
+            aria-labelledby="creation-tab-assistant-btn"
+            className="space-y-10 pt-8"
+          >
+            <div>
+              <h2 className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                ¿Qué necesitas hacer?
+              </h2>
+              <p className="mt-1 text-sm text-tremor-content dark:text-dark-tremor-content">
+                Atajos de negocio: al pulsar, el modelo genera el panel y lo guardamos automáticamente.
+              </p>
+
+              <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {TASK_PROMPTS.map((task) => (
+                  <button
+                    key={task.id}
+                    type="button"
+                    onClick={() => generateFromPrompt(task.prompt)}
+                    disabled={isDisabled}
+                    data-testid={`task-card-${task.id}`}
+                    className="flex flex-col items-start rounded-lg border border-violet-500/20 bg-tremor-background-subtle p-5 text-left shadow-sm hover:border-violet-500/45 hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed dark:border-violet-400/15 dark:bg-dark-tremor-background-subtle dark:hover:border-violet-400/35"
+                  >
+                    <BadgeUsesAi />
+                    <span className="text-2xl" aria-hidden="true">
+                      {task.icon}
+                    </span>
+                    <h3 className="mt-2 text-sm font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                      {task.title}
+                    </h3>
+                    <p className="mt-1 text-xs text-tremor-content dark:text-dark-tremor-content line-clamp-2">
+                      {task.description}
+                    </p>
+                    <span className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-violet-700 dark:text-violet-300">
+                      Crear panel
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <h2 className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                Recomendado para ti
+              </h2>
+              <p className="mt-1 text-sm text-tremor-content dark:text-dark-tremor-content">
+                Selecciona tu rol y te sugerimos paneles útiles evitando solaparse con los que ya
+                tienes.
+              </p>
+
+              <div className="mt-3 flex flex-wrap gap-2">
+                {ROLES.map((role) => (
+                  <button
+                    key={role}
+                    type="button"
+                    onClick={() => handleRoleSelect(role)}
+                    disabled={isDisabled || loadingSuggestions}
+                    data-testid={`role-pill-${role}`}
+                    className={`rounded-full border px-4 py-1.5 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed ${
+                      selectedRole === role
+                        ? "border-violet-600 bg-violet-600 text-white dark:border-violet-500 dark:bg-violet-600"
+                        : "border-tremor-border text-tremor-content hover:border-violet-400 hover:text-violet-600 dark:border-dark-tremor-border dark:text-dark-tremor-content dark:hover:border-violet-400 dark:hover:text-violet-300"
+                    }`}
+                  >
+                    {role}
+                  </button>
+                ))}
+              </div>
+
+              {loadingSuggestions && (
+                <div className="mt-4 flex items-center gap-2 text-sm text-tremor-content dark:text-dark-tremor-content">
+                  <span
+                    className="h-4 w-4 animate-spin rounded-full border-2 border-violet-500 border-t-transparent"
+                    role="status"
+                    aria-label="Cargando sugerencias"
+                  />
+                  Analizando tu perfil...
                 </div>
+              )}
+
+              {suggestError && <p className="mt-4 text-sm text-red-400">{suggestError}</p>}
+
+              {suggestions && suggestions.length > 0 && (
+                <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {suggestions.map((s, i) => (
+                    <div
+                      key={`${s.name}-${i}`}
+                      className="flex flex-col items-start rounded-lg border border-violet-500/20 bg-tremor-background-subtle p-5 shadow-sm dark:border-violet-400/15 dark:bg-dark-tremor-background-subtle"
+                    >
+                      <BadgeUsesAi />
+                      <h3 className="text-sm font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                        {s.name}
+                      </h3>
+                      <p className="mt-1 text-xs text-tremor-content dark:text-dark-tremor-content line-clamp-3">
+                        {s.description}
+                      </p>
+                      <button
+                        type="button"
+                        onClick={() => generateFromPrompt(s.prompt)}
+                        disabled={isDisabled}
+                        className="mt-3 inline-flex items-center gap-1 rounded-md bg-violet-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-violet-700 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-violet-600 dark:hover:bg-violet-500"
+                      >
+                        Crear
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {suggestions && suggestions.length === 0 && (
+                <p className="mt-4 text-sm text-tremor-content dark:text-dark-tremor-content">
+                  No se encontraron sugerencias para este rol.
+                </p>
+              )}
+            </div>
+
+            <div>
+              <h2 className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                ¿Qué me falta?
+              </h2>
+              <p className="mt-1 text-sm text-tremor-content dark:text-dark-tremor-content">
+                Analiza tus paneles actuales y descubre áreas de negocio poco cubiertas.
+              </p>
+
+              <div className="mt-3">
                 <button
-                  onClick={() => generateFromPrompt(g.suggestedPrompt)}
-                  disabled={isDisabled}
-                  className="shrink-0 inline-flex items-center gap-1 rounded-md bg-blue-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  type="button"
+                  onClick={handleAnalyzeGaps}
+                  disabled={isDisabled || loadingGaps}
+                  data-testid="analyze-gaps-button"
+                  className="inline-flex items-center gap-2 rounded-lg border border-violet-500/25 bg-tremor-background-subtle px-4 py-2 text-sm font-medium text-tremor-content-strong hover:border-violet-500/50 hover:text-violet-800 disabled:opacity-50 disabled:cursor-not-allowed dark:border-violet-400/20 dark:bg-dark-tremor-background-subtle dark:text-dark-tremor-content-strong dark:hover:text-violet-200"
                 >
-                  Crear panel
+                  {loadingGaps ? (
+                    <>
+                      <span
+                        className="h-4 w-4 animate-spin rounded-full border-2 border-violet-500 border-t-transparent"
+                        role="status"
+                        aria-label="Analizando cobertura"
+                      />
+                      Analizando...
+                    </>
+                  ) : (
+                    "Analizar cobertura"
+                  )}
                 </button>
               </div>
-            ))}
+
+              {gapsError && <p className="mt-4 text-sm text-red-400">{gapsError}</p>}
+
+              {gaps && gaps.length > 0 && (
+                <div className="mt-4 space-y-3">
+                  {gaps.map((g, i) => (
+                    <div
+                      key={`${g.area}-${i}`}
+                      className="flex items-start justify-between gap-4 rounded-lg border border-violet-500/20 bg-tremor-background-subtle p-4 shadow-sm dark:border-violet-400/15 dark:bg-dark-tremor-background-subtle"
+                    >
+                      <div className="flex-1">
+                        <BadgeUsesAi />
+                        <h3 className="text-sm font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                          {g.area}
+                        </h3>
+                        <p className="mt-1 text-xs text-tremor-content dark:text-dark-tremor-content">
+                          {g.description}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => generateFromPrompt(g.suggestedPrompt)}
+                        disabled={isDisabled}
+                        className="shrink-0 self-center rounded-md bg-violet-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-violet-700 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-violet-600 dark:hover:bg-violet-500"
+                      >
+                        Crear panel
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {gaps && gaps.length === 0 && (
+                <p className="mt-4 text-sm text-tremor-content dark:text-dark-tremor-content">
+                  ¡Excelente! Tu cobertura de dashboards parece completa.
+                </p>
+              )}
+            </div>
           </div>
         )}
 
-        {gaps && gaps.length === 0 && (
-          <p className="mt-4 text-sm text-tremor-content dark:text-dark-tremor-content">
-            ¡Excelente! Tu cobertura de dashboards parece completa.
-          </p>
-        )}
-      </div>
-
-      {/* Free-form prompt */}
-      <div>
-        <h2 className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-          Descripción libre
-        </h2>
-        <p className="mt-1 text-sm text-tremor-content dark:text-dark-tremor-content">
-          Describe el cuadro de mando que deseas crear con tus propias palabras
-        </p>
-
-        <div className="mt-4 max-w-2xl space-y-4">
-          <textarea
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            disabled={isDisabled}
-            placeholder="Describe el dashboard que necesitas..."
-            rows={6}
-            className="w-full resize-none rounded-lg border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-4 py-3 text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis placeholder:text-tremor-content-subtle dark:placeholder:text-dark-tremor-content-subtle focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
-          />
-
-          {error && lastErrorSource === "generate" && (
-            <ErrorDisplay
-              error={error}
-              onRetry={handleGenerate}
-            />
-          )}
-
-          <button
-            onClick={handleGenerate}
-            disabled={isDisabled || prompt.trim() === ""}
-            className="flex items-center gap-2 rounded-lg bg-blue-500 px-6 py-2.5 text-sm font-medium text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        {/* ─── Descripción libre ───────────────────────────────────────────── */}
+        {tab === "free" && (
+          <div
+            id="creation-tab-panel-free"
+            role="tabpanel"
+            aria-labelledby="creation-tab-free-btn"
+            className="pt-8"
           >
-            {loading && (
-              <span
-                className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
-                role="status"
-                aria-label="Generando"
+            <h2 className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+              Descripción libre
+            </h2>
+            <p className="mt-1 text-sm text-tremor-content dark:text-dark-tremor-content">
+              Describe el cuadro de mando con tus propias palabras; generamos el panel con IA.
+            </p>
+
+            <div className="mt-4 max-w-2xl space-y-4">
+              <BadgeUsesAi />
+              <textarea
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                disabled={isDisabled}
+                placeholder="Describe el dashboard que necesitas..."
+                rows={6}
+                className="w-full resize-none rounded-lg border border-tremor-border bg-tremor-background px-4 py-3 text-sm text-tremor-content-emphasis placeholder:text-tremor-content-subtle focus:outline-none focus:ring-2 focus:ring-violet-500 disabled:opacity-50 dark:border-dark-tremor-border dark:bg-dark-tremor-background dark:text-dark-tremor-content-emphasis dark:placeholder:text-dark-tremor-content-subtle"
               />
-            )}
-            {loading ? "Generando..." : "Generar Dashboard"}
-          </button>
-        </div>
-      </div>
 
-      {/* Template cards */}
-      <div>
-        <h2 className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-          Plantillas predefinidas
-        </h2>
-        <p className="mt-1 text-sm text-tremor-content dark:text-dark-tremor-content">
-          Usa una plantilla para empezar con un dashboard listo al instante
-        </p>
+              {error && lastErrorSource === "generate" && (
+                <ErrorDisplay error={error} onRetry={handleGenerate} />
+              )}
 
-        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {TEMPLATES.map((template) => (
-            <button
-              key={template.slug}
-              onClick={() => handleUseTemplate(template)}
-              disabled={isDisabled}
-              className="flex flex-col items-start rounded-lg border border-tremor-border dark:border-dark-tremor-border bg-tremor-background-subtle dark:bg-dark-tremor-background-subtle p-5 text-left shadow-sm hover:border-blue-400 hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed transition-all"
-            >
-              <h3 className="text-sm font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-                {template.name}
-              </h3>
-              <p className="mt-1 text-xs text-tremor-content dark:text-dark-tremor-content line-clamp-2">
-                {template.description}
-              </p>
-              <span className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-blue-400">
-                {loadingTemplate === template.slug ? (
-                  <>
-                    <span
-                      className="h-3 w-3 animate-spin rounded-full border-2 border-blue-400 border-t-transparent"
-                      role="status"
-                      aria-label="Cargando plantilla"
-                    />
-                    Creando...
-                  </>
-                ) : (
-                  "Usar plantilla"
+              <button
+                type="button"
+                onClick={handleGenerate}
+                disabled={isDisabled || prompt.trim() === ""}
+                className="flex items-center gap-2 rounded-lg bg-violet-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-violet-700 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-violet-600 dark:hover:bg-violet-500"
+              >
+                {loading && (
+                  <span
+                    className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+                    role="status"
+                    aria-label="Generando"
+                  />
                 )}
-              </span>
-            </button>
-          ))}
-        </div>
+                {loading ? "Generando..." : "Generar Dashboard"}
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Implementa la **fase A** de la issue #377 en `/dashboard/new`:

- Bloque introductorio (**tres formas**: plantillas sin IA, asistente con IA, descripción libre).
- **Pestañas** accesibles (`role=tablist` / `tabpanel`): Plantillas · Asistente IA · Descripción libre; por defecto **Asistente IA** para no ocultar los atajos habituales.
- **Badges** "Sin IA · instantáneo" / "Usa IA" y bordes de tarjeta diferenciados (esmeralda vs violeta).
- `data-testid` en pestañas (`creation-tab-*`) y en plantillas (`template-card-${slug}`).

## Testing
`cd dashboard && npm test -- --run`

Fixes #377

Made with [Cursor](https://cursor.com)