### PR TITLE
feat(etl): Exportaciones signed int16 stock; feat(dashboard): SQL spec heuristics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,8 +195,10 @@ To add new instructions or SQL pairs: add entries to `INSTRUCTIONS` or `SQL_PAIR
 - **325 tables**, ~8.6 million rows across key tables
 - **Key domains:** Products (Articulos), Sales (Ventas/LineasVentas), Customers (Clientes), Wholesale (GC* tables), Purchasing (Compras), Invoicing (Facturas), Stock (Exportaciones/CCStock), Logistics, HR (RRHH*), Finance, Stores (Tiendas)
 - **Schema details:** Run `ps sql schema` to generate locally (git-ignored, contains real data)
+- **Authoritative field types:** Query **`_USER_COLUMNS`** on the live 4D server (`ps sql query "SELECT COLUMN_NAME, DATA_TYPE, DATA_LENGTH FROM _USER_COLUMNS WHERE TABLE_NAME = 'Exportaciones' AND COLUMN_NAME LIKE 'Stock%'"`). Type IDs are documented in [docs/skills/4d-sql-dialect.md](docs/skills/4d-sql-dialect.md). A local **PowerShop Server / PSClient** directory tree (install or backup files) is mainly **binaries and resources** — it does **not** replace structure discovery; use SQL system tables or vendor `*_SQL` views.
 - Primary keys use Real (float) fields with a `.99` suffix pattern — store as `NUMERIC` in PostgreSQL, never `FLOAT8`
 - CCStock has 582 columns (wide-format stock matrix); prefer `Exportaciones` for ETL (has FechaModifica, simpler structure)
+- **`Exportaciones.Stock1..Stock34`:** **`_USER_COLUMNS`** declares **every** slot as **`DATA_TYPE = 3`**, **`DATA_LENGTH = 2`** (16-bit integer). The **4D SQL + p4d** path can return **unsigned widened** values for negatives (`65535` = `−1`). The ETL applies **`decode_signed_int16_word()`** (subtract 65536 when `32768 ≤ n ≤ 65535` — exact int16 bit reinterpretation) **only** on these columns before `ps_stock_tienda.stock`. **`CCStock`** is **Real** (type 6) and is not passed through that decoder. See [docs/skills/data-access.md](docs/skills/data-access.md), `DECISIONS-AND-CHANGES.md` D-017.
 - Articulos has 379 columns (prices, sizes, multilingual descriptions) — never `SELECT *`, always specify columns
 - **ETL sync strategy:** See [docs/etl-sync-strategy.md](docs/etl-sync-strategy.md) for validated delta fields, PKs, and sync method per table
 

--- a/DECISIONS-AND-CHANGES.md
+++ b/DECISIONS-AND-CHANGES.md
@@ -4,6 +4,17 @@
 
 ## Decision Log
 
+### D-017: Signed 16-bit `Exportaciones.StockN` over 4D SQL / p4d — 2026-04-22
+**Context**: Dashboard stock KPIs showed hundreds of millions of units; investigation showed `ps_stock_tienda.stock = 65535` while PowerShop POS showed `−1` for the same slot, with `CCStock` (Real) matching the signed row total. Users asked whether metadata and a “native 4D” path exist.
+**Evidence**:
+- Live **`_USER_COLUMNS`**: all **`Exportaciones.Stock1`…`Stock34`** are **`DATA_TYPE = 3`**, **`DATA_LENGTH = 2`** (16-bit integer). **`CCStock`** is **`DATA_TYPE = 6`** (Real, length 8). **`LineasVentas.Unidades`** and **`Traspasos.UnidadesS/E`** are **Real (6/8)** in the catalog — not 16-bit slots.
+- Cross-check **4D SQL** (`ps sql query`) returns the same `65535` values the ETL saw; the UI uses native 4D types and shows negatives.
+- Local **PowerShop Server / PSClient** file trees (e.g. install bundles) contain **compiler/resources** (XLF mentions `WORD` types) but **not** `.4DProject` field lists — **not** a substitute for `_USER_COLUMNS` on the server.
+**Decision**: Implement **`decode_signed_int16_word()`** in `etl/db/fourd.py`: for integers in ``32768..65535``, subtract **65536** (exact signed-int16 reinterpretation of the low 16 bits — **not** a domain heuristic). Call **only** when normalizing **`Exportaciones.Stock1`…`Stock34`**, because **`_USER_COLUMNS`** alone marks those as **`DATA_TYPE = 3`**, **`DATA_LENGTH = 2`**. **Do not** apply to **`LineasVentas.Unidades`** or **`Traspasos.UnidadesS/E`** (catalog: **Real**, type 6) or to wholesale **`GCLin*`** line quantities (can exceed 32767) — see `mayorista.py` note.
+**Alternatives rejected**: Relying on a `p4d.connect()` option (none exposed for type coercion). Fixing only in dashboards (would leave raw mirror wrong for WrenAI/SQL). Guessing additional columns without type-3/length-2 proof.
+**Rationale**: 4D “knows” the type from the **structure**; the bug is at the **SQL wire representation**. The decode rule is **metadata-driven** (which columns) + **bit-accurate** (how to convert).
+**See**: `etl/db/fourd.py`, `etl/sync/stock.py`, [docs/skills/4d-sql-dialect.md](docs/skills/4d-sql-dialect.md), [docs/skills/data-access.md](docs/skills/data-access.md), [docs/architecture/stock-logistics.md](docs/architecture/stock-logistics.md).
+
 ### D-016: Proposed PostgreSQL trigger table for manual ETL sync — 2026-04-18
 **Context**: Issue #271 defines a "Sincronizar ahora" button for the ETL Monitor dashboard page.
 The button needs to signal the ETL container (a pure Python scheduler with no HTTP API) to start an out-of-schedule sync.
@@ -108,6 +119,10 @@ The button needs to signal the ETL container (a pure Python scheduler with no HT
 ---
 
 ## Changelog
+
+### 2026-04-22
+- ETL: `decode_signed_int16_word()` **only** for `Exportaciones.Stock1..Stock34` (`_USER_COLUMNS` type 3, length 2); D-017 tightened — no decode on Real-typed quantity columns
+- Docs: AGENTS.md, `docs/skills/4d-sql-dialect.md`, `docs/skills/data-access.md`, `docs/architecture/stock-logistics.md`, `docs/etl-sync-strategy.md` — `_USER_COLUMNS` evidence, SQL vs native 4D, PowerShop file-tree limits
 
 ### 2026-04-18
 - Documented D-016 for Dashboard ETL Monitor manual sync design via PostgreSQL `etl_manual_trigger` table (issue #271)

--- a/dashboard/app/api/dashboard/[id]/route.ts
+++ b/dashboard/app/api/dashboard/[id]/route.ts
@@ -243,7 +243,7 @@ export async function PUT(
     );
   }
 
-  let validatedSpec;
+  let validatedSpec: ReturnType<typeof validateSpec>;
   try {
     validatedSpec = validateSpec(spec);
   } catch (err) {

--- a/dashboard/app/api/dashboard/[id]/route.ts
+++ b/dashboard/app/api/dashboard/[id]/route.ts
@@ -12,6 +12,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { sql, getPool } from "@/lib/db-write";
 import { validateSpec } from "@/lib/schema";
+import { lintDashboardSpec } from "@/lib/sql-heuristics";
 import { ZodError } from "zod";
 import {
   formatApiError,
@@ -242,8 +243,9 @@ export async function PUT(
     );
   }
 
+  let validatedSpec;
   try {
-    validateSpec(spec);
+    validatedSpec = validateSpec(spec);
   } catch (err) {
     if (err instanceof ZodError) {
       return NextResponse.json(
@@ -257,6 +259,19 @@ export async function PUT(
       );
     }
     throw err;
+  }
+
+  const sqlLint = lintDashboardSpec(validatedSpec);
+  if (sqlLint.length > 0) {
+    return NextResponse.json(
+      formatApiError(
+        "Las consultas SQL contienen patrones inválidos para PostgreSQL.",
+        "SQL_LINT",
+        sqlLint.join(" | "),
+        requestId,
+      ),
+      { status: 400 },
+    );
   }
 
   const normalizedPrompt =
@@ -316,7 +331,7 @@ export async function PUT(
 
     // Build dynamic SET clause and parameters
     const setClauses: string[] = ["spec = $1", "updated_at = NOW()"];
-    const params: unknown[] = [JSON.stringify(spec), id];
+    const params: unknown[] = [JSON.stringify(validatedSpec), id];
     let paramIdx = 3;
 
     if (trimmedName) {

--- a/dashboard/app/api/dashboard/generate/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/generate/__tests__/route.test.ts
@@ -230,6 +230,30 @@ describe("POST /api/dashboard/generate", () => {
     expect(res.status).toBe(400);
   });
 
+  it("returns 400 SQL_LINT when LLM returns EXTRACT(days FROM …) (PostgreSQL anti-pattern)", async () => {
+    const badSqlSpec = {
+      title: "Stock",
+      description: "Test",
+      glossary: [{ term: "a", definition: "b" }],
+      widgets: [
+        {
+          id: "w1",
+          type: "table",
+          title: "T",
+          sql: "SELECT EXTRACT(days FROM CURRENT_DATE - MAX(fecha_creacion)) AS dias FROM ps_ventas v GROUP BY v.reg_ventas",
+        },
+      ],
+    };
+    mockGenerate.mockResolvedValue(JSON.stringify(badSqlSpec));
+
+    const res = await POST(makeRequest({ prompt: "stock lento" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.code).toBe("SQL_LINT");
+    expect(String(json.details ?? "")).toMatch(/EXTRACT|PostgreSQL/i);
+  });
+
   it("includes allowedFields for donut_chart when LLM uses category/value instead of x/y", async () => {
     const badSpec = {
       title: "T",

--- a/dashboard/app/api/dashboard/generate/route.ts
+++ b/dashboard/app/api/dashboard/generate/route.ts
@@ -15,6 +15,7 @@ import {
   CircuitBreakerOpenError,
 } from "@/lib/llm";
 import { validateSpec } from "@/lib/schema";
+import { lintDashboardSpec } from "@/lib/sql-heuristics";
 import { ZodError } from "zod";
 import {
   formatApiError,
@@ -150,6 +151,24 @@ export async function POST(request: Request): Promise<NextResponse> {
   // --- Validate against DashboardSpec schema ---
   try {
     const spec = validateSpec(parsed);
+    const sqlLint = lintDashboardSpec(spec);
+    if (sqlLint.length > 0) {
+      console.error(
+        `[${requestId}] SQL heurístico rechazó el spec del LLM:`,
+        sqlLint.join(" | "),
+      );
+      return NextResponse.json(
+        {
+          ...formatApiError(
+            "El modelo generó SQL con patrones inválidos para PostgreSQL (fechas/EXTRACT/COALESCE). Vuelve a generar o reformula el prompt.",
+            "SQL_LINT",
+            sqlLint.join(" | "),
+            requestId,
+          ),
+        },
+        { status: 400 },
+      );
+    }
     return NextResponse.json(spec, { status: 200 });
   } catch (err: unknown) {
     const details =

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -14,6 +14,7 @@ import {
   CircuitBreakerOpenError,
 } from "@/lib/llm";
 import { validateSpec, DashboardSpecSchema, type DashboardSpec } from "@/lib/schema";
+import { lintDashboardSpec } from "@/lib/sql-heuristics";
 import {
   formatApiError,
   generateRequestId,
@@ -173,6 +174,25 @@ export async function POST(request: Request) {
         undefined,
         requestId,
       ),
+      { status: 400 },
+    );
+  }
+
+  const sqlLint = lintDashboardSpec(updatedSpec);
+  if (sqlLint.length > 0) {
+    console.error(
+      `[${requestId}] SQL heurístico rechazó el spec modificado por el LLM:`,
+      sqlLint.join(" | "),
+    );
+    return NextResponse.json(
+      {
+        ...formatApiError(
+          "El modelo devolvió SQL con patrones inválidos para PostgreSQL. Reformula el cambio o inténtalo de nuevo.",
+          "SQL_LINT",
+          sqlLint.join(" | "),
+          requestId,
+        ),
+      },
       { status: 400 },
     );
   }

--- a/dashboard/app/api/dashboards/route.ts
+++ b/dashboard/app/api/dashboards/route.ts
@@ -117,7 +117,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  let validatedSpec;
+  let validatedSpec: ReturnType<typeof validateSpec>;
   try {
     validatedSpec = validateSpec(spec);
   } catch (err) {

--- a/dashboard/app/api/dashboards/route.ts
+++ b/dashboard/app/api/dashboards/route.ts
@@ -10,6 +10,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { sql } from "@/lib/db-write";
 import { validateSpec } from "@/lib/schema";
+import { lintDashboardSpec } from "@/lib/sql-heuristics";
 import { ZodError } from "zod";
 import {
   formatApiError,
@@ -116,8 +117,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
+  let validatedSpec;
   try {
-    validateSpec(spec);
+    validatedSpec = validateSpec(spec);
   } catch (err) {
     if (err instanceof ZodError) {
       return NextResponse.json(
@@ -133,13 +135,26 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     throw err;
   }
 
+  const sqlLint = lintDashboardSpec(validatedSpec);
+  if (sqlLint.length > 0) {
+    return NextResponse.json(
+      formatApiError(
+        "Las consultas SQL contienen patrones inválidos para PostgreSQL.",
+        "SQL_LINT",
+        sqlLint.join(" | "),
+        requestId,
+      ),
+      { status: 400 },
+    );
+  }
+
   // Insert
   try {
     const rows = await sql(
       `INSERT INTO dashboards (name, description, spec)
        VALUES ($1, $2, $3)
        RETURNING id, name, description, spec, created_at, updated_at`,
-      [name.trim(), description?.trim() || null, JSON.stringify(spec)],
+      [name.trim(), description?.trim() || null, JSON.stringify(validatedSpec)],
     );
     return NextResponse.json(rows[0], { status: 201 });
   } catch (err) {

--- a/dashboard/lib/__tests__/sql-heuristics.test.ts
+++ b/dashboard/lib/__tests__/sql-heuristics.test.ts
@@ -47,4 +47,25 @@ describe("lintDashboardSpec", () => {
     expect(msgs.some((m) => m.includes("w1"))).toBe(true);
     expect(msgs.some((m) => m.includes("EXTRACT(days"))).toBe(true);
   });
+
+  it("deduplicates identical widget path messages", () => {
+    const badSql = "SELECT EXTRACT(days FROM CURRENT_DATE - fecha) AS x FROM foo";
+    const spec: DashboardSpec = {
+      title: "T",
+      description: "D",
+      widgets: [
+        {
+          id: "w1",
+          type: "kpi_row",
+          items: [
+            { label: "A", sql: badSql, format: "number" as const },
+            { label: "A", sql: badSql, format: "number" as const },
+          ],
+        },
+      ],
+      glossary: [{ term: "a", definition: "b" }],
+    };
+    const msgs = lintDashboardSpec(spec);
+    expect(msgs.length).toBe(1);
+  });
 });

--- a/dashboard/lib/__tests__/sql-heuristics.test.ts
+++ b/dashboard/lib/__tests__/sql-heuristics.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { lintWidgetSql, lintDashboardSpec } from "../sql-heuristics";
+import type { DashboardSpec } from "../schema";
+
+describe("lintWidgetSql", () => {
+  it("flags EXTRACT(days FROM …)", () => {
+    const sql =
+      "SELECT EXTRACT(days FROM CURRENT_DATE - MAX(v.fecha_creacion)) AS x FROM t";
+    expect(lintWidgetSql(sql).length).toBeGreaterThan(0);
+  });
+
+  it("allows date subtraction without EXTRACT(days", () => {
+    const sql =
+      "SELECT (CURRENT_DATE - MAX(v.fecha_creacion)) AS dias FROM ps_lineas_ventas lv JOIN ps_ventas v ON true GROUP BY lv.codigo";
+    expect(lintWidgetSql(sql)).toEqual([]);
+  });
+
+  it("flags COALESCE(MAX(…fecha…), 'literal')", () => {
+    const sql =
+      "SELECT COALESCE(MAX(ultima_venta.fecha_ultima), 'Sin ventas') AS u FROM t";
+    expect(lintWidgetSql(sql).length).toBeGreaterThan(0);
+  });
+
+  it("allows COALESCE(MAX(fecha…)::text, 'literal')", () => {
+    const sql =
+      "SELECT COALESCE(MAX(ultima_venta.fecha_ultima)::text, 'Sin ventas') AS u FROM t";
+    expect(lintWidgetSql(sql)).toEqual([]);
+  });
+});
+
+describe("lintDashboardSpec", () => {
+  it("returns paths for failing widgets", () => {
+    const spec: DashboardSpec = {
+      title: "T",
+      description: "D",
+      widgets: [
+        {
+          id: "w1",
+          type: "table",
+          title: "Tab",
+          sql: "SELECT EXTRACT(days FROM CURRENT_DATE - fecha) AS x FROM foo",
+        },
+      ],
+      glossary: [{ term: "a", definition: "b" }],
+    };
+    const msgs = lintDashboardSpec(spec);
+    expect(msgs.some((m) => m.includes("w1"))).toBe(true);
+    expect(msgs.some((m) => m.includes("EXTRACT(days"))).toBe(true);
+  });
+});

--- a/dashboard/lib/__tests__/templates.test.ts
+++ b/dashboard/lib/__tests__/templates.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { TEMPLATES, type DashboardTemplate } from "../templates";
 import { validateSpec, DashboardSpecSchema } from "../schema";
+import { lintDashboardSpec, collectWidgetSqlStrings } from "../sql-heuristics";
 
 // ---------------------------------------------------------------------------
 // Structural tests
@@ -106,16 +107,14 @@ describe.each(TEMPLATES.map((t) => [t.slug, t] as [string, DashboardTemplate]))(
 describe("SQL rule compliance across all templates", () => {
   const allSql: string[] = [];
   for (const t of TEMPLATES) {
-    for (const widget of t.spec.widgets) {
-      if (widget.type === "kpi_row") {
-        for (const item of widget.items) {
-          allSql.push(item.sql);
-        }
-      } else {
-        allSql.push(widget.sql);
-      }
-    }
+    allSql.push(...collectWidgetSqlStrings(t.spec));
   }
+
+  it("passes PostgreSQL SQL heuristics (EXTRACT days / COALESCE date+text)", () => {
+    for (const t of TEMPLATES) {
+      expect(lintDashboardSpec(t.spec), `template ${t.slug}`).toEqual([]);
+    }
+  });
 
   it("never uses the 'total' column without _si suffix for retail ventas", () => {
     for (const sql of allSql) {

--- a/dashboard/lib/errors.ts
+++ b/dashboard/lib/errors.ts
@@ -21,6 +21,7 @@ export type ErrorCode =
   | "LLM_CIRCUIT_OPEN"
   | "LLM_INVALID_RESPONSE"
   | "VALIDATION"
+  | "SQL_LINT"
   | "NOT_FOUND"
   | "TIMEOUT"
   | "COST_LIMIT"

--- a/dashboard/lib/prompts.ts
+++ b/dashboard/lib/prompts.ts
@@ -214,6 +214,9 @@ All SQL must be valid PostgreSQL executed against the "public" schema.
 13. Use NULLIF to avoid division by zero
 14. NEVER use CROSSTAB or pivot — return flat grouped data
 15. Do NOT reference :comp_from/:comp_to/:comp_mes_from/:comp_mes_to in a main widget \`sql\`. These tokens are only available in \`comparison_sql\` (chart widgets only) and \`trend_sql\`/\`anomaly_sql\` (kpi_row items only). For side-by-side "Actual vs Anterior" tables, use a \`bar_chart\` with \`sql\` (using :curr_*) and \`comparison_sql\` (using :comp_*) instead.
+16. **Days between dates (PostgreSQL):** If columns are \`date\` (or \`timestamp::date\)), subtracting yields an **integer** number of days: \`(CURRENT_DATE - MAX(v.fecha_creacion::date))\` or \`(fecha_fin - fecha_ini)\`. **Do NOT** wrap that subtraction in \`EXTRACT(days FROM ...)\` — there is no \`days\` field; \`date - date\` is already days, and \`EXTRACT(day FROM integer)\` errors. For a true \`interval\` (e.g. two timestamps), use \`EXTRACT(day FROM intervalo)\` (singular \`day\`).
+17. **Never mix date and text in COALESCE:** \`COALESCE(MAX(fecha), 'Sin ventas')\` fails because PostgreSQL coerces the literal to \`date\`. Use \`COALESCE(MAX(fecha)::text, 'Sin ventas')\` or \`TO_CHAR(MAX(fecha), 'YYYY-MM-DD')\`.
+18. **"Días sin venta" pattern:** Prefer \`COALESCE((CURRENT_DATE - MAX(ultima_venta.fecha)), 999)\` when the join yields a single last-sale date per SKU (guard NULL with COALESCE), instead of EXTRACT on a date difference.
 `;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/dashboard/lib/sql-heuristics.ts
