### PR TITLE
feat(dashboard): filtros globales v1 (#383)

### DIFF
--- a/dashboard/app/api/dashboard/filters/options/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/filters/options/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  query: vi.fn(),
+}));
+
+vi.mock("@/lib/db-write", () => ({
+  sql: vi.fn(),
+}));
+
+const { mockValidateQueryCost } = vi.hoisted(() => ({
+  mockValidateQueryCost: vi.fn().mockResolvedValue(1),
+}));
+
+vi.mock("@/lib/query-validator", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/query-validator")>(
+    "@/lib/query-validator",
+  );
+  return {
+    ...actual,
+    validateQueryCost: mockValidateQueryCost,
+  };
+});
+
+import { POST } from "../route";
+import { query } from "@/lib/db";
+import { sql } from "@/lib/db-write";
+import { NextRequest } from "next/server";
+
+const mockQuery = vi.mocked(query);
+const mockSql = vi.mocked(sql);
+
+function req(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/dashboard/filters/options", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const STORED_SPEC = {
+  title: "T",
+  widgets: [{ type: "table", title: "W", sql: "SELECT 1" }],
+  filters: [
+    {
+      id: "tienda",
+      type: "single_select",
+      label: "Tienda",
+      bind_expr: `v."tienda"`,
+      value_type: "text",
+      options_sql:
+        'SELECT DISTINCT v."tienda" AS value, v."tienda" AS label FROM "public"."ps_ventas" v WHERE v."entrada" = true LIMIT 5',
+    },
+  ],
+};
+
+describe("POST /api/dashboard/filters/options", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockSql.mockReset();
+    mockValidateQueryCost.mockReset();
+    mockValidateQueryCost.mockResolvedValue(1);
+  });
+
+  it("returns options for a valid filter", async () => {
+    mockSql.mockResolvedValueOnce([{ spec: STORED_SPEC }]);
+    mockQuery.mockResolvedValueOnce({
+      columns: ["value", "label"],
+      rows: [
+        ["01", "01"],
+        ["02", "02"],
+      ],
+    });
+
+    const res = await POST(
+      req({
+        dashboardId: 7,
+        filterId: "tienda",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.options).toEqual([
+      { value: "01", label: "01" },
+      { value: "02", label: "02" },
+    ]);
+    expect(mockValidateQueryCost).toHaveBeenCalled();
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 404 when dashboard is missing", async () => {
+    mockSql.mockResolvedValueOnce([]);
+    const res = await POST(req({ dashboardId: 999, filterId: "tienda" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when filter id is unknown", async () => {
+    mockSql.mockResolvedValueOnce([{ spec: STORED_SPEC }]);
+    const res = await POST(req({ dashboardId: 1, filterId: "no_existe" }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/dashboard/app/api/dashboard/filters/options/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/filters/options/__tests__/route.test.ts
@@ -100,4 +100,16 @@ describe("POST /api/dashboard/filters/options", () => {
     const res = await POST(req({ dashboardId: 1, filterId: "no_existe" }));
     expect(res.status).toBe(400);
   });
+
+  it("returns 400 when dateRange strings are not valid dates", async () => {
+    mockSql.mockResolvedValueOnce([{ spec: STORED_SPEC }]);
+    const res = await POST(
+      req({
+        dashboardId: 1,
+        filterId: "tienda",
+        dateRange: { from: "not-a-date", to: "also-bad" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
 });

--- a/dashboard/app/api/dashboard/filters/options/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/filters/options/__tests__/route.test.ts
@@ -112,4 +112,37 @@ describe("POST /api/dashboard/filters/options", () => {
     );
     expect(res.status).toBe(400);
   });
+
+  it("accepts activeFilters with numeric scalars and arrays", async () => {
+    const specWithTwo = {
+      title: "T",
+      widgets: [{ type: "table", title: "W", sql: "SELECT 1" }],
+      filters: [
+        STORED_SPEC.filters[0],
+        {
+          id: "familia",
+          type: "multi_select",
+          label: "Familia",
+          bind_expr: "fm.x",
+          value_type: "numeric",
+          options_sql: "SELECT 1 AS value, 1 AS label",
+        },
+      ],
+    };
+    mockSql.mockResolvedValueOnce([{ spec: specWithTwo }]);
+    mockQuery.mockResolvedValueOnce({
+      columns: ["value", "label"],
+      rows: [["1", "1"]],
+    });
+
+    const res = await POST(
+      req({
+        dashboardId: 1,
+        filterId: "familia",
+        activeFilters: { tienda: 7, other: [1, 2, 3] },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockQuery).toHaveBeenCalled();
+  });
 });

--- a/dashboard/app/api/dashboard/filters/options/route.ts
+++ b/dashboard/app/api/dashboard/filters/options/route.ts
@@ -42,6 +42,16 @@ function parseDashboardId(raw: unknown): number | null {
   return null;
 }
 
+function parseIsoDateRange(dr: {
+  from: string;
+  to: string;
+}): { from: Date; to: Date } | null {
+  const from = new Date(dr.from);
+  const to = new Date(dr.to);
+  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) return null;
+  return { from, to };
+}
+
 function normalizeBody(raw: unknown): z.infer<typeof BodySchema> | null {
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
   const o = raw as Record<string, unknown>;
@@ -133,12 +143,19 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   let optionsSql = filter.options_sql;
   if (parsed.dateRange) {
-    optionsSql = substituteDateParams(optionsSql, {
-      curr: {
-        from: new Date(parsed.dateRange.from),
-        to: new Date(parsed.dateRange.to),
-      },
-    });
+    const dr = parseIsoDateRange(parsed.dateRange);
+    if (!dr) {
+      return NextResponse.json(
+        formatApiError(
+          "dateRange.from y dateRange.to deben ser fechas ISO válidas.",
+          "VALIDATION",
+          undefined,
+          requestId,
+        ),
+        { status: 400 },
+      );
+    }
+    optionsSql = substituteDateParams(optionsSql, { curr: dr });
   }
 
   let compiled;

--- a/dashboard/app/api/dashboard/filters/options/route.ts
+++ b/dashboard/app/api/dashboard/filters/options/route.ts
@@ -1,0 +1,209 @@
+/**
+ * POST /api/dashboard/filters/options — Distinct values for a global dashboard filter.
+ *
+ * Body: { dashboardId, filterId, dateRange?, activeFilters? }
+ * Returns: { options: { value: string, label: string }[] }
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@/lib/db-write";
+import { validateSpec, type DashboardSpec } from "@/lib/schema";
+import { substituteDateParams } from "@/lib/date-params";
+import {
+  compileGlobalFilterSql,
+  type GlobalFilterValues,
+} from "@/lib/sql-filters";
+import { query } from "@/lib/db";
+import {
+  formatApiError,
+  generateRequestId,
+  sanitizeErrorMessage,
+} from "@/lib/errors";
+import { validateQueryCost, QueryTooExpensiveError } from "@/lib/query-validator";
+import { ZodError, z } from "zod";
+
+const BodySchema = z.object({
+  dashboardId: z.number().int().positive(),
+  filterId: z.string().min(1),
+  dateRange: z
+    .object({
+      from: z.string().min(1),
+      to: z.string().min(1),
+    })
+    .optional(),
+  activeFilters: z
+    .record(z.union([z.string(), z.array(z.string())]))
+    .optional(),
+});
+
+function parseDashboardId(raw: unknown): number | null {
+  if (typeof raw === "number" && Number.isInteger(raw) && raw > 0) return raw;
+  if (typeof raw === "string" && /^\d+$/.test(raw)) return parseInt(raw, 10);
+  return null;
+}
+
+function normalizeBody(raw: unknown): z.infer<typeof BodySchema> | null {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+  const o = raw as Record<string, unknown>;
+  const id = parseDashboardId(o.dashboardId);
+  if (id === null) return null;
+  const merged = { ...o, dashboardId: id };
+  const parsed = BodySchema.safeParse(merged);
+  return parsed.success ? parsed.data : null;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const requestId = generateRequestId();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      formatApiError("Cuerpo JSON no válido.", "VALIDATION", undefined, requestId),
+      { status: 400 },
+    );
+  }
+
+  const parsed = normalizeBody(body);
+  if (!parsed) {
+    return NextResponse.json(
+      formatApiError(
+        "Cuerpo inválido: se esperaba dashboardId, filterId y opcionalmente dateRange/activeFilters.",
+        "VALIDATION",
+        undefined,
+        requestId,
+      ),
+      { status: 400 },
+    );
+  }
+
+  let spec: DashboardSpec;
+  try {
+    const rows = await sql<{ spec: unknown }>(
+      `SELECT spec FROM dashboards WHERE id = $1`,
+      [parsed.dashboardId],
+    );
+    if (rows.length === 0) {
+      return NextResponse.json(
+        formatApiError("Dashboard no encontrado.", "NOT_FOUND", undefined, requestId),
+        { status: 404 },
+      );
+    }
+    spec = validateSpec(rows[0].spec);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        formatApiError(
+          "El dashboard guardado tiene un spec inválido.",
+          "VALIDATION",
+          err.message,
+          requestId,
+        ),
+        { status: 400 },
+      );
+    }
+    console.error(`[${requestId}] Error al cargar spec del dashboard:`, err);
+    return NextResponse.json(
+      formatApiError(
+        "No se pudo cargar el dashboard.",
+        "DB_QUERY",
+        sanitizeErrorMessage(err),
+        requestId,
+      ),
+      { status: 500 },
+    );
+  }
+
+  const filter = spec.filters?.find((f) => f.id === parsed.filterId);
+  if (!filter) {
+    return NextResponse.json(
+      formatApiError(
+        `Filtro desconocido: ${parsed.filterId}`,
+        "VALIDATION",
+        undefined,
+        requestId,
+      ),
+      { status: 400 },
+    );
+  }
+
+  const active: GlobalFilterValues = { ...(parsed.activeFilters ?? {}) };
+  delete active[parsed.filterId];
+
+  let optionsSql = filter.options_sql;
+  if (parsed.dateRange) {
+    optionsSql = substituteDateParams(optionsSql, {
+      curr: {
+        from: new Date(parsed.dateRange.from),
+        to: new Date(parsed.dateRange.to),
+      },
+    });
+  }
+
+  let compiled;
+  try {
+    compiled = compileGlobalFilterSql(optionsSql, spec.filters, active, {
+      excludeFilterId: parsed.filterId,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      formatApiError(
+        "No se pudo compilar el SQL de opciones del filtro.",
+        "VALIDATION",
+        sanitizeErrorMessage(err),
+        requestId,
+      ),
+      { status: 400 },
+    );
+  }
+
+  const forceHeader = request.headers.get("X-Query-Force") ?? undefined;
+  try {
+    await validateQueryCost(compiled.sql, {
+      forceHeader,
+      params: compiled.params,
+    });
+  } catch (err) {
+    if (err instanceof QueryTooExpensiveError) {
+      return NextResponse.json(
+        { ...formatApiError(err.message, "COST_LIMIT", undefined, requestId), cost: err.cost },
+        { status: 422 },
+      );
+    }
+    throw err;
+  }
+
+  try {
+    const result = await query(compiled.sql, compiled.params);
+    const valueIdx = result.columns.findIndex((c) => c === "value");
+    const labelIdx = result.columns.findIndex((c) => c === "label");
+    if (valueIdx === -1 || labelIdx === -1) {
+      return NextResponse.json(
+        formatApiError(
+          "options_sql debe devolver columnas nombradas value y label.",
+          "VALIDATION",
+          undefined,
+          requestId,
+        ),
+        { status: 400 },
+      );
+    }
+    const options = result.rows.map((row) => ({
+      value: String(row[valueIdx] ?? ""),
+      label: String(row[labelIdx] ?? ""),
+    }));
+    return NextResponse.json({ options });
+  } catch (err) {
+    console.error(`[${requestId}] Error ejecutando options_sql:`, err);
+    return NextResponse.json(
+      formatApiError(
+        "Error al cargar opciones del filtro.",
+        "DB_QUERY",
+        sanitizeErrorMessage(err),
+        requestId,
+      ),
+      { status: 500 },
+    );
+  }
+}

--- a/dashboard/app/api/dashboard/filters/options/route.ts
+++ b/dashboard/app/api/dashboard/filters/options/route.ts
@@ -22,6 +22,14 @@ import {
 import { validateQueryCost, QueryTooExpensiveError } from "@/lib/query-validator";
 import { ZodError, z } from "zod";
 
+/** Values POSTed for cascading options — mirrors `GlobalFilterValues` JSON shape. */
+const ActiveFilterEntrySchema = z.union([
+  z.string(),
+  z.number(),
+  z.array(z.string()),
+  z.array(z.number()),
+]);
+
 const BodySchema = z.object({
   dashboardId: z.number().int().positive(),
   filterId: z.string().min(1),
@@ -31,9 +39,7 @@ const BodySchema = z.object({
       to: z.string().min(1),
     })
     .optional(),
-  activeFilters: z
-    .record(z.union([z.string(), z.array(z.string())]))
-    .optional(),
+  activeFilters: z.record(z.string(), ActiveFilterEntrySchema).optional(),
 });
 
 function parseDashboardId(raw: unknown): number | null {

--- a/dashboard/app/api/query/__tests__/route.test.ts
+++ b/dashboard/app/api/query/__tests__/route.test.ts
@@ -346,4 +346,19 @@ describe("POST /api/query", () => {
     );
     expect(res.status).toBe(400);
   });
+
+  it("accepts number[] for ANY-style bind params", async () => {
+    mockValidateQueryCost.mockResolvedValue(0.1);
+    mockQuery.mockResolvedValue({
+      fields: [{ name: "x" }],
+      rows: [[1]],
+    });
+    const res = await POST(
+      makeRequest({
+        sql: "SELECT x FROM (VALUES ($1::int), ($2::int)) AS t(x) WHERE t.x = ANY($3::int[])",
+        params: [1, 2, [1, 2]],
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
 });

--- a/dashboard/app/api/query/__tests__/route.test.ts
+++ b/dashboard/app/api/query/__tests__/route.test.ts
@@ -316,7 +316,34 @@ describe("POST /api/query", () => {
 
     expect(mockValidateQueryCost).toHaveBeenCalledWith(
       "SELECT id FROM ps_ventas",
-      { forceHeader: "my-secret" },
+      { forceHeader: "my-secret", params: [] },
     );
+  });
+
+  it("executes parameterized SELECT with params array", async () => {
+    mockValidateQueryCost.mockResolvedValue(1);
+    mockQuery.mockResolvedValue({
+      fields: [{ name: "n" }],
+      rows: [[42]],
+    });
+
+    const res = await POST(
+      makeRequest({ sql: "SELECT n FROM (VALUES ($1::int)) AS t(n)", params: [42] }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "SELECT n FROM (VALUES ($1::int)) AS t(n)",
+        values: [42],
+        rowMode: "array",
+      }),
+    );
+  });
+
+  it("rejects invalid params shape with 400", async () => {
+    const res = await POST(
+      makeRequest({ sql: "SELECT 1", params: { a: 1 } }),
+    );
+    expect(res.status).toBe(400);
   });
 });

--- a/dashboard/app/api/query/route.ts
+++ b/dashboard/app/api/query/route.ts
@@ -1,7 +1,7 @@
 /**
  * POST /api/query — Execute a read-only SQL query against PostgreSQL.
  *
- * Accepts: { sql: string }
+ * Accepts: { sql: string, params?: unknown[] }
  * Returns: { columns: string[], rows: unknown[][] }
  *
  * Error codes:
@@ -28,6 +28,34 @@ import {
 } from "@/lib/errors";
 import { validateQueryCost, QueryTooExpensiveError } from "@/lib/query-validator";
 
+function isParamScalar(v: unknown): boolean {
+  return (
+    v === null ||
+    typeof v === "string" ||
+    typeof v === "number" ||
+    typeof v === "boolean"
+  );
+}
+
+/** Normalize JSON `params` for pg — scalars or string[] for ANY($n::text[]). */
+export function normalizeQueryParams(raw: unknown): unknown[] | null {
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) return null;
+  const out: unknown[] = [];
+  for (const p of raw) {
+    if (isParamScalar(p)) {
+      out.push(p);
+      continue;
+    }
+    if (Array.isArray(p) && p.every((x) => typeof x === "string")) {
+      out.push(p);
+      continue;
+    }
+    return null;
+  }
+  return out;
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const requestId = generateRequestId();
 
@@ -53,12 +81,25 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const { sql } = body as { sql?: string };
+  const { sql, params: rawParams } = body as { sql?: string; params?: unknown };
 
   if (!sql || typeof sql !== "string" || !sql.trim()) {
     return NextResponse.json(
       formatApiError(
         "Falta el campo 'sql' o está vacío.",
+        "VALIDATION",
+        undefined,
+        requestId,
+      ),
+      { status: 400 },
+    );
+  }
+
+  const params = normalizeQueryParams(rawParams);
+  if (params === null) {
+    return NextResponse.json(
+      formatApiError(
+        "El campo 'params' debe ser un array de valores escalares o arrays de string.",
         "VALIDATION",
         undefined,
         requestId,
@@ -89,7 +130,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   let cost = 0;
   const forceHeader = request.headers.get("X-Query-Force") ?? undefined;
   try {
-    cost = await validateQueryCost(sql, { forceHeader });
+    cost = await validateQueryCost(sql, { forceHeader, params });
   } catch (err) {
     if (err instanceof QueryTooExpensiveError) {
       return NextResponse.json(
@@ -102,7 +143,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Execute the query
   try {
-    const result = await query(sql);
+    const result = await query(sql, params.length > 0 ? params : undefined);
     const response = NextResponse.json(result);
     response.headers.set("X-Query-Cost", String(cost));
     return response;

--- a/dashboard/app/api/query/route.ts
+++ b/dashboard/app/api/query/route.ts
@@ -47,9 +47,15 @@ export function normalizeQueryParams(raw: unknown): unknown[] | null {
       out.push(p);
       continue;
     }
-    if (Array.isArray(p) && p.every((x) => typeof x === "string")) {
-      out.push(p);
-      continue;
+    if (Array.isArray(p)) {
+      if (p.every((x) => typeof x === "string")) {
+        out.push(p);
+        continue;
+      }
+      if (p.every((x) => typeof x === "number")) {
+        out.push(p);
+        continue;
+      }
     }
     return null;
   }
@@ -99,7 +105,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (params === null) {
     return NextResponse.json(
       formatApiError(
-        "El campo 'params' debe ser un array de valores escalares o arrays de string.",
+        "El campo 'params' debe ser un array de valores escalares o arrays homogéneos de string o de number.",
         "VALIDATION",
         undefined,
         requestId,

--- a/dashboard/app/dashboard/[id]/page.tsx
+++ b/dashboard/app/dashboard/[id]/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { DashboardRenderer } from "@/components/DashboardRenderer";
+import { DashboardFiltersBar } from "@/components/DashboardFiltersBar";
+import type { GlobalFilterValues } from "@/lib/sql-filters";
 import type { WidgetState } from "@/components/DashboardRenderer";
 import { DataFreshnessBanner } from "@/components/DataFreshnessBanner";
 import ChatSidebar from "@/components/ChatSidebar";
@@ -119,6 +121,7 @@ export default function ViewDashboard() {
   const [comparisonRange, setComparisonRange] = useState<ComparisonRange | undefined>(() =>
     defaultComparisonRangeFor(getDefaultDashboardDateRange()),
   );
+  const [globalFilterValues, setGlobalFilterValues] = useState<GlobalFilterValues>({});
 
   // When date range changes, store the range and re-run all widget queries.
   // The date range is displayed in the picker for context; actual SQL filtering
@@ -133,6 +136,11 @@ export default function ViewDashboard() {
     },
     [],
   );
+
+  const handleGlobalFilterChange = useCallback((next: GlobalFilterValues) => {
+    setGlobalFilterValues(next);
+    setRefreshKey((k) => k + 1);
+  }, []);
 
   // Export dropdown state
   const [exportOpen, setExportOpen] = useState(false);
@@ -184,6 +192,10 @@ export default function ViewDashboard() {
   useEffect(() => {
     fetchDashboard();
   }, [fetchDashboard]);
+
+  useEffect(() => {
+    setGlobalFilterValues({});
+  }, [id]);
 
   // Keep latestSpecRef in sync
   useEffect(() => {
@@ -707,12 +719,23 @@ export default function ViewDashboard() {
       {/* Data freshness banner — loads independently, does not block dashboard */}
       <DataFreshnessBanner />
 
+      {dashboard.spec.filters && dashboard.spec.filters.length > 0 && (
+        <DashboardFiltersBar
+          dashboardId={dashboard.id}
+          spec={dashboard.spec}
+          dateRange={dateRange}
+          value={globalFilterValues}
+          onChange={handleGlobalFilterChange}
+        />
+      )}
+
       {/* Dashboard renderer */}
       <DashboardRenderer
         spec={dashboard.spec}
         refreshKey={refreshKey}
         dateRange={dateRange}
         comparisonRange={comparisonRange}
+        globalFilterValues={globalFilterValues}
         onWidgetDataChange={setWidgetData}
       />
 

--- a/dashboard/components/DashboardFiltersBar.tsx
+++ b/dashboard/components/DashboardFiltersBar.tsx
@@ -15,6 +15,32 @@ export interface DashboardFiltersBarProps {
 
 type OptionRow = { value: string; label: string };
 
+/** HTML `<select>` value is always string — coerce stored numbers for controlled value. */
+function singleSelectFormValue(
+  filter: GlobalFilter,
+  value: GlobalFilterValues,
+): string {
+  const raw = value[filter.id];
+  if (raw === undefined || raw === null) return "";
+  if (typeof raw === "number" && Number.isFinite(raw)) return String(raw);
+  if (typeof raw === "string") return raw;
+  return "";
+}
+
+function multiSelectFormValue(
+  filter: GlobalFilter,
+  value: GlobalFilterValues,
+): string[] {
+  const raw = value[filter.id];
+  if (!Array.isArray(raw)) return [];
+  if (filter.value_type === "numeric") {
+    return (raw as unknown[])
+      .filter((x): x is number => typeof x === "number" && Number.isFinite(x))
+      .map(String);
+  }
+  return (raw as string[]).filter((x) => typeof x === "string");
+}
+
 async function postOptions(
   body: Record<string, unknown>,
 ): Promise<OptionRow[]> {
@@ -118,13 +144,18 @@ export function DashboardFiltersBar({
               aria-label={f.label}
               aria-busy={!!loading[f.id]}
               className="rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1.5 text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis"
-              value={typeof value[f.id] === "string" ? (value[f.id] as string) : ""}
+              value={singleSelectFormValue(f, value)}
               disabled={!!loading[f.id]}
               onChange={(ev) => {
                 const v = ev.target.value;
                 const next = { ...value };
                 if (!v) delete next[f.id];
-                else next[f.id] = v;
+                else if (f.value_type === "numeric") {
+                  const n = Number(v);
+                  next[f.id] = Number.isFinite(n) ? n : v;
+                } else {
+                  next[f.id] = v;
+                }
                 onChange(next);
               }}
             >
@@ -144,12 +175,18 @@ export function DashboardFiltersBar({
               size={Math.min(6, Math.max(3, (optionsById[f.id] ?? []).length || 3))}
               className="rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1.5 text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis min-h-[72px]"
               disabled={!!loading[f.id]}
-              value={Array.isArray(value[f.id]) ? (value[f.id] as string[]) : []}
+              value={multiSelectFormValue(f, value)}
               onChange={(ev) => {
                 const selected = Array.from(ev.target.selectedOptions).map((o) => o.value);
                 const next = { ...value };
                 if (selected.length === 0) delete next[f.id];
-                else next[f.id] = selected;
+                else if (f.value_type === "numeric") {
+                  next[f.id] = selected
+                    .map((s) => Number(s))
+                    .filter((n) => Number.isFinite(n));
+                } else {
+                  next[f.id] = selected;
+                }
                 onChange(next);
               }}
             >

--- a/dashboard/components/DashboardFiltersBar.tsx
+++ b/dashboard/components/DashboardFiltersBar.tsx
@@ -9,7 +9,6 @@ export interface DashboardFiltersBarProps {
   dashboardId: number;
   spec: DashboardSpec;
   dateRange?: DateRange;
-  comparisonRange?: ComparisonRange;
   value: GlobalFilterValues;
   onChange: (next: GlobalFilterValues) => void;
 }

--- a/dashboard/components/DashboardFiltersBar.tsx
+++ b/dashboard/components/DashboardFiltersBar.tsx
@@ -116,6 +116,8 @@ export function DashboardFiltersBar({
           {f.type === "single_select" ? (
             <select
               id={`gf-${f.id}`}
+              aria-label={f.label}
+              aria-busy={!!loading[f.id]}
               className="rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1.5 text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis"
               value={typeof value[f.id] === "string" ? (value[f.id] as string) : ""}
               disabled={!!loading[f.id]}
@@ -138,6 +140,8 @@ export function DashboardFiltersBar({
             <select
               id={`gf-${f.id}`}
               multiple
+              aria-label={f.label}
+              aria-busy={!!loading[f.id]}
               size={Math.min(6, Math.max(3, (optionsById[f.id] ?? []).length || 3))}
               className="rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1.5 text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis min-h-[72px]"
               disabled={!!loading[f.id]}

--- a/dashboard/components/DashboardFiltersBar.tsx
+++ b/dashboard/components/DashboardFiltersBar.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { DashboardSpec, GlobalFilter } from "@/lib/schema";
+import type { GlobalFilterValues } from "@/lib/sql-filters";
+import type { DateRange } from "./DateRangePicker";
+
+export interface DashboardFiltersBarProps {
+  dashboardId: number;
+  spec: DashboardSpec;
+  dateRange?: DateRange;
+  comparisonRange?: ComparisonRange;
+  value: GlobalFilterValues;
+  onChange: (next: GlobalFilterValues) => void;
+}
+
+type OptionRow = { value: string; label: string };
+
+async function postOptions(
+  body: Record<string, unknown>,
+): Promise<OptionRow[]> {
+  const res = await fetch("/api/dashboard/filters/options", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const j = await res.json().catch(() => null);
+    const msg =
+      j && typeof j === "object" && "error" in j && typeof j.error === "string"
+        ? j.error
+        : "Error al cargar opciones";
+    throw new Error(msg);
+  }
+  const data = (await res.json()) as { options?: OptionRow[] };
+  return Array.isArray(data.options) ? data.options : [];
+}
+
+export function DashboardFiltersBar({
+  dashboardId,
+  spec,
+  dateRange,
+  value,
+  onChange,
+}: DashboardFiltersBarProps) {
+  const filters = useMemo(() => spec.filters ?? [], [spec.filters]);
+  const [optionsById, setOptionsById] = useState<Record<string, OptionRow[]>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState<Record<string, boolean>>({});
+
+  const rangePayload = useMemo(() => {
+    if (!dateRange) return undefined;
+    return { from: dateRange.from.toISOString(), to: dateRange.to.toISOString() };
+  }, [dateRange]);
+
+  const loadOptions = useCallback(
+    async (filter: GlobalFilter) => {
+      setLoading((m) => ({ ...m, [filter.id]: true }));
+      setErrors((m) => {
+        const n = { ...m };
+        delete n[filter.id];
+        return n;
+      });
+      try {
+        const opts = await postOptions({
+          dashboardId,
+          filterId: filter.id,
+          dateRange: rangePayload,
+          activeFilters: value,
+        });
+        setOptionsById((m) => ({ ...m, [filter.id]: opts }));
+      } catch (e) {
+        setErrors((m) => ({
+          ...m,
+          [filter.id]: e instanceof Error ? e.message : "Error",
+        }));
+      } finally {
+        setLoading((m) => ({ ...m, [filter.id]: false }));
+      }
+    },
+    [dashboardId, rangePayload, value],
+  );
+
+  useEffect(() => {
+    if (filters.length === 0) return;
+    let cancelled = false;
+    void (async () => {
+      for (const f of filters) {
+        if (cancelled) return;
+        await loadOptions(f);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [filters, loadOptions]);
+
+  if (filters.length === 0) return null;
+
+  return (
+    <div
+      className="no-print mb-4 flex flex-wrap items-end gap-4 rounded-lg border border-tremor-border dark:border-dark-tremor-border bg-tremor-background-subtle dark:bg-dark-tremor-background-subtle p-4"
+      data-testid="global-filters-bar"
+    >
+      <span className="text-xs font-semibold uppercase tracking-wide text-tremor-content-subtle dark:text-dark-tremor-content-subtle w-full sm:w-auto">
+        Filtros
+      </span>
+      {filters.map((f) => (
+        <div key={f.id} className="flex min-w-[160px] flex-col gap-1">
+          <label
+            htmlFor={`gf-${f.id}`}
+            className="text-xs text-tremor-content dark:text-dark-tremor-content"
+          >
+            {f.label}
+          </label>
+          {f.type === "single_select" ? (
+            <select
+              id={`gf-${f.id}`}
+              className="rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1.5 text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis"
+              value={typeof value[f.id] === "string" ? (value[f.id] as string) : ""}
+              disabled={!!loading[f.id]}
+              onChange={(ev) => {
+                const v = ev.target.value;
+                const next = { ...value };
+                if (!v) delete next[f.id];
+                else next[f.id] = v;
+                onChange(next);
+              }}
+            >
+              <option value="">Todos</option>
+              {(optionsById[f.id] ?? []).map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <select
+              id={`gf-${f.id}`}
+              multiple
+              size={Math.min(6, Math.max(3, (optionsById[f.id] ?? []).length || 3))}
+              className="rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1.5 text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis min-h-[72px]"
+              disabled={!!loading[f.id]}
+              value={Array.isArray(value[f.id]) ? (value[f.id] as string[]) : []}
+              onChange={(ev) => {
+                const selected = Array.from(ev.target.selectedOptions).map((o) => o.value);
+                const next = { ...value };
+                if (selected.length === 0) delete next[f.id];
+                else next[f.id] = selected;
+                onChange(next);
+              }}
+            >
+              {(optionsById[f.id] ?? []).map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          )}
+          {errors[f.id] && (
+            <span className="text-xs text-red-500">{errors[f.id]}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dashboard/components/DashboardRenderer.tsx
+++ b/dashboard/components/DashboardRenderer.tsx
@@ -222,6 +222,8 @@ export function DashboardRenderer({
   const globalFilterValuesRef = useRef<GlobalFilterValues>(EMPTY_GLOBAL_FILTERS);
   globalFilterValuesRef.current = globalFilterValues ?? EMPTY_GLOBAL_FILTERS;
 
+  // Key off `specKey` (serialized spec) so a parent that recreates `spec.filters`
+  // with identical content does not recreate `bindGlobalFilters` / `fetchAll` / refetch.
   const bindGlobalFilters = useCallback(
     (sqlAfterDates: string): { sql: string; params: unknown[] } =>
       compileGlobalFilterSql(
@@ -229,7 +231,8 @@ export function DashboardRenderer({
         spec.filters,
         globalFilterValuesRef.current,
       ),
-    [spec.filters],
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally `specKey` only; `spec` is read from the same render as this key
+    [specKey],
   );
 
   // Fetch all widgets for a given spec

--- a/dashboard/components/DashboardRenderer.tsx
+++ b/dashboard/components/DashboardRenderer.tsx
@@ -2,10 +2,11 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@headlessui/react";
-import type { DashboardSpec, Widget } from "@/lib/schema";
+import type { DashboardSpec, Widget, GlossaryItem } from "@/lib/schema";
 import type { WidgetData } from "./widgets/types";
 import type { DateRange, ComparisonRange } from "./DateRangePicker";
 import { substituteDateParams } from "@/lib/date-params";
+import { compileGlobalFilterSql } from "@/lib/sql-filters";
 import { isApiErrorResponse } from "@/lib/errors";
 import type { ApiErrorResponse } from "@/lib/errors";
 import { ErrorDisplay } from "./ErrorDisplay";
@@ -18,7 +19,9 @@ import {
   TableWidget,
   NumberWidget,
 } from "./widgets";
-import type { GlossaryItem } from "@/lib/schema";
+import type { GlobalFilterValues } from "@/lib/sql-filters";
+
+const EMPTY_GLOBAL_FILTERS: GlobalFilterValues = Object.freeze({});
 
 // ---------------------------------------------------------------------------
 // Props
@@ -51,6 +54,8 @@ export interface DashboardRendererProps {
    * passed to chart widgets so they can render two series side by side.
    */
   comparisonRange?: ComparisonRange;
+  /** Active global dashboard filter values (bound as SQL parameters). */
+  globalFilterValues?: GlobalFilterValues;
   /**
    * Optional callback fired whenever widget states change (e.g. a widget
    * finishes loading).  Use this to expose live widget data to the parent
@@ -116,11 +121,14 @@ const COMP_MISSING_ERROR = "Este panel requiere seleccionar un período de compa
 async function fetchWidgetData(
   sql: string,
   signal?: AbortSignal,
+  params?: unknown[],
 ): Promise<WidgetData> {
+  const body: { sql: string; params?: unknown[] } = { sql };
+  if (params && params.length > 0) body.params = params;
   const res = await fetch("/api/query", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ sql }),
+    body: JSON.stringify(body),
     signal,
   });
   if (!res.ok) {
@@ -156,7 +164,14 @@ async function fetchWidgetData(
 // Component
 // ---------------------------------------------------------------------------
 
-export function DashboardRenderer({ spec, refreshKey = 0, dateRange, comparisonRange, onWidgetDataChange }: DashboardRendererProps) {
+export function DashboardRenderer({
+  spec,
+  refreshKey = 0,
+  dateRange,
+  comparisonRange,
+  globalFilterValues,
+  onWidgetDataChange,
+}: DashboardRendererProps) {
   const [widgetStates, setWidgetStates] = useState<Map<number, WidgetState>>(
     new Map()
   );
@@ -166,6 +181,8 @@ export function DashboardRenderer({ spec, refreshKey = 0, dateRange, comparisonR
   const retryAbortMap = useRef<Map<number, AbortController>>(new Map());
   // Stable key derived from spec content (not referential identity) so
   // parent re-renders that recreate the same spec object don't trigger refetches.
+  // Intentionally exclude globalFilterValues: parents should bump `refreshKey`
+  // when filter values change (avoids double-stringifying huge specs each render).
   const specKey = useMemo(() => JSON.stringify(spec), [spec]);
   // Track the specKey that widgetStates corresponds to, so we show skeletons
   // (not stale data) when spec changes before the effect runs.
@@ -198,6 +215,21 @@ export function DashboardRenderer({ spec, refreshKey = 0, dateRange, comparisonR
       return substituteDateParams(comparisonSql, ranges);
     },
     [dateRange, comparisonRange],
+  );
+
+  // Use a ref so parent re-renders with inline `globalFilterValues={{...}}` objects
+  // do not recreate fetch pipelines every frame (would re-trigger effects / OOM).
+  const globalFilterValuesRef = useRef<GlobalFilterValues>(EMPTY_GLOBAL_FILTERS);
+  globalFilterValuesRef.current = globalFilterValues ?? EMPTY_GLOBAL_FILTERS;
+
+  const bindGlobalFilters = useCallback(
+    (sqlAfterDates: string): { sql: string; params: unknown[] } =>
+      compileGlobalFilterSql(
+        sqlAfterDates,
+        spec.filters,
+        globalFilterValuesRef.current,
+      ),
+    [spec.filters],
   );
 
   // Fetch all widgets for a given spec
@@ -236,7 +268,8 @@ export function DashboardRenderer({ spec, refreshKey = 0, dateRange, comparisonR
             Promise.all(
               widget.items.map(async (item) => {
                 try {
-                  const data = await fetchWidgetData(buildMainSql(item.sql), signal);
+                  const q = bindGlobalFilters(buildMainSql(item.sql));
+                  const data = await fetchWidgetData(q.sql, signal, q.params);
                   return { data, error: null as ApiErrorResponse | string | null };
                 } catch (err) {
                   const structured =
@@ -261,7 +294,8 @@ export function DashboardRenderer({ spec, refreshKey = 0, dateRange, comparisonR
                 const trendSql = buildComparisonSql(item.trend_sql);
                 if (!trendSql) return null;
                 try {
-                  return await fetchWidgetData(trendSql, signal);
+                  const q = bindGlobalFilters(trendSql);
+                  return await fetchWidgetData(q.sql, signal, q.params);
                 } catch {
                   return null;
                 }
@@ -272,7 +306,8 @@ export function DashboardRenderer({ spec, refreshKey = 0, dateRange, comparisonR
               widget.items.map(async (item): Promise<WidgetData | null> => {
                 if (!item.anomaly_sql) return null;
                 try {
-                  return await fetchWidgetData(buildMainSql(item.anomaly_sql), signal);
+                  const q = bindGlobalFilters(buildMainSql(item.anomaly_sql));
+                  return await fetchWidgetData(q.sql, signal, q.params);
                 } catch {
                   return null;
                 }
@@ -303,9 +338,13 @@ export function DashboardRenderer({ spec, refreshKey = 0, dateRange, comparisonR
             return;
           }
           const compSql = "comparison_sql" in widget ? buildComparisonSql(widget.comparison_sql) : null;
+          const mainQ = bindGlobalFilters(buildMainSql(widget.sql));
+          const compQ = compSql ? bindGlobalFilters(compSql) : null;
           const [data, comparisonData] = await Promise.all([
-            fetchWidgetData(buildMainSql(widget.sql), signal),
-            compSql ? fetchWidgetData(compSql, signal).catch(() => null) : Promise.resolve(null),
+            fetchWidgetData(mainQ.sql, signal, mainQ.params),
+            compQ
+              ? fetchWidgetData(compQ.sql, signal, compQ.params).catch(() => null)
+              : Promise.resolve(null),
           ]);
           if (!signal.aborted) {
             setWidgetStates((prev) => {
@@ -335,7 +374,7 @@ export function DashboardRenderer({ spec, refreshKey = 0, dateRange, comparisonR
     });
 
     await Promise.all(promises);
-  }, [buildMainSql, buildComparisonSql, comparisonRange]);
+  }, [buildMainSql, buildComparisonSql, comparisonRange, bindGlobalFilters]);
 
   // Retry a single widget by re-fetching it.
   // Uses a per-widget AbortController so retrying one widget never cancels another.
@@ -370,7 +409,8 @@ export function DashboardRenderer({ spec, refreshKey = 0, dateRange, comparisonR
             Promise.all(
               widget.items.map(async (item) => {
                 try {
-                  const data = await fetchWidgetData(buildMainSql(item.sql), signal);
+                  const q = bindGlobalFilters(buildMainSql(item.sql));
+                  const data = await fetchWidgetData(q.sql, signal, q.params);
                   return { data, error: null as ApiErrorResponse | string | null };
                 } catch (err) {
                   const structured =
@@ -392,7 +432,8 @@ export function DashboardRenderer({ spec, refreshKey = 0, dateRange, comparisonR
                 const trendSql = buildComparisonSql(item.trend_sql);
                 if (!trendSql) return null;
                 try {
-                  return await fetchWidgetData(trendSql, signal);
+                  const q = bindGlobalFilters(trendSql);
+                  return await fetchWidgetData(q.sql, signal, q.params);
                 } catch {
                   return null;
                 }
@@ -402,7 +443,8 @@ export function DashboardRenderer({ spec, refreshKey = 0, dateRange, comparisonR
               widget.items.map(async (item): Promise<WidgetData | null> => {
                 if (!item.anomaly_sql) return null;
                 try {
-                  return await fetchWidgetData(buildMainSql(item.anomaly_sql), signal);
+                  const q = bindGlobalFilters(buildMainSql(item.anomaly_sql));
+                  return await fetchWidgetData(q.sql, signal, q.params);
                 } catch {
                   return null;
                 }
@@ -432,9 +474,13 @@ export function DashboardRenderer({ spec, refreshKey = 0, dateRange, comparisonR
             return;
           }
           const compSql = "comparison_sql" in widget ? buildComparisonSql(widget.comparison_sql) : null;
+          const mainQ = bindGlobalFilters(buildMainSql(widget.sql));
+          const compQ = compSql ? bindGlobalFilters(compSql) : null;
           const [data, comparisonData] = await Promise.all([
-            fetchWidgetData(buildMainSql(widget.sql), signal),
-            compSql ? fetchWidgetData(compSql, signal).catch(() => null) : Promise.resolve(null),
+            fetchWidgetData(mainQ.sql, signal, mainQ.params),
+            compQ
+              ? fetchWidgetData(compQ.sql, signal, compQ.params).catch(() => null)
+              : Promise.resolve(null),
           ]);
           if (!signal.aborted) {
             setWidgetStates((prev) => {
@@ -465,7 +511,7 @@ export function DashboardRenderer({ spec, refreshKey = 0, dateRange, comparisonR
         retryAbortMap.current.delete(idx);
       }
     },
-    [buildMainSql, buildComparisonSql, comparisonRange],
+    [buildMainSql, buildComparisonSql, comparisonRange, bindGlobalFilters],
   );
 
   useEffect(() => {

--- a/dashboard/components/__tests__/DashboardFiltersBar.test.tsx
+++ b/dashboard/components/__tests__/DashboardFiltersBar.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { DashboardFiltersBar } from "../DashboardFiltersBar";
+import type { DashboardSpec } from "@/lib/schema";
+
+const spec: DashboardSpec = {
+  title: "T",
+  widgets: [{ type: "number", title: "N", sql: "SELECT 1", format: "number" }],
+  filters: [
+    {
+      id: "tienda",
+      type: "single_select",
+      label: "Tienda",
+      bind_expr: `v."tienda"`,
+      value_type: "text",
+      options_sql: "SELECT 1",
+    },
+  ],
+};
+
+describe("DashboardFiltersBar", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("loads options and calls onChange when selection changes", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ options: [{ value: "A", label: "Alfa" }] }),
+    } as unknown as Response);
+
+    const onChange = vi.fn();
+
+    render(
+      <DashboardFiltersBar
+        dashboardId={1}
+        spec={spec}
+        value={{}}
+        onChange={onChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("global-filters-bar")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Tienda"), { target: { value: "A" } });
+
+    expect(onChange).toHaveBeenCalledWith({ tienda: "A" });
+  });
+});

--- a/dashboard/components/__tests__/DashboardFiltersBar.test.tsx
+++ b/dashboard/components/__tests__/DashboardFiltersBar.test.tsx
@@ -5,7 +5,7 @@ import "@testing-library/jest-dom/vitest";
 import { DashboardFiltersBar } from "../DashboardFiltersBar";
 import type { DashboardSpec } from "@/lib/schema";
 
-const spec: DashboardSpec = {
+const baseSpec: DashboardSpec = {
   title: "T",
   widgets: [{ type: "number", title: "N", sql: "SELECT 1", format: "number" }],
   filters: [
@@ -15,6 +15,20 @@ const spec: DashboardSpec = {
       label: "Tienda",
       bind_expr: `v."tienda"`,
       value_type: "text",
+      options_sql: "SELECT 1",
+    },
+  ],
+};
+
+const numericSpec: DashboardSpec = {
+  ...baseSpec,
+  filters: [
+    {
+      id: "n",
+      type: "single_select",
+      label: "N",
+      bind_expr: "t.x",
+      value_type: "numeric",
       options_sql: "SELECT 1",
     },
   ],
@@ -42,7 +56,7 @@ describe("DashboardFiltersBar", () => {
     render(
       <DashboardFiltersBar
         dashboardId={1}
-        spec={spec}
+        spec={baseSpec}
         value={{}}
         onChange={onChange}
       />,
@@ -55,5 +69,39 @@ describe("DashboardFiltersBar", () => {
     fireEvent.change(screen.getByLabelText("Tienda"), { target: { value: "A" } });
 
     expect(onChange).toHaveBeenCalledWith({ tienda: "A" });
+  });
+
+  it("shows numeric single_select selection and emits a number", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          options: [
+            { value: "42", label: "42" },
+            { value: "7", label: "7" },
+          ],
+        }),
+    } as unknown as Response);
+
+    const onChange = vi.fn();
+
+    render(
+      <DashboardFiltersBar
+        dashboardId={1}
+        spec={numericSpec}
+        value={{ n: 42 }}
+        onChange={onChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("global-filters-bar")).toBeInTheDocument();
+    });
+
+    const sel = screen.getByLabelText("N") as HTMLSelectElement;
+    expect(sel.value).toBe("42");
+
+    fireEvent.change(sel, { target: { value: "7" } });
+    expect(onChange).toHaveBeenCalledWith({ n: 7 });
   });
 });

--- a/dashboard/components/__tests__/DashboardRenderer.test.tsx
+++ b/dashboard/components/__tests__/DashboardRenderer.test.tsx
@@ -881,6 +881,62 @@ describe("DashboardRenderer", () => {
       expect(fetch).not.toHaveBeenCalled();
     });
 
+    it("sends SQL params when spec uses __gf tokens and globalFilterValues are set", async () => {
+      const fetchMock = mockFetchSuccess({ columns: ["value"], rows: [[1]] });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const specWithFilters: DashboardSpec = {
+        title: "Con filtros",
+        filters: [
+          {
+            id: "tienda",
+            type: "single_select",
+            label: "Tienda",
+            bind_expr: `v."tienda"`,
+            value_type: "text",
+            options_sql: "SELECT 1 AS value, 1 AS label",
+          },
+        ],
+        widgets: [
+          {
+            type: "number",
+            title: "N",
+            sql: 'SELECT 1 AS value FROM "public"."ps_ventas" v WHERE __gf_tienda__',
+            format: "number",
+          },
+        ],
+      };
+
+      const { rerender } = render(
+        <DashboardRenderer
+          spec={specWithFilters}
+          globalFilterValues={{ tienda: "01" }}
+          refreshKey={0}
+        />,
+      );
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      const firstBody = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+      expect(firstBody.sql).toContain("$1::text");
+      expect(firstBody.params).toEqual(["01"]);
+
+      rerender(
+        <DashboardRenderer
+          spec={specWithFilters}
+          globalFilterValues={{ tienda: "02" }}
+          refreshKey={1}
+        />,
+      );
+
+      await waitFor(() => {
+        const last = JSON.parse(
+          fetchMock.mock.calls[fetchMock.mock.calls.length - 1][1].body as string,
+        );
+        expect(last.params).toEqual(["02"]);
+      });
+    });
+
     it("calls fetchWidgetData with substituted SQL (no :comp_*) when comparisonRange is set", async () => {
       const fetchMock = mockFetchSuccess({ columns: ["tienda", "anterior"], rows: [["Madrid", 500]] });
       vi.stubGlobal("fetch", fetchMock);

--- a/dashboard/lib/__tests__/prompts.test.ts
+++ b/dashboard/lib/__tests__/prompts.test.ts
@@ -55,6 +55,12 @@ describe("prompts", () => {
       expect(prompt).toContain('"glossary"');
     });
 
+    it("documents global dashboard filters and __gf tokens", () => {
+      expect(prompt).toContain("Global dashboard filters");
+      expect(prompt).toContain("__gf_tienda__");
+      expect(prompt).toContain('"filters"');
+    });
+
     it("includes rule requiring glossary to always be present", () => {
       expect(prompt).toContain('glossary" field MUST always be included');
     });
@@ -219,6 +225,11 @@ describe("prompts", () => {
 
     it("instructs to preserve existing glossary entries", () => {
       expect(prompt).toContain("Preserve all existing glossary entries");
+    });
+
+    it("instructs to preserve global filters and __gf tokens", () => {
+      expect(prompt).toContain("Global filters preservation");
+      expect(prompt).toContain("__gf_<id>__");
     });
 
     it("instructs to add new glossary terms for new widgets", () => {

--- a/dashboard/lib/__tests__/query-validator.test.ts
+++ b/dashboard/lib/__tests__/query-validator.test.ts
@@ -69,6 +69,19 @@ describe("validateQueryCost", () => {
     expect(cost).toBe(500);
   });
 
+  it("forwards bind params to EXPLAIN query", async () => {
+    mockQuery.mockResolvedValueOnce({
+      columns: ["QUERY PLAN"],
+      rows: [[makePlan(12)]],
+    });
+    await validateQueryCost("SELECT * FROM ps_ventas WHERE id = $1", { params: [1] });
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [text, values] = mockQuery.mock.calls[0] as [string, unknown[] | undefined];
+    expect(text).toContain("EXPLAIN (FORMAT JSON)");
+    expect(text).toContain("SELECT * FROM ps_ventas WHERE id = $1");
+    expect(values).toEqual([1]);
+  });
+
   it("does not throw when QUERY_COST_LIMIT is unset even for very high planner cost", async () => {
     mockQuery.mockResolvedValueOnce({
       columns: ["QUERY PLAN"],

--- a/dashboard/lib/__tests__/schema.test.ts
+++ b/dashboard/lib/__tests__/schema.test.ts
@@ -322,6 +322,85 @@ describe("WidgetSchema", () => {
 // default_time_range field tests
 // ---------------------------------------------------------------------------
 
+describe("DashboardSpecSchema — filters (global)", () => {
+  const BASE = {
+    title: "T",
+    widgets: [{ type: "table", title: "W", sql: "SELECT 1" }],
+  };
+
+  it("accepts spec without filters (optional)", () => {
+    expect(() => DashboardSpecSchema.parse(BASE)).not.toThrow();
+  });
+
+  it("accepts valid single_select and multi_select filters", () => {
+    const spec = {
+      ...BASE,
+      filters: [
+        {
+          id: "tienda",
+          type: "single_select",
+          label: "Tienda",
+          bind_expr: `v."tienda"`,
+          value_type: "text",
+          options_sql: "SELECT 1 AS value, 1 AS label",
+        },
+        {
+          id: "familia",
+          type: "multi_select",
+          label: "Familia",
+          bind_expr: `fm."fami_grup_marc"`,
+          value_type: "text",
+          options_sql: "SELECT 1 AS value, 1 AS label",
+        },
+      ],
+    };
+    const r = DashboardSpecSchema.parse(spec);
+    expect(r.filters).toHaveLength(2);
+  });
+
+  it("rejects duplicate filter ids", () => {
+    const spec = {
+      ...BASE,
+      filters: [
+        {
+          id: "tienda",
+          type: "single_select",
+          label: "A",
+          bind_expr: "v.a",
+          value_type: "text",
+          options_sql: "SELECT 1 AS value, 1 AS label",
+        },
+        {
+          id: "tienda",
+          type: "single_select",
+          label: "B",
+          bind_expr: "v.b",
+          value_type: "text",
+          options_sql: "SELECT 1 AS value, 1 AS label",
+        },
+      ],
+    };
+    expect(() => DashboardSpecSchema.parse(spec)).toThrow(ZodError);
+  });
+
+  it("rejects invalid filter id slug", () => {
+    const spec = {
+      ...BASE,
+      filters: [
+        {
+          id: "1bad",
+          type: "single_select",
+          label: "X",
+          bind_expr: "x",
+          value_type: "text",
+          options_sql: "SELECT 1 AS value, 1 AS label",
+        },
+      ],
+    };
+    expect(() => DashboardSpecSchema.parse(spec)).toThrow(ZodError);
+  });
+});
+
 describe("DashboardSpecSchema — default_time_range", () => {
   const BASE = {
     title: "T",

--- a/dashboard/lib/__tests__/sql-filters.test.ts
+++ b/dashboard/lib/__tests__/sql-filters.test.ts
@@ -54,6 +54,41 @@ describe("compileGlobalFilterSql", () => {
     expect(params).toEqual([["A", "B"]]);
   });
 
+  it("binds numeric single_select from string or number", () => {
+    const filters = [
+      {
+        id: "n",
+        type: "single_select" as const,
+        label: "N",
+        bind_expr: "t.x",
+        value_type: "numeric" as const,
+        options_sql: "SELECT 1",
+      },
+    ];
+    const a = compileGlobalFilterSql(`SELECT 1 WHERE __gf_n__`, filters, { n: "42" });
+    expect(a.params).toEqual([42]);
+    const b = compileGlobalFilterSql(`SELECT 1 WHERE __gf_n__`, filters, { n: 7 });
+    expect(b.params).toEqual([7]);
+  });
+
+  it("binds numeric multi_select arrays", () => {
+    const filters = [
+      {
+        id: "n",
+        type: "multi_select" as const,
+        label: "N",
+        bind_expr: "t.x",
+        value_type: "numeric" as const,
+        options_sql: "SELECT 1",
+      },
+    ];
+    const { sql, params } = compileGlobalFilterSql(`WHERE __gf_n__`, filters, {
+      n: [1, 2, 3],
+    });
+    expect(sql).toContain("::numeric[]");
+    expect(params).toEqual([[1, 2, 3]]);
+  });
+
   it("excludeFilterId forces TRUE for that token", () => {
     const { sql } = compileGlobalFilterSql(
       `SELECT 1 WHERE __gf_tienda__ AND __gf_familia__`,

--- a/dashboard/lib/__tests__/sql-filters.test.ts
+++ b/dashboard/lib/__tests__/sql-filters.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  compileGlobalFilterSql,
-  listReferencedGlobalFilterIds,
-  hasUnresolvedGlobalFilterTokens,
-} from "../sql-filters";
+import { compileGlobalFilterSql, listReferencedGlobalFilterIds } from "../sql-filters";
 import type { DashboardSpec } from "../schema";
 
 const FILTERS_SPEC: Pick<DashboardSpec, "filters"> = {
@@ -76,13 +72,5 @@ describe("listReferencedGlobalFilterIds", () => {
     expect(
       listReferencedGlobalFilterIds(`__gf_tienda__ AND __gf_familia__ OR __gf_tienda__`),
     ).toEqual(["familia", "tienda"]);
-  });
-});
-
-describe("hasUnresolvedGlobalFilterTokens", () => {
-  it("detects leftover tokens", () => {
-    expect(
-      hasUnresolvedGlobalFilterTokens("SELECT 1 WHERE __gf_tienda__", FILTERS_SPEC.filters),
-    ).toBe(true);
   });
 });

--- a/dashboard/lib/__tests__/sql-filters.test.ts
+++ b/dashboard/lib/__tests__/sql-filters.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileGlobalFilterSql,
+  listReferencedGlobalFilterIds,
+  hasUnresolvedGlobalFilterTokens,
+} from "../sql-filters";
+import type { DashboardSpec } from "../schema";
+
+const FILTERS_SPEC: Pick<DashboardSpec, "filters"> = {
+  filters: [
+    {
+      id: "tienda",
+      type: "single_select",
+      label: "Tienda",
+      bind_expr: `v."tienda"`,
+      value_type: "text",
+      options_sql: "SELECT 1",
+    },
+    {
+      id: "familia",
+      type: "multi_select",
+      label: "Familia",
+      bind_expr: `fm."fami_grup_marc"`,
+      value_type: "text",
+      options_sql: "SELECT 1",
+    },
+  ],
+};
+
+describe("compileGlobalFilterSql", () => {
+  it("replaces inactive single_select with TRUE", () => {
+    const { sql, params } = compileGlobalFilterSql(
+      `SELECT 1 WHERE __gf_tienda__`,
+      FILTERS_SPEC.filters,
+      {},
+    );
+    expect(sql).toBe("SELECT 1 WHERE TRUE");
+    expect(params).toEqual([]);
+  });
+
+  it("binds active single_select as parameterized equality", () => {
+    const { sql, params } = compileGlobalFilterSql(
+      `SELECT 1 WHERE __gf_tienda__`,
+      FILTERS_SPEC.filters,
+      { tienda: "01" },
+    );
+    expect(sql).toBe(`SELECT 1 WHERE ((v."tienda") = $1::text)`);
+    expect(params).toEqual(["01"]);
+  });
+
+  it("binds multi_select with ANY", () => {
+    const { sql, params } = compileGlobalFilterSql(
+      `SELECT 1 WHERE __gf_familia__`,
+      FILTERS_SPEC.filters,
+      { familia: ["A", "B"] },
+    );
+    expect(sql).toBe(`SELECT 1 WHERE ((fm."fami_grup_marc") = ANY($1::text[]))`);
+    expect(params).toEqual([["A", "B"]]);
+  });
+
+  it("excludeFilterId forces TRUE for that token", () => {
+    const { sql } = compileGlobalFilterSql(
+      `SELECT 1 WHERE __gf_tienda__ AND __gf_familia__`,
+      FILTERS_SPEC.filters,
+      { tienda: "01", familia: ["X"] },
+      { excludeFilterId: "familia" },
+    );
+    expect(sql).toContain("TRUE");
+    expect(sql).toContain("$1::text");
+    expect(sql).not.toContain("fami_grup_marc");
+  });
+});
+
+describe("listReferencedGlobalFilterIds", () => {
+  it("lists unique ids", () => {
+    expect(
+      listReferencedGlobalFilterIds(`__gf_tienda__ AND __gf_familia__ OR __gf_tienda__`),
+    ).toEqual(["familia", "tienda"]);
+  });
+});
+
+describe("hasUnresolvedGlobalFilterTokens", () => {
+  it("detects leftover tokens", () => {
+    expect(
+      hasUnresolvedGlobalFilterTokens("SELECT 1 WHERE __gf_tienda__", FILTERS_SPEC.filters),
+    ).toBe(true);
+  });
+});

--- a/dashboard/lib/prompts.ts
+++ b/dashboard/lib/prompts.ts
@@ -56,6 +56,20 @@ SQL strings can embed placeholder tokens replaced at render time with the active
 
 Use :curr_from/:curr_to for dynamic date filtering instead of hardcoded dates. Use :comp_from/:comp_to in comparison_sql and trend_sql to reference the comparison period.
 
+### Global dashboard filters (v1)
+
+Dashboard JSON includes a top-level **filters** array (alongside **widgets**) so users can slice every widget consistently from the UI.
+
+Each filter object:
+- **id**: snake_case identifier (e.g. \`tienda\`, \`familia\`).
+- **type**: \`single_select\` or \`multi_select\`.
+- **label**: Spanish label shown in the filter bar.
+- **bind_expr**: SQL expression compared to the selection, e.g. \`v."tienda"\` or \`fm."fami_grup_marc"\`. **Alias \`ps_ventas\` as \`v\`** wherever \`__gf_tienda__\` is used.
+- **value_type**: \`text\` or \`numeric\` (controls PostgreSQL casts for bound parameters).
+- **options_sql**: Read-only \`SELECT\` that returns columns **value** and **label**. It may use date tokens (\`:curr_from\` / \`:curr_to\`) and may reference other filters with \`__gf_<other_id>__\` tokens for cascading lists.
+
+Widget SQL (including \`trend_sql\`, \`anomaly_sql\`, \`comparison_sql\`) must embed \`__gf_<id>__\` boolean slots inside \`WHERE\` clauses, e.g. \`AND __gf_tienda__\`. When a filter has no selection, the slot becomes SQL \`TRUE\` (no-op). **Never** interpolate user-selected filter values into SQL — only these tokens plus parameterized binding executed by the server.
+
 ### Chart widget comparison series
 
 Chart widgets (bar_chart, line_chart, area_chart, donut_chart) support an optional comparison_sql field:
@@ -174,6 +188,12 @@ The JSON must conform to this structure:
     // Each widget has an "id" field: "w1", "w2", ... (auto-incrementing)
     // KPI rows should come first, then charts, then tables
   ],
+  "filters": [
+    // Global business filters — ALWAYS include at least tienda (single_select) for retail dashboards
+    // Example:
+    // { "id": "tienda", "type": "single_select", "label": "Tienda", "bind_expr": "v.\\"tienda\\"", "value_type": "text",
+    //   "options_sql": "SELECT DISTINCT v.\\"tienda\\" AS value, v.\\"tienda\\" AS label FROM \\"public\\".\\"ps_ventas\\" v WHERE v.\\"entrada\\" = true AND v.\\"tienda\\" <> '99' AND v.\\"fecha_creacion\\" BETWEEN :curr_from AND :curr_to ORDER BY 1" }
+  ],
   "glossary": [
     // Array of 5-10 key business terms used in the dashboard
     // Each entry: { "term": "Ventas Netas", "definition": "Importe de ventas sin IVA. No incluye devoluciones (entrada = false)." }
@@ -184,6 +204,7 @@ The JSON must conform to this structure:
 
 Rules:
 - Every widget MUST have a unique "id" field (e.g. "w1", "w2", "w3")
+- The **filters** field MUST be present for new dashboards (use an empty array only if the domain truly has no sliceable dimensions)
 - A dashboard should have 4-8 widgets unless the user requests otherwise
 - Start with a kpi_row for the most important metrics
 - Follow with charts that provide visual context
@@ -217,6 +238,7 @@ All SQL must be valid PostgreSQL executed against the "public" schema.
 16. **Days between dates (PostgreSQL):** If columns are \`date\` (or \`timestamp::date\)), subtracting yields an **integer** number of days: \`(CURRENT_DATE - MAX(v.fecha_creacion::date))\` or \`(fecha_fin - fecha_ini)\`. **Do NOT** wrap that subtraction in \`EXTRACT(days FROM ...)\` — there is no \`days\` field; \`date - date\` is already days, and \`EXTRACT(day FROM integer)\` errors. For a true \`interval\` (e.g. two timestamps), use \`EXTRACT(day FROM intervalo)\` (singular \`day\`).
 17. **Never mix date and text in COALESCE:** \`COALESCE(MAX(fecha), 'Sin ventas')\` fails because PostgreSQL coerces the literal to \`date\`. Use \`COALESCE(MAX(fecha)::text, 'Sin ventas')\` or \`TO_CHAR(MAX(fecha), 'YYYY-MM-DD')\`.
 18. **"Días sin venta" pattern:** Prefer \`COALESCE((CURRENT_DATE - MAX(ultima_venta.fecha)), 999)\` when the join yields a single last-sale date per SKU (guard NULL with COALESCE), instead of EXTRACT on a date difference.
+19. **Global filters:** Include a **filters** array and \`AND __gf_tienda__\` (and other \`__gf_*\` slots) in retail widget SQL as required by the Global dashboard filters section. Never inline filter values — tokens only.
 `;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -288,6 +310,12 @@ export function buildModifyPrompt(currentSpec: string): string {
     "You must return the COMPLETE updated dashboard JSON — not just the changed parts.",
     "Preserve all existing widgets unless the user explicitly asks to remove them.",
     "When adding new widgets, continue the id sequence (e.g. if the last widget is w6, the new one is w7).",
+    "",
+    "## Global filters preservation rule",
+    "",
+    "The existing dashboard may contain a **filters** array and __gf_<id>__ tokens in widget SQL. You MUST:",
+    "1. Preserve all existing filter definitions unless the user explicitly asks to change them.",
+    "2. When adding retail widgets that use **ps_ventas**, keep **alias v** and include AND __gf_tienda__ (and other relevant __gf_<id>__ slots) in WHERE clauses.",
     "",
     "## Glossary preservation rule",
     "",

--- a/dashboard/lib/query-validator.ts
+++ b/dashboard/lib/query-validator.ts
@@ -57,7 +57,7 @@ function safeEquals(a: string, b: string): boolean {
 
 export async function validateQueryCost(
   sql: string,
-  options?: { forceHeader?: string }
+  options?: { forceHeader?: string; params?: unknown[] }
 ): Promise<number> {
   const secret = process.env.QUERY_COST_OVERRIDE_SECRET;
   if (secret && options?.forceHeader && safeEquals(options.forceHeader, secret)) {
@@ -74,7 +74,8 @@ export async function validateQueryCost(
   }
 
   try {
-    const result = await query(`EXPLAIN (FORMAT JSON) ${sql}`); // safe: sql validated to start with SELECT/WITH above; validateReadOnly() also rejects semicolons and write keywords
+    const params = options?.params ?? [];
+    const result = await query(`EXPLAIN (FORMAT JSON) ${sql}`, params); // safe: sql validated to start with SELECT/WITH above; validateReadOnly() also rejects semicolons and write keywords
     const raw = result.rows[0][0] as unknown;
     // node-postgres returns json columns as parsed JS values; handle both string (test mocks) and object
     const plan = (typeof raw === "string"

--- a/dashboard/lib/schema.ts
+++ b/dashboard/lib/schema.ts
@@ -143,7 +143,47 @@ export const DefaultTimeRangeSchema = z.object({
   preset: TimeRangePresetSchema,
 }).strict();
 
-export const DashboardSpecSchema = z.object({
+const GlobalFilterIdSchema = z
+  .string()
+  .min(1)
+  .regex(/^[a-z][a-z0-9_]*$/, "filter id must be a snake_case slug (a-z, digits, underscore)");
+
+const GlobalFilterBaseSchema = z
+  .object({
+    id: GlobalFilterIdSchema,
+    label: z.string().min(1),
+    /**
+     * SQL expression compared to the selected value(s), e.g. `v."tienda"` or
+     * `fm."fami_grup_marc"`. Widget SQL must include the token `__gf_<id>__`
+     * (this filter's id) where the predicate should apply.
+     */
+    bind_expr: z.string().min(1),
+    /** How bound parameters are cast in PostgreSQL. */
+    value_type: z.enum(["text", "numeric"]).default("text"),
+    /**
+     * Read-only SELECT that returns exactly two columns aliased as `value`
+     * and `label` (order does not matter). May include date tokens and other
+     * `__gf_*__` tokens for cascading option lists.
+     */
+    options_sql: z.string().min(1),
+  })
+  .strict();
+
+export const SingleSelectGlobalFilterSchema = GlobalFilterBaseSchema.extend({
+  type: z.literal("single_select"),
+}).strict();
+
+export const MultiSelectGlobalFilterSchema = GlobalFilterBaseSchema.extend({
+  type: z.literal("multi_select"),
+}).strict();
+
+export const GlobalFilterSchema = z.discriminatedUnion("type", [
+  SingleSelectGlobalFilterSchema,
+  MultiSelectGlobalFilterSchema,
+]);
+
+export const DashboardSpecSchema = z
+  .object({
   title: z.string().min(1),
   description: z.string().min(1).optional(),
   widgets: z.array(WidgetSchema).min(1),
@@ -164,7 +204,29 @@ export const DashboardSpecSchema = z.object({
    * for absent optional fields, so we treat null the same as undefined here.
    */
   default_time_range: DefaultTimeRangeSchema.nullish(),
-}).strict();
+  /**
+   * Global business filters (tienda, familia, proveedor, etc.) shown in the
+   * dashboard chrome. Widget SQL should reference them with `__gf_<id>__`
+   * tokens; values are bound as PostgreSQL parameters at query time.
+   */
+  filters: z.array(GlobalFilterSchema).optional(),
+})
+  .strict()
+  .superRefine((spec, ctx) => {
+    const ids = spec.filters?.map((f) => f.id) ?? [];
+    const seen = new Set<string>();
+    for (const id of ids) {
+      if (seen.has(id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `duplicate global filter id: ${id}`,
+          path: ["filters"],
+        });
+        return;
+      }
+      seen.add(id);
+    }
+  });
 
 // ---------------------------------------------------------------------------
 // TypeScript types (inferred from Zod — single source of truth)
@@ -185,6 +247,9 @@ export type GlossaryItem = z.infer<typeof GlossaryItemSchema>;
 export type DashboardSpec = z.infer<typeof DashboardSpecSchema>;
 export type TimeRangePreset = z.infer<typeof TimeRangePresetSchema>;
 export type DefaultTimeRange = z.infer<typeof DefaultTimeRangeSchema>;
+export type GlobalFilter = z.infer<typeof GlobalFilterSchema>;
+export type SingleSelectGlobalFilter = z.infer<typeof SingleSelectGlobalFilterSchema>;
+export type MultiSelectGlobalFilter = z.infer<typeof MultiSelectGlobalFilterSchema>;
 
 // ---------------------------------------------------------------------------
 // Validation helper

--- a/dashboard/lib/sql-filters.ts
+++ b/dashboard/lib/sql-filters.ts
@@ -10,18 +10,35 @@
 import type { DashboardSpec, GlobalFilter } from "./schema";
 
 /** Active values keyed by global filter `id`. */
-export type GlobalFilterValues = Record<string, string | string[]>;
-
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
+export type GlobalFilterScalar = string | number;
+export type GlobalFilterValues = Record<
+  string,
+  GlobalFilterScalar | GlobalFilterScalar[]
+>;
 
 function isNonEmptyString(v: unknown): v is string {
   return typeof v === "string" && v.trim().length > 0;
 }
 
+function coalesceNumericScalar(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string" && v.trim().length > 0) {
+    const n = Number(v);
+    if (!Number.isNaN(n) && Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
 function isNonEmptyStringArray(v: unknown): v is string[] {
   return Array.isArray(v) && v.length > 0 && v.every((x) => typeof x === "string" && x.length > 0);
+}
+
+function isNonEmptyNumberArray(v: unknown): v is number[] {
+  return (
+    Array.isArray(v) &&
+    v.length > 0 &&
+    v.every((x) => typeof x === "number" && Number.isFinite(x))
+  );
 }
 
 function tokenForFilterId(id: string): string {
@@ -67,20 +84,25 @@ export function compileGlobalFilterSql(
     const raw = values[filter.id];
 
     if (filter.type === "single_select") {
-      if (!isNonEmptyString(raw)) {
+      const castKind = pgScalarCast(filter);
+      const scalar =
+        castKind === "numeric" ? coalesceNumericScalar(raw) : isNonEmptyString(raw) ? raw.trim() : null;
+      if (scalar === null) {
         out = out.replaceAll(token, "TRUE");
         continue;
       }
       const idx = params.length + 1;
-      const cast = pgScalarCast(filter);
-      params.push(raw);
+      const cast = castKind;
+      params.push(scalar);
       const fragment = `((${filter.bind_expr}) = $${idx}::${cast})`;
       out = out.replaceAll(token, fragment);
       continue;
     }
 
     // multi_select
-    if (!isNonEmptyStringArray(raw)) {
+    const useNumeric = filter.value_type === "numeric";
+    const arrOk = useNumeric ? isNonEmptyNumberArray(raw) : isNonEmptyStringArray(raw);
+    if (!arrOk) {
       out = out.replaceAll(token, "TRUE");
       continue;
     }

--- a/dashboard/lib/sql-filters.ts
+++ b/dashboard/lib/sql-filters.ts
@@ -94,17 +94,6 @@ export function compileGlobalFilterSql(
   return { sql: out, params };
 }
 
-/** True if `sql` still contains any global filter token for the given definitions. */
-export function hasUnresolvedGlobalFilterTokens(
-  sql: string,
-  filters: DashboardSpec["filters"] | undefined,
-): boolean {
-  for (const f of filters ?? []) {
-    if (sql.includes(tokenForFilterId(f.id))) return true;
-  }
-  return false;
-}
-
 /** Regex that matches any `__gf_<id>__` token with a sane id slug. */
 const GF_TOKEN_RE = /__gf_([a-z][a-z0-9_]*)__/g;
 

--- a/dashboard/lib/sql-filters.ts
+++ b/dashboard/lib/sql-filters.ts
@@ -1,0 +1,120 @@
+/**
+ * Compile dashboard global filter tokens in widget SQL into PostgreSQL
+ * parameterized fragments ($1, $2, …) plus a matching params array.
+ *
+ * Widget and options SQL may contain tokens `__gf_<id>__` (see schema docs).
+ * Date-range tokens (:curr_from, etc.) must already be substituted before
+ * calling this module.
+ */
+
+import type { DashboardSpec, GlobalFilter } from "./schema";
+
+/** Active values keyed by global filter `id`. */
+export type GlobalFilterValues = Record<string, string | string[]>;
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.trim().length > 0;
+}
+
+function isNonEmptyStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.length > 0 && v.every((x) => typeof x === "string" && x.length > 0);
+}
+
+function tokenForFilterId(id: string): string {
+  return `__gf_${id}__`;
+}
+
+function pgScalarCast(filter: GlobalFilter): "text" | "numeric" {
+  return filter.value_type === "numeric" ? "numeric" : "text";
+}
+
+function pgArrayCast(filter: GlobalFilter): "text[]" | "numeric[]" {
+  return filter.value_type === "numeric" ? "numeric[]" : "text[]";
+}
+
+export interface CompileGlobalFiltersOptions {
+  /** When set, the filter with this id is always neutralized to TRUE (for option lists). */
+  excludeFilterId?: string;
+}
+
+/**
+ * Replace every `__gf_<id>__` token in `sql` using `spec.filters` and `values`.
+ * Returns parameterized SQL suitable for `query(sql, params)`.
+ */
+export function compileGlobalFilterSql(
+  sql: string,
+  filters: DashboardSpec["filters"],
+  values: GlobalFilterValues,
+  options?: CompileGlobalFiltersOptions,
+): { sql: string; params: unknown[] } {
+  const defs = filters ?? [];
+  const params: unknown[] = [];
+  let out = sql;
+
+  for (const filter of defs) {
+    const token = tokenForFilterId(filter.id);
+    if (!out.includes(token)) continue;
+
+    if (options?.excludeFilterId === filter.id) {
+      out = out.replaceAll(token, "TRUE");
+      continue;
+    }
+
+    const raw = values[filter.id];
+
+    if (filter.type === "single_select") {
+      if (!isNonEmptyString(raw)) {
+        out = out.replaceAll(token, "TRUE");
+        continue;
+      }
+      const idx = params.length + 1;
+      const cast = pgScalarCast(filter);
+      params.push(raw);
+      const fragment = `((${filter.bind_expr}) = $${idx}::${cast})`;
+      out = out.replaceAll(token, fragment);
+      continue;
+    }
+
+    // multi_select
+    if (!isNonEmptyStringArray(raw)) {
+      out = out.replaceAll(token, "TRUE");
+      continue;
+    }
+    const idx = params.length + 1;
+    const cast = pgArrayCast(filter);
+    params.push(raw);
+    const fragment = `((${filter.bind_expr}) = ANY($${idx}::${cast}))`;
+    out = out.replaceAll(token, fragment);
+  }
+
+  return { sql: out, params };
+}
+
+/** True if `sql` still contains any global filter token for the given definitions. */
+export function hasUnresolvedGlobalFilterTokens(
+  sql: string,
+  filters: DashboardSpec["filters"] | undefined,
+): boolean {
+  for (const f of filters ?? []) {
+    if (sql.includes(tokenForFilterId(f.id))) return true;
+  }
+  return false;
+}
+
+/** Regex that matches any `__gf_<id>__` token with a sane id slug. */
+const GF_TOKEN_RE = /__gf_([a-z][a-z0-9_]*)__/g;
+
+/**
+ * Return sorted unique global filter ids referenced by a SQL string.
+ */
+export function listReferencedGlobalFilterIds(sql: string): string[] {
+  const ids = new Set<string>();
+  for (const m of sql.matchAll(GF_TOKEN_RE)) {
+    ids.add(m[1]);
+  }
+  return Array.from(ids).sort();
+}

--- a/dashboard/lib/template-global-filters.ts
+++ b/dashboard/lib/template-global-filters.ts
@@ -1,0 +1,41 @@
+import type { GlobalFilter } from "./schema";
+
+/**
+ * Default global filters for retail-heavy dashboard templates (v1).
+ * Widget SQL must alias `ps_ventas` as `v` where `__gf_tienda__` is used, and
+ * include joins to `ps_familias` as `fm` where `__gf_familia__` is used.
+ */
+export const templateGlobalFiltersRetail: GlobalFilter[] = [
+  {
+    id: "tienda",
+    type: "single_select",
+    label: "Tienda",
+    bind_expr: `v."tienda"`,
+    value_type: "text",
+    options_sql: `SELECT DISTINCT v."tienda" AS value, v."tienda" AS label
+FROM "public"."ps_ventas" v
+WHERE v."entrada" = true
+  AND v."tienda" <> '99'
+  AND v."fecha_creacion" >= :curr_from
+  AND v."fecha_creacion" <= :curr_to
+ORDER BY 1`,
+  },
+  {
+    id: "familia",
+    type: "multi_select",
+    label: "Familia",
+    bind_expr: `fm."fami_grup_marc"`,
+    value_type: "text",
+    options_sql: `SELECT DISTINCT fm."fami_grup_marc" AS value, fm."fami_grup_marc" AS label
+FROM "public"."ps_lineas_ventas" lv
+JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
+JOIN "public"."ps_articulos" p ON lv."codigo" = p."codigo"
+JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
+WHERE v."entrada" = true
+  AND lv."tienda" <> '99'
+  AND lv."fecha_creacion" >= :curr_from
+  AND lv."fecha_creacion" <= :curr_to
+  AND __gf_tienda__
+ORDER BY 1`,
+  },
+];

--- a/dashboard/lib/templates/general.ts
+++ b/dashboard/lib/templates/general.ts
@@ -7,6 +7,7 @@
  * YoY KPI compares selected period vs same period one year prior.
  */
 import type { DashboardSpec } from "@/lib/schema";
+import { templateGlobalFiltersRetail } from "@/lib/template-global-filters";
 
 export const name = "Director General";
 
@@ -16,6 +17,7 @@ export const description =
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Director General",
   description,
+  filters: templateGlobalFiltersRetail,
   widgets: [
     {
       id: "general-kpis",
@@ -23,12 +25,13 @@ export const spec: DashboardSpec = {
       items: [
         {
           label: "Ventas Retail Netas (período seleccionado)",
-          sql: `SELECT COALESCE(SUM("total_si"), 0) AS value
-FROM "public"."ps_ventas"
-WHERE "entrada" = true
-  AND "tienda" <> '99'
-  AND "fecha_creacion" >= :curr_from
-  AND "fecha_creacion" <= :curr_to`,
+          sql: `SELECT COALESCE(SUM(v."total_si"), 0) AS value
+FROM "public"."ps_ventas" v
+WHERE v."entrada" = true
+  AND v."tienda" <> '99'
+  AND v."fecha_creacion" >= :curr_from
+  AND v."fecha_creacion" <= :curr_to
+  AND __gf_tienda__`,
           format: "currency",
           prefix: "€",
         },
@@ -50,11 +53,15 @@ WHERE "abono" = false
 ) AS value
 FROM "public"."ps_lineas_ventas" lv
 JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
+JOIN "public"."ps_articulos" p ON lv."codigo" = p."codigo"
+JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
 WHERE v."entrada" = true
   AND lv."tienda" <> '99'
   AND lv."total_si" > 0
   AND lv."fecha_creacion" >= :curr_from
-  AND lv."fecha_creacion" <= :curr_to`,
+  AND lv."fecha_creacion" <= :curr_to
+  AND __gf_tienda__
+  AND __gf_familia__`,
           format: "percent",
         },
         {
@@ -63,18 +70,20 @@ WHERE v."entrada" = true
   (curr.ventas - prev.ventas) / NULLIF(ABS(prev.ventas), 0) * 100, 1
 ) AS value
 FROM (
-  SELECT COALESCE(SUM("total_si"), 0) AS ventas
-  FROM "public"."ps_ventas"
-  WHERE "entrada" = true AND "tienda" <> '99'
-    AND "fecha_creacion" >= :curr_from
-    AND "fecha_creacion" <= :curr_to
+  SELECT COALESCE(SUM(v."total_si"), 0) AS ventas
+  FROM "public"."ps_ventas" v
+  WHERE v."entrada" = true AND v."tienda" <> '99'
+    AND v."fecha_creacion" >= :curr_from
+    AND v."fecha_creacion" <= :curr_to
+    AND __gf_tienda__
 ) curr,
 (
-  SELECT COALESCE(SUM("total_si"), 0) AS ventas
-  FROM "public"."ps_ventas"
-  WHERE "entrada" = true AND "tienda" <> '99'
-    AND "fecha_creacion" >= :curr_from::date - INTERVAL '1 year'
-    AND "fecha_creacion" <= :curr_to::date - INTERVAL '1 year'
+  SELECT COALESCE(SUM(v."total_si"), 0) AS ventas
+  FROM "public"."ps_ventas" v
+  WHERE v."entrada" = true AND v."tienda" <> '99'
+    AND v."fecha_creacion" >= :curr_from::date - INTERVAL '1 year'
+    AND v."fecha_creacion" <= :curr_to::date - INTERVAL '1 year'
+    AND __gf_tienda__
 ) prev`,
           format: "percent",
         },
@@ -85,12 +94,13 @@ FROM (
       type: "donut_chart",
       title: "Mix Retail vs Mayorista (período seleccionado)",
       sql: `SELECT 'Retail' AS label,
-       COALESCE(SUM("total_si"), 0) AS value
-FROM "public"."ps_ventas"
-WHERE "entrada" = true
-  AND "tienda" <> '99'
-  AND "fecha_creacion" >= :curr_from
-  AND "fecha_creacion" <= :curr_to
+       COALESCE(SUM(v."total_si"), 0) AS value
+FROM "public"."ps_ventas" v
+WHERE v."entrada" = true
+  AND v."tienda" <> '99'
+  AND v."fecha_creacion" >= :curr_from
+  AND v."fecha_creacion" <= :curr_to
+  AND __gf_tienda__
 UNION ALL
 SELECT 'Mayorista' AS label,
        COALESCE(SUM("base1" + "base2" + "base3"), 0) AS value
@@ -105,13 +115,14 @@ WHERE "abono" = false
       id: "general-ventas-por-tienda",
       type: "bar_chart",
       title: "Ventas Retail por Tienda (período seleccionado)",
-      sql: `SELECT "tienda" AS label, SUM("total_si") AS value
-FROM "public"."ps_ventas"
-WHERE "entrada" = true
-  AND "tienda" <> '99'
-  AND "fecha_creacion" >= :curr_from
-  AND "fecha_creacion" <= :curr_to
-GROUP BY "tienda"
+      sql: `SELECT v."tienda" AS label, SUM(v."total_si") AS value
+FROM "public"."ps_ventas" v
+WHERE v."entrada" = true
+  AND v."tienda" <> '99'
+  AND v."fecha_creacion" >= :curr_from
+  AND v."fecha_creacion" <= :curr_to
+  AND __gf_tienda__
+GROUP BY v."tienda"
 ORDER BY value DESC`,
       x: "label",
       y: "value",
@@ -121,14 +132,15 @@ ORDER BY value DESC`,
       type: "line_chart",
       title: "Tendencia Mensual Retail + Mayorista (período seleccionado)",
       sql: `SELECT mes, SUM(importe) AS y, mes AS x FROM (
-  SELECT DATE_TRUNC('month', "fecha_creacion") AS mes,
-         SUM("total_si") AS importe
-  FROM "public"."ps_ventas"
-  WHERE "entrada" = true
-    AND "tienda" <> '99'
-    AND "fecha_creacion" >= :curr_from
-    AND "fecha_creacion" <= :curr_to
-  GROUP BY DATE_TRUNC('month', "fecha_creacion")
+  SELECT DATE_TRUNC('month', v."fecha_creacion") AS mes,
+         SUM(v."total_si") AS importe
+  FROM "public"."ps_ventas" v
+  WHERE v."entrada" = true
+    AND v."tienda" <> '99'
+    AND v."fecha_creacion" >= :curr_from
+    AND v."fecha_creacion" <= :curr_to
+    AND __gf_tienda__
+  GROUP BY DATE_TRUNC('month', v."fecha_creacion")
   UNION ALL
   SELECT DATE_TRUNC('month', "fecha_factura") AS mes,
          SUM("base1" + "base2" + "base3") AS importe
@@ -161,6 +173,8 @@ WHERE v."entrada" = true
   AND lv."total_si" > 0
   AND lv."fecha_creacion" >= :curr_from
   AND lv."fecha_creacion" <= :curr_to
+  AND __gf_tienda__
+  AND __gf_familia__
 GROUP BY fm."fami_grup_marc"
 ORDER BY "Ventas Netas" DESC
 LIMIT 10`,

--- a/dashboard/lib/templates/ventas.ts
+++ b/dashboard/lib/templates/ventas.ts
@@ -6,6 +6,7 @@
  * All date filters use :curr_from / :curr_to tokens set by the date picker.
  */
 import type { DashboardSpec } from "@/lib/schema";
+import { templateGlobalFiltersRetail } from "@/lib/template-global-filters";
 
 export const name = "Responsable de Ventas";
 
@@ -15,6 +16,7 @@ export const description =
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Ventas Retail",
   description,
+  filters: templateGlobalFiltersRetail,
   widgets: [
     {
       id: "ventas-kpis",
@@ -22,44 +24,48 @@ export const spec: DashboardSpec = {
       items: [
         {
           label: "Ventas Netas",
-          sql: `SELECT COALESCE(SUM("total_si"), 0) AS value
-FROM "public"."ps_ventas"
-WHERE "entrada" = true
-  AND "tienda" <> '99'
-  AND "fecha_creacion" >= :curr_from
-  AND "fecha_creacion" <= :curr_to`,
+          sql: `SELECT COALESCE(SUM(v."total_si"), 0) AS value
+FROM "public"."ps_ventas" v
+WHERE v."entrada" = true
+  AND v."tienda" <> '99'
+  AND v."fecha_creacion" >= :curr_from
+  AND v."fecha_creacion" <= :curr_to
+  AND __gf_tienda__`,
           format: "currency",
           prefix: "€",
         },
         {
           label: "Tickets",
-          sql: `SELECT COUNT(DISTINCT "reg_ventas") AS value
-FROM "public"."ps_ventas"
-WHERE "entrada" = true
-  AND "tienda" <> '99'
-  AND "fecha_creacion" >= :curr_from
-  AND "fecha_creacion" <= :curr_to`,
+          sql: `SELECT COUNT(DISTINCT v."reg_ventas") AS value
+FROM "public"."ps_ventas" v
+WHERE v."entrada" = true
+  AND v."tienda" <> '99'
+  AND v."fecha_creacion" >= :curr_from
+  AND v."fecha_creacion" <= :curr_to
+  AND __gf_tienda__`,
           format: "number",
         },
         {
           label: "Ticket Medio",
-          sql: `SELECT ROUND(SUM("total_si") / NULLIF(COUNT(DISTINCT "reg_ventas"), 0), 2) AS value
-FROM "public"."ps_ventas"
-WHERE "entrada" = true
-  AND "tienda" <> '99'
-  AND "fecha_creacion" >= :curr_from
-  AND "fecha_creacion" <= :curr_to`,
+          sql: `SELECT ROUND(SUM(v."total_si") / NULLIF(COUNT(DISTINCT v."reg_ventas"), 0), 2) AS value
+FROM "public"."ps_ventas" v
+WHERE v."entrada" = true
+  AND v."tienda" <> '99'
+  AND v."fecha_creacion" >= :curr_from
+  AND v."fecha_creacion" <= :curr_to
+  AND __gf_tienda__`,
           format: "currency",
           prefix: "€",
         },
         {
           label: "Devoluciones",
-          sql: `SELECT COALESCE(ABS(SUM("total_si")), 0) AS value
-FROM "public"."ps_ventas"
-WHERE "entrada" = false
-  AND "tienda" <> '99'
-  AND "fecha_creacion" >= :curr_from
-  AND "fecha_creacion" <= :curr_to`,
+          sql: `SELECT COALESCE(ABS(SUM(v."total_si")), 0) AS value
+FROM "public"."ps_ventas" v
+WHERE v."entrada" = false
+  AND v."tienda" <> '99'
+  AND v."fecha_creacion" >= :curr_from
+  AND v."fecha_creacion" <= :curr_to
+  AND __gf_tienda__`,
           format: "currency",
           prefix: "€",
         },
@@ -69,13 +75,14 @@ WHERE "entrada" = false
       id: "ventas-por-tienda",
       type: "bar_chart",
       title: "Ventas por Tienda (período seleccionado)",
-      sql: `SELECT "tienda" AS label, SUM("total_si") AS value
-FROM "public"."ps_ventas"
-WHERE "entrada" = true
-  AND "tienda" <> '99'
-  AND "fecha_creacion" >= :curr_from
-  AND "fecha_creacion" <= :curr_to
-GROUP BY "tienda"
+      sql: `SELECT v."tienda" AS label, SUM(v."total_si") AS value
+FROM "public"."ps_ventas" v
+WHERE v."entrada" = true
+  AND v."tienda" <> '99'
+  AND v."fecha_creacion" >= :curr_from
+  AND v."fecha_creacion" <= :curr_to
+  AND __gf_tienda__
+GROUP BY v."tienda"
 ORDER BY value DESC`,
       x: "label",
       y: "value",
@@ -84,13 +91,14 @@ ORDER BY value DESC`,
       id: "ventas-tendencia-semanal",
       type: "line_chart",
       title: "Tendencia Semanal (período seleccionado)",
-      sql: `SELECT DATE_TRUNC('week', "fecha_creacion") AS x, SUM("total_si") AS y
-FROM "public"."ps_ventas"
-WHERE "entrada" = true
-  AND "tienda" <> '99'
-  AND "fecha_creacion" >= :curr_from
-  AND "fecha_creacion" <= :curr_to
-GROUP BY DATE_TRUNC('week', "fecha_creacion")
+      sql: `SELECT DATE_TRUNC('week', v."fecha_creacion") AS x, SUM(v."total_si") AS y
+FROM "public"."ps_ventas" v
+WHERE v."entrada" = true
+  AND v."tienda" <> '99'
+  AND v."fecha_creacion" >= :curr_from
+  AND v."fecha_creacion" <= :curr_to
+  AND __gf_tienda__
+GROUP BY DATE_TRUNC('week', v."fecha_creacion")
 ORDER BY x`,
       x: "x",
       y: "y",
@@ -102,10 +110,12 @@ ORDER BY x`,
       sql: `SELECT p."forma" AS label,
        SUM(p."importe_cob") AS value
 FROM "public"."ps_pagos_ventas" p
-WHERE p."entrada" = true
+JOIN "public"."ps_ventas" v ON p."num_ventas" = v."reg_ventas"
+WHERE v."entrada" = true
   AND p."tienda" <> '99'
   AND p."fecha_creacion" >= :curr_from
   AND p."fecha_creacion" <= :curr_to
+  AND __gf_tienda__
 GROUP BY p."forma"
 ORDER BY value DESC`,
       x: "label",
@@ -120,11 +130,15 @@ ORDER BY value DESC`,
          / NULLIF(SUM(lv."total_si"), 0) * 100, 1) AS value
 FROM "public"."ps_lineas_ventas" lv
 JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
+JOIN "public"."ps_articulos" pa ON lv."codigo" = pa."codigo"
+JOIN "public"."ps_familias" fm ON pa."num_familia" = fm."reg_familia"
 WHERE v."entrada" = true
   AND lv."tienda" <> '99'
   AND lv."total_si" > 0
   AND lv."fecha_creacion" >= :curr_from
   AND lv."fecha_creacion" <= :curr_to
+  AND __gf_tienda__
+  AND __gf_familia__
 GROUP BY lv."tienda"
 ORDER BY value DESC`,
       x: "label",
@@ -143,11 +157,14 @@ ORDER BY value DESC`,
 FROM "public"."ps_lineas_ventas" lv
 JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
 JOIN "public"."ps_articulos" p ON lv."codigo" = p."codigo"
+JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
 WHERE v."entrada" = true
   AND lv."tienda" <> '99'
   AND lv."total_si" > 0
   AND lv."fecha_creacion" >= :curr_from
   AND lv."fecha_creacion" <= :curr_to
+  AND __gf_tienda__
+  AND __gf_familia__
 GROUP BY p."ccrefejofacm", p."descripcion"
 ORDER BY "Ventas Netas" DESC
 LIMIT 10`,


### PR DESCRIPTION
## Resumen
Implementación de la issue #383: filtros globales de negocio en dashboards con SQL parametrizado (`__gf_<id>__` → `$n`), barra de filtros, endpoint de opciones y actualización de prompts/plantillas retail.

## Cambios principales
- `DashboardSpec.filters`: `single_select` / `multi_select` con `bind_expr`, `options_sql`, `value_type`.
- `lib/sql-filters.ts`: compilador de tokens + params.
- `POST /api/query`: cuerpo `{ sql, params? }`; `validateQueryCost` reenvía params al EXPLAIN.
- `POST /api/dashboard/filters/options`: opciones por dashboard + filtro + rango de fechas + filtros activos (cascada).
- UI: `DashboardFiltersBar`, wiring en `app/dashboard/[id]/page.tsx`, `DashboardRenderer` con ref estable para evitar bucles de efecto.
- Plantillas `general` y `ventas` + `template-global-filters.ts`; prompts actualizados.

## Pruebas
`cd dashboard && npm run test && npm run lint`

Closes #383

Made with [Cursor](https://cursor.com)