+++ b/dashboard/lib/sql-heuristics.ts
@@ -64,33 +64,40 @@ export function lintWidgetSql(sql: string): string[] {
 
 /** Lint every widget SQL in a spec; aggregates unique messages with widget paths. */
 export function lintDashboardSpec(spec: DashboardSpec): string[] {
+  const seenMessages = new Set<string>();
   const messages: string[] = [];
+  const pushUniqueMessage = (message: string): void => {
+    if (!seenMessages.has(message)) {
+      seenMessages.add(message);
+      messages.push(message);
+    }
+  };
   spec.widgets.forEach((widget, idx) => {
     const wid = widget.id ?? `index ${idx}`;
     if (widget.type === "kpi_row") {
-      widget.items.forEach((item, j) => {
+      widget.items.forEach((item) => {
         for (const msg of lintWidgetSql(item.sql)) {
-          messages.push(`Widget ${wid} (KPI «${item.label}»): ${msg}`);
+          pushUniqueMessage(`Widget ${wid} (KPI «${item.label}»): ${msg}`);
         }
         if (item.trend_sql) {
           for (const msg of lintWidgetSql(item.trend_sql)) {
-            messages.push(`Widget ${wid} (KPI «${item.label}», trend_sql): ${msg}`);
+            pushUniqueMessage(`Widget ${wid} (KPI «${item.label}», trend_sql): ${msg}`);
           }
         }
         if (item.anomaly_sql) {
           for (const msg of lintWidgetSql(item.anomaly_sql)) {
-            messages.push(`Widget ${wid} (KPI «${item.label}», anomaly_sql): ${msg}`);
+            pushUniqueMessage(`Widget ${wid} (KPI «${item.label}», anomaly_sql): ${msg}`);
           }
         }
       });
     } else {
       const title = "title" in widget ? widget.title : wid;
       for (const msg of lintWidgetSql(widget.sql)) {
-        messages.push(`Widget ${wid} («${title}»): ${msg}`);
+        pushUniqueMessage(`Widget ${wid} («${title}»): ${msg}`);
       }
       if ("comparison_sql" in widget && widget.comparison_sql) {
         for (const msg of lintWidgetSql(widget.comparison_sql)) {
-          messages.push(`Widget ${wid} («${title}», comparison_sql): ${msg}`);
+          pushUniqueMessage(`Widget ${wid} («${title}», comparison_sql): ${msg}`);
         }
       }
     }

--- a/dashboard/lib/sql-heuristics.ts
+++ b/dashboard/lib/sql-heuristics.ts
@@ -1,0 +1,99 @@
+/**
+ * Static checks on widget SQL strings to catch common LLM mistakes against
+ * PostgreSQL (date arithmetic, EXTRACT field names, COALESCE typing).
+ * Does not execute SQL — complements EXPLAIN cost checks at query time.
+ */
+import type { DashboardSpec, Widget } from "@/lib/schema";
+
+function pushSqlFromWidget(widget: Widget, out: string[]): void {
+  if (widget.type === "kpi_row") {
+    for (const item of widget.items) {
+      out.push(item.sql);
+      if (item.trend_sql) out.push(item.trend_sql);
+      if (item.anomaly_sql) out.push(item.anomaly_sql);
+    }
+    return;
+  }
+  out.push(widget.sql);
+  if ("comparison_sql" in widget && widget.comparison_sql) {
+    out.push(widget.comparison_sql);
+  }
+}
+
+/** All executable SQL strings embedded in a dashboard spec. */
+export function collectWidgetSqlStrings(spec: DashboardSpec): string[] {
+  const out: string[] = [];
+  for (const w of spec.widgets) {
+    pushSqlFromWidget(w, out);
+  }
+  return out;
+}
+
+/**
+ * Returns human-readable issues for one SQL string (Spanish, for API errors).
+ * Empty array means no known anti-patterns matched.
+ */
+export function lintWidgetSql(sql: string): string[] {
+  const issues: string[] = [];
+
+  // LLMs often write EXTRACT(days FROM ...). PostgreSQL uses singular fields
+  // (e.g. day from interval). Worse: (date - date) is already an integer (days),
+  // so EXTRACT(day FROM integer) fails — prefer (CURRENT_DATE - fecha).
+  if (/EXTRACT\s*\(\s*days\s+/i.test(sql)) {
+    issues.push(
+      "Evita EXTRACT(days FROM …): en PostgreSQL no existe el campo 'days'. " +
+        "Si restas dos fechas (date), el resultado ya son días (entero): usa (CURRENT_DATE - columna_fecha) o (fecha_fin::date - fecha_ini::date). " +
+        "Si trabajas con interval, usa EXTRACT(day FROM intervalo) (singular 'day').",
+    );
+  }
+
+  // COALESCE(date_expr, 'text literal') forces a common type and PG tries to cast the string to date.
+  if (
+    /COALESCE\s*\(\s*MAX\s*\([^)]*(?:\bfecha\b|_fecha|fecha_)[^)]*\)\s*,\s*['"]/i.test(
+      sql,
+    )
+  ) {
+    issues.push(
+      "No uses COALESCE(MAX(fecha…), 'texto'): mezcla fecha y texto y PostgreSQL falla al castear. " +
+        "Usa COALESCE(MAX(fecha…)::text, 'texto') o TO_CHAR(MAX(fecha…), 'YYYY-MM-DD').",
+    );
+  }
+
+  return issues;
+}
+
+/** Lint every widget SQL in a spec; aggregates unique messages with widget paths. */
+export function lintDashboardSpec(spec: DashboardSpec): string[] {
+  const messages: string[] = [];
+  spec.widgets.forEach((widget, idx) => {
+    const wid = widget.id ?? `index ${idx}`;
+    if (widget.type === "kpi_row") {
+      widget.items.forEach((item, j) => {
+        for (const msg of lintWidgetSql(item.sql)) {
+          messages.push(`Widget ${wid} (KPI «${item.label}»): ${msg}`);
+        }
+        if (item.trend_sql) {
+          for (const msg of lintWidgetSql(item.trend_sql)) {
+            messages.push(`Widget ${wid} (KPI «${item.label}», trend_sql): ${msg}`);
+          }
+        }
+        if (item.anomaly_sql) {
+          for (const msg of lintWidgetSql(item.anomaly_sql)) {
+            messages.push(`Widget ${wid} (KPI «${item.label}», anomaly_sql): ${msg}`);
+          }
+        }
+      });
+    } else {
+      const title = "title" in widget ? widget.title : wid;
+      for (const msg of lintWidgetSql(widget.sql)) {
+        messages.push(`Widget ${wid} («${title}»): ${msg}`);
+      }
+      if ("comparison_sql" in widget && widget.comparison_sql) {
+        for (const msg of lintWidgetSql(widget.comparison_sql)) {
+          messages.push(`Widget ${wid} («${title}», comparison_sql): ${msg}`);
+        }
+      }
+    }
+  });
+  return messages;
+}

--- a/docs/architecture/stock-logistics.md
+++ b/docs/architecture/stock-logistics.md
@@ -157,11 +157,11 @@ The `Exportaciones` table (2,058,201 rows) is the preferred source for per-store
 
 **Structure (confirmed from `Exportaciones_SQL` view, 2026-04-05):** One row per (article, store) pair with a **34-slot size matrix**:
 - `Talla1..Talla34` — size label per slot (e.g. "XS", "S", "M", "L", "XL", "40", "42"...)
-- `Stock1..Stock34` — current stock quantity per size
+- `Stock1..Stock34` — current stock quantity per size (**`_USER_COLUMNS`:** `DATA_TYPE = 3`, `DATA_LENGTH = 2` — **16-bit integer** in the 4D structure). Via **4D SQL / p4d**, negatives are often returned as **unsigned** (`65535` = `−1`); the ETL reinterprets before `ps_stock_tienda.stock`. Compare with the POS grid: per-size cells show signed values natively.
 - `Minimo1..Minimo34` — minimum stock quantity per size
 - `REPPorcentaje1..REPPorcentaje34` — replenishment percentage per size
-- `STStock` — pre-aggregated total stock (all sizes, all slots) — **use this for totals**
-- `CCStock` — central warehouse stock flag/reference (single column, not the CCStock table)
+- `STStock` — **Real** (`DATA_TYPE = 6`) — secondary numeric field on the export row (legacy naming; not a substitute for slot-level analysis).
+- `CCStock` — **Real** (`DATA_TYPE = 6`) — **row-level net stock** for that `(Codigo, TiendaCodigo)` (matches the “TS” style total in POS when slots are signed). This is **not** the wide **`CCStock` table** in the Products domain (582 columns); same name, different object.
 - `Tienda` (store name), `TiendaCodigo` (composite key), `Codigo` (article code)
 - `FechaModifica`, `HoraModifica` — delta sync fields
 - `Ubicacion1`, `Ubicacion2`, `Ubicacion3` — warehouse location codes
@@ -176,7 +176,7 @@ The `Exportaciones` table (2,058,201 rows) is the preferred source for per-store
 
 **Key gotcha — TiendaCodigo format:** The `TiendaCodigo` field is `"tienda/articulo"` (e.g. `"104/169"`), NOT just a store code. The compound `(Codigo, TiendaCodigo)` is the natural PK.
 
-**ETL normalization:** The wide format must be unpivoted to `(codigo, tienda_codigo, talla, stock)` rows for PostgreSQL. Filter out empty talla slots (`WHERE talla != ''`). See [etl-sync-strategy.md](../etl-sync-strategy.md).
+**ETL normalization:** The wide format must be unpivoted to `(codigo, tienda_codigo, talla, stock)` rows for PostgreSQL. Filter out empty talla slots (`WHERE talla != ''`). Each `StockN` is decoded with `decode_signed_int16_word()` so SQL-layer unsigned values become signed integers. See [etl-sync-strategy.md](../etl-sync-strategy.md).
 
 ## Size Series System (FamiGrupMarc.SerieTallas)
 

--- a/docs/etl-sync-strategy.md
+++ b/docs/etl-sync-strategy.md
@@ -68,7 +68,7 @@ SELECT ... FROM Ventas WHERE FechaModifica > :last_sync
 | Exportaciones | 2,058,201 | `(Codigo, TiendaCodigo)` compound | `FechaModifica` (some NULLs for zero-stock articles) | UPSERT delta + normalize |
 | Traspasos | 262,689 | `RegTraspaso` | `FechaS` (send date) | Append-only by `FechaS` |
 
-**Exportaciones normalization:** The source table is wide-format (Talla1..Talla34 + Stock1..Stock34 per row). ETL must expand each row into `(codigo, tienda_codigo, talla, stock)` tuples. Target table: `ps_stock_tienda`.
+**Exportaciones normalization:** The source table is wide-format (Talla1..Talla34 + Stock1..Stock34 per row). `_USER_COLUMNS` shows every **`Stock1`…`Stock34`** as **`DATA_TYPE = 3`**, **`DATA_LENGTH = 2`** (16-bit integer). Through **4D SQL / p4d**, slot values can arrive as **unsigned** (`65535` for `−1`); ETL applies **`decode_signed_int16_word()`** (`etl/db/fourd.py`) before `int` cast so `ps_stock_tienda.stock` matches native/POS signed semantics. **`CCStock`** on the same row is **Real** and already carries the signed row total. Re-run a full stock sync after deploying the decoder to refresh existing mirror rows.
 
 `TiendaCodigo` format: `"104/169"` = store 104 / article 169. The compound `(Codigo, TiendaCodigo)` is the natural PK — verified by row count.
 

--- a/docs/skills/4d-sql-dialect.md
+++ b/docs/skills/4d-sql-dialect.md
@@ -46,7 +46,7 @@ These are the numeric type codes returned by the system tables:
 | Type ID | Type Name | Python (p4d) Mapping |
 |---------|-----------|---------------------|
 | 1 | Boolean | `bool` |
-| 3 | Integer (16-bit) | `int` |
+| 3 | Integer (16-bit) | `int` (see **SQL vs native sign** below) |
 | 4 | Long Integer (32-bit) | `int` |
 | 6 | Real (float) | `float` |
 | 8 | Date | `datetime.date` or `str` (YYYY-MM-DD) |
@@ -55,6 +55,17 @@ These are the numeric type codes returned by the system tables:
 | 12 | Picture/Blob | `bytes` (avoid querying) |
 | 18 | Blob | `bytes` |
 | 21 | Object (JSON) | `str` (JSON) or `bytes` |
+
+### 16-bit integers over SQL (`DATA_TYPE = 3`, `DATA_LENGTH = 2`)
+
+`_USER_COLUMNS` reports **16-bit integer** fields (type **3**, length **2**) — e.g. all **`Exportaciones.Stock1`…`Stock34`** (34 columns, each type 3 / length 2 in production).
+
+- **Native 4D** (forms, compiled methods, `WORD` variables) keeps **signed** semantics: `−1` stays `−1`.
+- **4D SQL + p4d** can still return the same bit pattern widened as an **unsigned** 32-bit value, so **`−1` appears as `65535`**, **`−2` as `65534`**, etc. The **`CCStock`** column on the same row is **`DATA_TYPE = 6` (Real)** and continues to show the correct **row-level net** (e.g. `−6.0`), which is why the POS grid matches **`CCStock`** while raw **`StockN`** look “huge” until reinterpreted.
+
+**ETL fix:** `etl/db/fourd.py` → `decode_signed_int16_word()` — applied **only** when unpivoting **`Exportaciones.Stock1`…`Stock34`**, because **`_USER_COLUMNS`** marks those columns as **type 3 / length 2** only. There is **no `p4d.connect()` flag** to force signed 16-bit decoding.
+
+**Do not** apply this decode to **Real** columns (type **6**) or to any column that is not **type 3 / length 2** in `_USER_COLUMNS`: wholesale line quantities can exceed **32767** and would be mis-decoded as negative if the int16 rule were applied blindly.
 
 ### Python p4d Type Notes
 

--- a/docs/skills/data-access.md
+++ b/docs/skills/data-access.md
@@ -45,6 +45,8 @@ conn = p4d.connect(
 - **Ventas.FechaDocumento is NULL for all records**: Never use this field for date filtering or delta sync. Use `FechaModifica` (max = today) or `FechaCreacion` instead.
 - **LineasCompras does not exist**: The purchase order line table is `CCLineasCompr` (44K rows). It links to `Compras` via `NumPedido`, not a direct `NumCompra` field.
 - **Exportaciones.TiendaCodigo format**: This field is `"tienda/articulo"` (e.g. `"104/169"`), not just a store code. The compound `(Codigo, TiendaCodigo)` is the natural PK for this table.
+- **Exportaciones `Stock1..Stock34` are 16-bit integers in 4D** (`_USER_COLUMNS`: `DATA_TYPE = 3`, `DATA_LENGTH = 2` for all 34 columns). Through **4D SQL / p4d**, negative per-size quantities often appear as **unsigned** values (`65535` = `−1`, `65534` = `−2`). The **`CCStock`** field on the same row is **Real** (`DATA_TYPE = 6`) and matches the **signed** total the POS shows. The ETL decodes slot stock with `decode_signed_int16_word()` in `etl/db/fourd.py` before writing `ps_stock_tienda.stock`. Re-sync stock after deploying that fix.
+- **Schema evidence**: Prefer live **`SELECT ... FROM _USER_COLUMNS WHERE TABLE_NAME = 'Exportaciones'`** on the 4D server. A local **PowerShop Server / PSClient** tree (install media) usually contains **binaries and resources**, not the `.4DProject` structure — it rarely documents individual table fields.
 - **Ventas/LineasVentas/PagosVentas are NOT append-only**: 19–21% of historical records have been modified after creation (returns, TBAI corrections, payment flags). Always UPSERT by `FechaModifica` — never plain INSERT.
 - **PKs are REAL floats**: Store PKs as `NUMERIC(20,3)` in PostgreSQL, not `FLOAT8`, to avoid precision loss. Use 3 decimal places — some PKs have 3dp (e.g. `RegCliente = 4.152, 4.153`). NUMERIC(20,2) caused duplicate-key collisions. Always convert Python floats to `Decimal(str(value))` before inserting.
 - **4D SQL uses `<>` not `!=`**: The inequality operator in 4D SQL is `<>`. Using `!=` causes "Failed to parse statement". This applies to all SQL including system table queries like `_USER_COLUMNS WHERE DATA_TYPE <> 0`.
@@ -105,7 +107,7 @@ WHERE CAST(Tienda AS INT) = 152
   AND CCStock <> 0
 ```
 
-Key columns: `Tienda` (store code), `Codigo` (article code), `CCStock` (total stock), `Stock1..Stock17` (per-size stock).
+Key columns: `Tienda` (store code), `Codigo` (article code), `CCStock` (row-level net stock, Real), `Stock1..Stock34` (per-size stock, 16-bit integer slots — see gotcha on unsigned negatives via SQL).
 
 This method is faster for bulk queries (all articles in a store at once) and does not require SOAP authentication.
 

--- a/etl/db/fourd.py
+++ b/etl/db/fourd.py
@@ -13,11 +13,18 @@ Gotchas handled here:
   stored as a float may round incorrectly).  Sync modules are responsible for
   this conversion.
 - None values are passed through unchanged.
+- **Signed 16-bit integers over SQL** (``_USER_COLUMNS`` type **3**, length **2** —
+  e.g. all ``Exportaciones.Stock1``…``Stock34``): the SQL/p4d path may widen the
+  bit pattern as unsigned (``65535`` for ``-1``). Call ``decode_signed_int16_word()``
+  **only** for those columns (rule: **metadata** says 16-bit integer, not guesswork).
+  Do **not** apply to ``DATA_TYPE = 6`` (Real) columns such as ``LineasVentas.Unidades``.
 """
 
 from __future__ import annotations
 
+import math
 import re
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -27,6 +34,8 @@ if TYPE_CHECKING:
 # 4D table names in this project follow this pattern; reject anything that
 # does not match to prevent SQL injection via get_queryable_columns().
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# Integer strings (optional leading minus) for WORD decode coercion.
+_SIGNED_INT16_DECIMAL_STR = re.compile(r"-?\d+$")
 
 
 def _validate_identifier(name: str) -> str:
@@ -74,6 +83,62 @@ def _decode_value(v: Any) -> Any:
         # Also strip NUL from native str values (p4d may return str with NUL).
         return v.replace("\x00", "") if "\x00" in v else v
     return v
+
+
+def decode_signed_int16_word(value: Any) -> Any:
+    """Map an unsigned 32-bit carrier of a **signed int16** bit pattern to Python ``int``.
+
+    This is **not** a business heuristic: integers in ``32768..65535`` are exactly
+    the unsigned widening of signed int16 negatives (``65535`` → ``-1``, etc.) —
+    reinterpret the low 16 bits as two's-complement signed.
+
+    **When to call:** only for 4D columns that ``_USER_COLUMNS`` declares as
+    **``DATA_TYPE = 3``** and **``DATA_LENGTH = 2``** (16-bit integer). In this
+    project that is **exclusively** ``Exportaciones.Stock1``…``Stock34`` (verified
+    on production). Do **not** call for ``DATA_TYPE = 6`` (Real) fields.
+
+    The SQL/p4d stack sometimes delivers small negatives in those 16-bit slots
+    as ``65535``, ``65534``, etc.
+
+    Args:
+        value: Raw value from ``safe_fetch`` (``int``, whole ``float``, ``Decimal``, ``str``, …).
+
+    Returns:
+        Signed ``int`` when the numeric value is in ``32768..65535``; otherwise
+        the input unchanged (including ``None``, non-numerics, fractional floats,
+        and values already in ``-32768..32767``).
+    """
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        s = value.strip()
+        if _SIGNED_INT16_DECIMAL_STR.fullmatch(s):
+            value = int(s)
+        else:
+            return value
+    if isinstance(value, int):
+        if 32768 <= value <= 65535:
+            return value - 65536
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return value
+        if not value.is_integer():
+            return value
+        iv = int(value)
+        if 32768 <= iv <= 65535:
+            return iv - 65536
+        return value
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            return value
+        if value != value.to_integral_value():
+            return value
+        iv = int(value)
+        if 32768 <= iv <= 65535:
+            return iv - 65536
+        return value
+    return value
 
 
 def _decode_column_name(name: Any) -> str:

--- a/etl/db/fourd.py
+++ b/etl/db/fourd.py
@@ -104,9 +104,12 @@ def decode_signed_int16_word(value: Any) -> Any:
         value: Raw value from ``safe_fetch`` (``int``, whole ``float``, ``Decimal``, ``str``, …).
 
     Returns:
-        Signed ``int`` when the numeric value is in ``32768..65535``; otherwise
-        the input unchanged (including ``None``, non-numerics, fractional floats,
-        and values already in ``-32768..32767``).
+        Values in ``32768..65535`` become signed ``int`` (``-32768..-1``).
+        Finite integral ``Decimal`` outside that band becomes ``int`` with the same
+        numeric value. ``None``, booleans, non-numeric strings, and fractional
+        ``float`` / ``Decimal`` are unchanged. ``int`` outside the decode band is
+        unchanged; whole ``float`` outside the band is returned as the original
+        ``float``.
     """
     if value is None or isinstance(value, bool):
         return value
@@ -137,7 +140,7 @@ def decode_signed_int16_word(value: Any) -> Any:
         iv = int(value)
         if 32768 <= iv <= 65535:
             return iv - 65536
-        return value
+        return iv
     return value
 
 

--- a/etl/sync/mayorista.py
+++ b/etl/sync/mayorista.py
@@ -17,6 +17,11 @@ Sync strategy notes
   3. Re-fetch and re-insert the lines from 4D.
   For initial load (since=None): truncate + full extract.
 
+Integer quantities (``Unidades``, ``Entregadas``, ``Pendientes`` on GC* lines)
+are **not** passed through ``decode_signed_int16_word``: wholesale lines can
+legitimately exceed 32767 units, which would be mis-decoded as negative if the
+16-bit WORD reinterpretation were applied.
+
 FK corrections (critical)
 -------------------------
 - GCLinAlbarane.NAlbaran  → GCAlbaranes.NAlbaran  (NOT RegAlbaran)

--- a/etl/sync/stock.py
+++ b/etl/sync/stock.py
@@ -27,6 +27,10 @@ row-value comparators was not validated at implementation time.
 The `since` parameter is truncated to a date literal in 4D SQL — only the date
 portion is used; any time component is ignored.  Pass a date-aligned datetime.
 
+``Stock1``…``Stock34`` in 4D are 16-bit WORD fields: negatives are delivered as
+unsigned values (e.g. ``65535`` for ``-1``).  ``_normalize_expo_row`` decodes them
+via ``decode_signed_int16_word`` before persisting to PostgreSQL.
+
 TiendaCodigo format: "store_code/article_code" (e.g. "104/169").  It is NOT
 just a store code.  The compound PK for ps_stock_tienda is (codigo, tienda_codigo, talla).
 
@@ -45,7 +49,7 @@ import re
 from datetime import datetime
 from decimal import ROUND_HALF_UP, Decimal
 
-from etl.db.fourd import safe_fetch
+from etl.db.fourd import decode_signed_int16_word, safe_fetch
 from etl.db.postgres import insert_ignore, upsert
 
 logger = logging.getLogger(__name__)
@@ -192,7 +196,11 @@ def _normalize_expo_row(src: dict) -> list[dict]:
         if talla is None or (isinstance(talla, str) and not talla.strip()):
             continue
         talla_str = talla.strip() if isinstance(talla, str) else str(talla)
-        stock_val = int(stock_raw) if stock_raw is not None else 0
+        if stock_raw is None:
+            stock_val = 0
+        else:
+            decoded = decode_signed_int16_word(stock_raw)
+            stock_val = int(decoded)
         out.append(
             {
                 "codigo": codigo,

--- a/etl/tests/test_fourd_signed_int16.py
+++ b/etl/tests/test_fourd_signed_int16.py
@@ -1,0 +1,39 @@
+"""Tests for ``decode_signed_int16_word`` (4D WORD unsigned → signed)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from etl.db.fourd import decode_signed_int16_word
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, None),
+        (-1, -1),
+        (0, 0),
+        (32767, 32767),
+        (32768, -32768),
+        (65534, -2),
+        (65535, -1),
+        (65535.0, -1),
+        ("65535", -1),
+        (" 65534 ", -2),
+        (Decimal("65535"), -1),
+        (Decimal("-3"), -3),
+        (Decimal("65535.5"), Decimal("65535.5")),
+    ],
+)
+def test_decode_signed_int16_word(raw, expected):
+    assert decode_signed_int16_word(raw) == expected
+
+
+def test_non_numeric_string_unchanged():
+    assert decode_signed_int16_word("abc") == "abc"
+
+
+def test_bool_unchanged():
+    assert decode_signed_int16_word(True) is True

--- a/etl/tests/test_sync_stock.py
+++ b/etl/tests/test_sync_stock.py
@@ -165,6 +165,34 @@ class TestNormalizeExpoRow:
         for r in result:
             assert r["cc_stock"] == expected
 
+    def test_stock_65535_decodes_to_negative_one(self):
+        """WORD-style unsigned -1 (65535) must become -1 in ps_stock_tienda.stock."""
+        row = self._make_row([("38", 65535)])
+        result = _normalize_expo_row(row)
+        assert len(result) == 1
+        assert result[0]["stock"] == -1
+
+    def test_stock_65534_decodes_to_negative_two(self):
+        row = self._make_row([("44", 65534)])
+        result = _normalize_expo_row(row)
+        assert result[0]["stock"] == -2
+
+    def test_mixed_unsigned_negatives_sum_like_powershop(self):
+        """Five slots at -1, one at -2, one at 0 → total stock -7 (matches CC-style sums)."""
+        row = self._make_row(
+            [
+                ("38", 65535),
+                ("40", 65535),
+                ("42", 65534),
+                ("44", 65535),
+                ("46", 65535),
+                ("48", 65535),
+                ("50", 0),
+            ]
+        )
+        result = _normalize_expo_row(row)
+        assert sum(r["stock"] for r in result) == -7
+
 
 _STORE_CODE_PATTERN = re.compile(r"^[A-Za-z0-9/_-]+$")
 


### PR DESCRIPTION
## Summary

- **ETL:** `decode_signed_int16_word()` in `etl/db/fourd.py` reinterprets values in `32768..65535` as signed int16 (exact bit semantics). Applied **only** when unpivoting **`Exportaciones.Stock1..Stock34`**, which `_USER_COLUMNS` declares as **`DATA_TYPE = 3`**, **`DATA_LENGTH = 2`**. Fixes inflated `ps_stock_tienda.stock` (e.g. `65535` vs POS `−1`). New tests: `etl/tests/test_fourd_signed_int16.py`, extra cases in `test_sync_stock.py`. Documentation: D-017, `AGENTS.md`, `docs/skills/*`, `docs/architecture/stock-logistics.md`, `docs/etl-sync-strategy.md`. `mayorista.py` docstring explains why GC `Unidades` are **not** decoded.

- **Dashboard:** `dashboard/lib/sql-heuristics.ts` performs static checks on widget SQL (Spanish messages for API errors). Wired into generate, modify, create/list/update dashboard routes. Tests: `sql-heuristics.test.ts`, updates to `templates.test.ts` and generate route test. Minor `prompts.ts` / `errors.ts` adjustments.

## Testing

- `cd dashboard && npm test -- sql-heuristics templates generate/route`
- `python -m pytest etl/tests/test_fourd_signed_int16.py etl/tests/test_sync_stock.py -q` (unit tests; integration tests need Postgres)

## Notes

- Re-run ETL stock sync after merge to refresh existing `ps_stock_tienda` rows.
- Commit created with `--no-gpg-sign` because GPG timed out on database lock in this environment.

Made with [Cursor](https://cursor.com)