### PR TITLE
Admin session, ETL hygiene, agentic dashboard progress and EXPLAIN fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,10 @@ DASHBOARD_LLM_MODEL=anthropic/claude-sonnet-4
 # Use a long random string in production.
 # ADMIN_API_KEY=
 
+# Set ADMIN_COOKIE_SECURE=true only when the dashboard is served over HTTPS (e.g. behind TLS).
+# On plain HTTP (typical LAN access by IP), leave unset so the browser stores the admin session cookie.
+# ADMIN_COOKIE_SECURE=true
+
 # Optional daily spend cap for LLM calls in USD (e.g. 5.00); unset = no limit
 # LLM_DAILY_BUDGET_USD=5.00
 
@@ -121,8 +125,8 @@ DASHBOARD_LLM_MODEL=anthropic/claude-sonnet-4
 
 # Agentic tool-calling for generate/modify/analyze (defaults match production policy)
 # DASHBOARD_AGENTIC_TOOLS_ENABLED=true
-# DASHBOARD_AGENTIC_MAX_TOOL_ROUNDS=4
-# DASHBOARD_AGENTIC_MAX_TOOL_CALLS=12
+# DASHBOARD_AGENTIC_MAX_TOOL_ROUNDS=8
+# DASHBOARD_AGENTIC_MAX_TOOL_CALLS=24
 # DASHBOARD_AGENTIC_TOOL_TIMEOUT_MS=15000
 # DASHBOARD_AGENTIC_MAX_ROWS=200
 # DASHBOARD_AGENTIC_MAX_COLUMNS=30

--- a/dashboard/app/__tests__/helpers/stream-generate-mock.ts
+++ b/dashboard/app/__tests__/helpers/stream-generate-mock.ts
@@ -1,0 +1,65 @@
+/**
+ * Test helpers for POST /api/dashboard/generate with `{ stream: true }` (NDJSON body).
+ */
+
+export function mockJsonFetchOk(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  };
+}
+
+export function mockNdjsonGenerateSuccess(spec: Record<string, unknown>, requestId = "req_stream_test") {
+  const lines = [
+    JSON.stringify({
+      type: "meta",
+      requestId,
+      message: "Generación con IA iniciada",
+      promptPreview: "…",
+    }),
+    JSON.stringify({
+      type: "progress",
+      requestId,
+      event: { type: "round", round: 1, maxRounds: 8 },
+    }),
+    JSON.stringify({
+      type: "phase",
+      requestId,
+      message: "Validando JSON del panel…",
+    }),
+    JSON.stringify({ type: "result", requestId, spec }),
+  ].join("\n");
+
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({
+      "Content-Type": "application/x-ndjson; charset=utf-8",
+    }),
+    json: () => Promise.reject(new Error("NDJSON response — read body")),
+    body: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(`${lines}\n`));
+        controller.close();
+      },
+    }),
+  };
+}
+
+/** ReadableStream that never closes — for loading-state tests. */
+export function mockNdjsonGenerateHang() {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({
+      "Content-Type": "application/x-ndjson; charset=utf-8",
+    }),
+    json: () => Promise.reject(new Error("NDJSON stream")),
+    body: new ReadableStream({
+      start() {
+        /* intentionally never close */
+      },
+    }),
+  };
+}

--- a/dashboard/app/__tests__/new-page.test.tsx
+++ b/dashboard/app/__tests__/new-page.test.tsx
@@ -4,6 +4,11 @@ import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 import "@testing-library/jest-dom/vitest";
 import NewDashboard from "../dashboard/new/page";
 import type { DashboardSpec } from "@/lib/schema";
+import {
+  mockJsonFetchOk,
+  mockNdjsonGenerateSuccess,
+  mockNdjsonGenerateHang,
+} from "./helpers/stream-generate-mock";
 
 // ---------------------------------------------------------------------------
 // Mock next/navigation
@@ -84,26 +89,11 @@ describe("NewDashboard page", () => {
 
   it("generates and saves dashboard, then redirects", async () => {
     const fetchMock = vi.fn()
-      // data-health call from DataFreshnessBanner (no specific order guaranteed)
-      .mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ tables: [], overallStale: false, stalestTable: null }),
-      });
-
-    // Override specific calls for generate and save
-    fetchMock
+      .mockResolvedValueOnce(
+        mockJsonFetchOk({ tables: [], overallStale: false, stalestTable: null }),
+      )
+      .mockResolvedValueOnce(mockNdjsonGenerateSuccess(generatedSpec as unknown as Record<string, unknown>))
       .mockResolvedValueOnce({
-        // data-health
-        ok: true,
-        json: () => Promise.resolve({ tables: [], overallStale: false, stalestTable: null }),
-      })
-      .mockResolvedValueOnce({
-        // generate
-        ok: true,
-        json: () => Promise.resolve(generatedSpec),
-      })
-      .mockResolvedValueOnce({
-        // save
         ok: true,
         status: 201,
         json: () => Promise.resolve({ id: 42, ...generatedSpec }),
@@ -141,13 +131,24 @@ describe("NewDashboard page", () => {
     expect(generateCall![1]).toEqual(
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ prompt: "Ventas del mes" }),
+        body: JSON.stringify({ prompt: "Ventas del mes", stream: true }),
       }),
     );
   });
 
   it("shows loading spinner while generating", async () => {
-    globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    globalThis.fetch = vi.fn().mockImplementation((url: RequestInfo) => {
+      const u = typeof url === "string" ? url : String(url);
+      if (u.includes("data-health")) {
+        return Promise.resolve(
+          mockJsonFetchOk({ tables: [], overallStale: false, stalestTable: null }),
+        );
+      }
+      if (u.includes("/api/dashboard/generate")) {
+        return Promise.resolve(mockNdjsonGenerateHang());
+      }
+      return new Promise(() => {});
+    });
 
     render(<NewDashboard />);
     await act(async () => {
@@ -166,13 +167,32 @@ describe("NewDashboard page", () => {
     });
 
     expect(screen.getByText("Generando...")).toBeInTheDocument();
-    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Generando panel con IA" })).toBeInTheDocument();
   });
 
   it("shows error message on generation failure", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      json: () => Promise.resolve({ error: "LLM error: timeout" }),
+    globalThis.fetch = vi.fn().mockImplementation((url: RequestInfo) => {
+      const u = typeof url === "string" ? url : String(url);
+      if (u.includes("data-health")) {
+        return Promise.resolve(
+          mockJsonFetchOk({ tables: [], overallStale: false, stalestTable: null }),
+        );
+      }
+      if (u.includes("/api/dashboard/generate")) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          headers: new Headers({ "content-type": "application/json" }),
+          json: () =>
+            Promise.resolve({
+              error: "LLM error: timeout",
+              code: "LLM_ERROR",
+              timestamp: new Date().toISOString(),
+              requestId: "req_err_test",
+            }),
+        });
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
     });
 
     render(<NewDashboard />);
@@ -193,6 +213,10 @@ describe("NewDashboard page", () => {
 
     await waitFor(() => {
       expect(screen.getByText("LLM error: timeout")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Cerrar" }));
     });
 
     // Button should be re-enabled for retry

--- a/dashboard/app/__tests__/smart-creation.test.tsx
+++ b/dashboard/app/__tests__/smart-creation.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import NewDashboard from "../dashboard/new/page";
+import { mockNdjsonGenerateSuccess } from "./helpers/stream-generate-mock";
 
 // ---------------------------------------------------------------------------
 // Mock next/navigation
@@ -121,10 +122,7 @@ describe("NewDashboard page — smart creation sections", () => {
     };
 
     const fetchMock = vi.fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(generatedSpec),
-      })
+      .mockResolvedValueOnce(mockNdjsonGenerateSuccess(generatedSpec))
       .mockResolvedValueOnce({
         ok: true,
         status: 201,
@@ -230,10 +228,7 @@ describe("NewDashboard page — smart creation sections", () => {
         json: () => Promise.resolve({ suggestions: mockSuggestions }),
       })
       // POST /api/dashboard/generate
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(generatedSpec),
-      })
+      .mockResolvedValueOnce(mockNdjsonGenerateSuccess(generatedSpec))
       // POST /api/dashboards (save)
       .mockResolvedValueOnce({
         ok: true,
@@ -369,10 +364,7 @@ describe("NewDashboard page — smart creation sections", () => {
         json: () => Promise.resolve({ gaps: mockGaps }),
       })
       // POST /api/dashboard/generate
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(generatedSpec),
-      })
+      .mockResolvedValueOnce(mockNdjsonGenerateSuccess(generatedSpec))
       // POST /api/dashboards (save)
       .mockResolvedValueOnce({
         ok: true,

--- a/dashboard/app/admin/AdminChrome.tsx
+++ b/dashboard/app/admin/AdminChrome.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+const ADMIN_LINKS = [
+  { href: "/etl", label: "Monitor ETL" },
+  { href: "/admin/slow-queries", label: "Consultas lentas" },
+  { href: "/admin/tool-calls", label: "Herramientas LLM" },
+  { href: "/admin/usage", label: "Uso LLM" },
+] as const;
+
+export function AdminChrome({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  if (pathname === "/admin/login") {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-tremor-border bg-tremor-background-muted/60 p-4 dark:border-dark-tremor-border dark:bg-dark-tremor-background-muted/40">
+        <p className="text-xs font-medium uppercase tracking-wide text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+          Administración
+        </p>
+        <nav className="mt-3 flex flex-wrap gap-2" aria-label="Secciones de administración">
+          {ADMIN_LINKS.map(({ href, label }) => {
+            const active = pathname === href || (href !== "/etl" && pathname.startsWith(href));
+            return (
+              <Link
+                key={href}
+                href={href}
+                className={
+                  active
+                    ? "rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white dark:bg-blue-500"
+                    : "rounded-md border border-transparent px-3 py-1.5 text-sm font-medium text-tremor-content-emphasis hover:border-tremor-border hover:bg-tremor-background dark:text-dark-tremor-content-emphasis dark:hover:border-dark-tremor-border dark:hover:bg-dark-tremor-background-subtle"
+                }
+              >
+                {label}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/dashboard/app/admin/layout.tsx
+++ b/dashboard/app/admin/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { AdminChrome } from "./AdminChrome";
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return <AdminChrome>{children}</AdminChrome>;
+}

--- a/dashboard/app/admin/login/actions.ts
+++ b/dashboard/app/admin/login/actions.ts
@@ -14,10 +14,11 @@ export async function loginAdmin(formData: FormData): Promise<void> {
   }
 
   const jar = await cookies();
+  const secureFlag = process.env.ADMIN_COOKIE_SECURE === "true";
   jar.set("ps_admin", expected, {
     httpOnly: true,
     sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
+    secure: secureFlag,
     path: "/admin",
     maxAge: 60 * 60 * 8,
   });

--- a/dashboard/app/admin/slow-queries/page.tsx
+++ b/dashboard/app/admin/slow-queries/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { fetchSlowQueries } from "@/lib/admin-slow-queries";
 
 export const metadata = {
@@ -12,22 +11,9 @@ export default async function AdminSlowQueriesPage() {
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <h1 className="text-xl font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-          Consultas lentas (pg_stat_statements)
-        </h1>
-        <nav className="flex gap-3 text-sm">
-          <Link href="/admin/usage" className="text-blue-600 hover:underline dark:text-blue-400">
-            Uso LLM
-          </Link>
-          <Link href="/admin/tool-calls" className="text-blue-600 hover:underline dark:text-blue-400">
-            Herramientas LLM
-          </Link>
-          <Link href="/" className="text-tremor-content dark:text-dark-tremor-content hover:underline">
-            Inicio
-          </Link>
-        </nav>
-      </div>
+      <h1 className="text-xl font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+        Consultas lentas (pg_stat_statements)
+      </h1>
 
       {data.error && (
         <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">

--- a/dashboard/app/admin/tool-calls/page.tsx
+++ b/dashboard/app/admin/tool-calls/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { fetchToolCallAggregates } from "@/lib/llm-tools/logging";
 import { formatIntegerEs } from "@/lib/usage-number-format";
 
@@ -30,22 +29,9 @@ export default async function AdminToolCallsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <h1 className="text-xl font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-          Telemetría de herramientas (llm_tool_calls)
-        </h1>
-        <nav className="flex flex-wrap gap-3 text-sm">
-          <Link href="/admin/usage" className="text-blue-600 hover:underline dark:text-blue-400">
-            Uso LLM
-          </Link>
-          <Link href="/admin/slow-queries" className="text-blue-600 hover:underline dark:text-blue-400">
-            Consultas lentas
-          </Link>
-          <Link href="/" className="text-tremor-content dark:text-dark-tremor-content hover:underline">
-            Inicio
-          </Link>
-        </nav>
-      </div>
+      <h1 className="text-xl font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+        Telemetría de herramientas (llm_tool_calls)
+      </h1>
 
       <p className="text-sm text-tremor-content dark:text-dark-tremor-content">
         Ventana deslizante de <strong>30 días</strong>. Los totales de bytes son sumas aproximadas (PostgreSQL

--- a/dashboard/app/admin/usage/page.tsx
+++ b/dashboard/app/admin/usage/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { getLlmUsageAggregates } from "@/lib/llm-usage-stats";
 import { getDashboardLlmModel } from "@/lib/llm-model-config";
 import {
@@ -19,22 +18,9 @@ export default async function AdminUsagePage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <h1 className="text-xl font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-          Uso del modelo (llm_usage)
-        </h1>
-        <nav className="flex gap-3 text-sm">
-          <Link href="/admin/tool-calls" className="text-blue-600 hover:underline dark:text-blue-400">
-            Herramientas LLM
-          </Link>
-          <Link href="/admin/slow-queries" className="text-blue-600 hover:underline dark:text-blue-400">
-            Consultas lentas
-          </Link>
-          <Link href="/" className="text-tremor-content dark:text-dark-tremor-content hover:underline">
-            Inicio
-          </Link>
-        </nav>
-      </div>
+      <h1 className="text-xl font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+        Uso del modelo (llm_usage)
+      </h1>
 
       <section className="grid gap-4 sm:grid-cols-3">
         {(["today", "week", "month"] as const).map((period) => {

--- a/dashboard/app/api/dashboard/generate/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/generate/__tests__/route.test.ts
@@ -78,6 +78,36 @@ describe("POST /api/dashboard/generate", () => {
     expect(json.widgets[0].type).toBe("kpi_row");
   });
 
+  it("returns NDJSON with meta, progress tail, and result when stream: true", async () => {
+    mockGenerate.mockImplementation(async (_prompt, ctx) => {
+      ctx?.onAgenticProgress?.({
+        type: "round",
+        round: 1,
+        maxRounds: 8,
+      });
+      return JSON.stringify(VALID_SPEC);
+    });
+
+    const res = await POST(makeRequest({ prompt: "Ventas del mes", stream: true }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toContain("ndjson");
+
+    const text = await res.text();
+    const lines = text
+      .trim()
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+
+    const parsed = lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(parsed.some((o) => o.type === "meta")).toBe(true);
+    expect(parsed.some((o) => o.type === "progress")).toBe(true);
+    const resultLine = parsed.find((o) => o.type === "result");
+    expect(resultLine?.spec).toBeDefined();
+    expect((resultLine?.spec as { title?: string }).title).toBe("Ventas Marzo 2026");
+  });
+
   it("strips markdown code fences from LLM response", async () => {
     const wrapped = "```json\n" + JSON.stringify(VALID_SPEC) + "\n```";
     mockGenerate.mockResolvedValue(wrapped);

--- a/dashboard/app/api/dashboard/generate/route.ts
+++ b/dashboard/app/api/dashboard/generate/route.ts
@@ -1,11 +1,9 @@
 /**
  * POST /api/dashboard/generate
  *
- * Accepts a user prompt (Spanish) and returns an AI-generated dashboard spec.
- *
- * Request body: { prompt: string }
- * Success response (200): DashboardSpec JSON
- * Error responses: 400 (invalid input / invalid spec), 429 (rate limit), 500 (LLM error)
+ * Request body: { prompt: string, stream?: boolean }
+ * - stream false (default): success 200 = DashboardSpec JSON
+ * - stream true: `application/x-ndjson` — lines: meta, progress (×N), result | error
  */
 
 import { NextResponse } from "next/server";
@@ -15,7 +13,7 @@ import {
   CircuitBreakerOpenError,
   AgenticRunnerError,
 } from "@/lib/llm";
-import { validateSpec } from "@/lib/schema";
+import { validateSpec, type DashboardSpec } from "@/lib/schema";
 import { lintDashboardSpec } from "@/lib/sql-heuristics";
 import { ZodError } from "zod";
 import {
@@ -23,168 +21,58 @@ import {
   generateRequestId,
   sanitizeErrorMessage,
 } from "@/lib/errors";
+import type { AgenticProgressEvent } from "@/lib/llm-tools/types";
 
-/**
- * Extract JSON from an LLM response that may be wrapped in markdown code blocks.
- *
- * LLMs sometimes return:
- *   ```json
- *   { ... }
- *   ```
- * This strips the fences and returns the inner content.
- */
 function extractJson(raw: string): string {
   const trimmed = raw.trim();
-
-  // Match ```json ... ``` or ``` ... ```
   const fenceMatch = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```$/);
   if (fenceMatch) {
     return fenceMatch[1].trim();
   }
-
   return trimmed;
 }
 
-export async function POST(request: Request): Promise<NextResponse> {
-  const requestId = generateRequestId();
+type GenerateFinishOk = { ok: true; spec: DashboardSpec };
+type GenerateFinishErr = { ok: false; status: number; payload: Record<string, unknown> };
 
-  // --- Parse request body ---
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      formatApiError("Cuerpo JSON no válido.", "VALIDATION", undefined, requestId),
-      { status: 400 },
-    );
-  }
-
-  // --- Validate prompt ---
-  if (
-    typeof body !== "object" ||
-    body === null ||
-    !("prompt" in body) ||
-    typeof (body as Record<string, unknown>).prompt !== "string"
-  ) {
-    return NextResponse.json(
-      formatApiError(
-        "El cuerpo debe incluir un campo 'prompt' de tipo texto.",
-        "VALIDATION",
-        undefined,
-        requestId,
-      ),
-      { status: 400 },
-    );
-  }
-
-  const prompt = ((body as Record<string, unknown>).prompt as string).trim();
-  if (prompt.length === 0) {
-    return NextResponse.json(
-      formatApiError(
-        "El prompt no puede estar vacío.",
-        "VALIDATION",
-        undefined,
-        requestId,
-      ),
-      { status: 400 },
-    );
-  }
-
-  // --- Call LLM ---
-  let rawResponse: string;
-  try {
-    rawResponse = await generateDashboard(prompt, {
-      requestId,
-      endpoint: "generateDashboard",
-    });
-  } catch (err: unknown) {
-    if (err instanceof AgenticRunnerError) {
-      return NextResponse.json(
-        formatApiError(
-          "El flujo de IA con herramientas alcanzó un límite o no pudo completarse. Reformula el prompt o inténtalo de nuevo.",
-          "AGENTIC_RUNNER",
-          `${err.code}: ${err.message}`,
-          err.requestId,
-        ),
-        { status: 500 },
-      );
-    }
-    if (err instanceof BudgetExceededError) {
-      return NextResponse.json(
-        formatApiError(err.message, "LLM_BUDGET_EXCEEDED", undefined, requestId),
-        { status: 429 },
-      );
-    }
-    if (err instanceof CircuitBreakerOpenError) {
-      return NextResponse.json(
-        formatApiError(err.message, "LLM_CIRCUIT_OPEN", undefined, requestId),
-        { status: 503 },
-      );
-    }
-    const message = err instanceof Error ? err.message : String(err);
-    const normalizedMessage = message.toLowerCase();
-    console.error(`[${requestId}] Error al generar dashboard con LLM:`, err);
-
-    const isRateLimit =
-      normalizedMessage.includes("rate limit") ||
-      normalizedMessage.includes("ratelimit") ||
-      normalizedMessage.includes("429");
-
-    return NextResponse.json(
-      formatApiError(
-        isRateLimit
-          ? "Límite de uso del modelo de IA alcanzado. Inténtalo en unos minutos."
-          : "Error al generar el dashboard. Inténtalo de nuevo.",
-        isRateLimit ? "LLM_RATE_LIMIT" : "LLM_ERROR",
-        sanitizeErrorMessage(err),
-        requestId,
-      ),
-      { status: isRateLimit ? 429 : 500 },
-    );
-  }
-
-  // --- Parse JSON from LLM output ---
+function finishGenerateFromRawLlm(rawResponse: string, requestId: string): GenerateFinishOk | GenerateFinishErr {
   const jsonStr = extractJson(rawResponse);
   let parsed: unknown;
   try {
     parsed = JSON.parse(jsonStr);
   } catch {
-    console.error(
-      `[${requestId}] El LLM devolvió JSON inválido (${jsonStr.length} chars)`,
-    );
-    return NextResponse.json(
-      formatApiError(
+    console.error(`[${requestId}] El LLM devolvió JSON inválido (${jsonStr.length} chars)`);
+    return {
+      ok: false,
+      status: 400,
+      payload: formatApiError(
         "El modelo de IA devolvió una respuesta con formato incorrecto.",
         "LLM_INVALID_RESPONSE",
         undefined,
         requestId,
-      ),
-      { status: 400 },
-    );
+      ) as unknown as Record<string, unknown>,
+    };
   }
 
-  // --- Validate against DashboardSpec schema ---
   try {
     const spec = validateSpec(parsed);
     const sqlLint = lintDashboardSpec(spec);
     if (sqlLint.length > 0) {
-      console.error(
-        `[${requestId}] SQL heurístico rechazó el spec del LLM:`,
-        sqlLint.join(" | "),
-      );
-      return NextResponse.json(
-        {
+      console.error(`[${requestId}] SQL heurístico rechazó el spec del LLM:`, sqlLint.join(" | "));
+      return {
+        ok: false,
+        status: 400,
+        payload: {
           ...formatApiError(
             "El modelo generó SQL con patrones inválidos para PostgreSQL (fechas/EXTRACT/COALESCE). Vuelve a generar o reformula el prompt.",
             "SQL_LINT",
             sqlLint.join(" | "),
             requestId,
           ),
-        },
-        { status: 400 },
-      );
+        } as Record<string, unknown>,
+      };
     }
-    return NextResponse.json(spec, { status: 200 });
+    return { ok: true, spec };
   } catch (err: unknown) {
     const details =
       err instanceof ZodError
@@ -194,12 +82,12 @@ export async function POST(request: Request): Promise<NextResponse> {
     console.error(`[${requestId}] El LLM devolvió un spec inválido:`, details);
 
     const allowedFields =
-      err instanceof ZodError
-        ? resolveWidgetAllowedFields(err, parsed)
-        : undefined;
+      err instanceof ZodError ? resolveWidgetAllowedFields(err, parsed) : undefined;
 
-    return NextResponse.json(
-      {
+    return {
+      ok: false,
+      status: 400,
+      payload: {
         ...formatApiError(
           "El modelo de IA generó un dashboard con estructura incorrecta.",
           "LLM_INVALID_RESPONSE",
@@ -207,15 +95,70 @@ export async function POST(request: Request): Promise<NextResponse> {
           requestId,
         ),
         ...(allowedFields !== undefined ? { allowedFields } : {}),
-      },
-      { status: 400 },
-    );
+      } as Record<string, unknown>,
+    };
   }
 }
 
-// ---------------------------------------------------------------------------
-// Helpers for allowedFields enrichment
-// ---------------------------------------------------------------------------
+function logAgenticProgress(requestId: string, event: AgenticProgressEvent): void {
+  console.info(`[agentic][generateDashboard][${requestId}]`, JSON.stringify(event));
+}
+
+function mapGenerateLlmError(err: unknown, requestId: string): GenerateFinishErr {
+  if (err instanceof AgenticRunnerError) {
+    return {
+      ok: false,
+      status: 500,
+      payload: formatApiError(
+        "El flujo de IA con herramientas alcanzó un límite o no pudo completarse. Reformula el prompt o inténtalo de nuevo.",
+        "AGENTIC_RUNNER",
+        `${err.code}: ${err.message}`,
+        err.requestId,
+      ) as unknown as Record<string, unknown>,
+    };
+  }
+  if (err instanceof BudgetExceededError) {
+    return {
+      ok: false,
+      status: 429,
+      payload: formatApiError(err.message, "LLM_BUDGET_EXCEEDED", undefined, requestId) as unknown as Record<
+        string,
+        unknown
+      >,
+    };
+  }
+  if (err instanceof CircuitBreakerOpenError) {
+    return {
+      ok: false,
+      status: 503,
+      payload: formatApiError(err.message, "LLM_CIRCUIT_OPEN", undefined, requestId) as unknown as Record<
+        string,
+        unknown
+      >,
+    };
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  const normalizedMessage = message.toLowerCase();
+  console.error(`[${requestId}] Error al generar dashboard con LLM:`, err);
+
+  const isRateLimit =
+    normalizedMessage.includes("rate limit") ||
+    normalizedMessage.includes("ratelimit") ||
+    normalizedMessage.includes("429");
+
+  return {
+    ok: false,
+    status: isRateLimit ? 429 : 500,
+    payload: formatApiError(
+      isRateLimit
+        ? "Límite de uso del modelo de IA alcanzado. Inténtalo en unos minutos."
+        : "Error al generar el dashboard. Inténtalo de nuevo.",
+      isRateLimit ? "LLM_RATE_LIMIT" : "LLM_ERROR",
+      sanitizeErrorMessage(err),
+      requestId,
+    ) as unknown as Record<string, unknown>,
+  };
+}
 
 const WIDGET_ALLOWED_FIELDS: Record<string, string[]> = {
   kpi_row: ["id", "type", "items"],
@@ -227,26 +170,10 @@ const WIDGET_ALLOWED_FIELDS: Record<string, string[]> = {
   number: ["id", "type", "title", "sql", "format", "prefix"],
 };
 
-/**
- * When a ZodError path targets a widget (widgets.N, path length 2) or one of
- * its direct fields (widgets.N.<key>, path length 3), extract the widget type
- * from the parsed object and return the known allowed fields for that type.
- * Deeply nested errors (e.g. widgets.N.items.0.label, path length > 3) are
- * excluded — those belong to a sub-schema and the top-level allowed-fields
- * list would be misleading.
- */
-function resolveWidgetAllowedFields(
-  zodError: ZodError,
-  parsed: unknown,
-): string[] | undefined {
+function resolveWidgetAllowedFields(zodError: ZodError, parsed: unknown): string[] | undefined {
   for (const issue of zodError.issues) {
     const [seg0, seg1] = issue.path;
-    if (
-      seg0 !== "widgets" ||
-      typeof seg1 !== "number" ||
-      issue.path.length > 3
-    )
-      continue;
+    if (seg0 !== "widgets" || typeof seg1 !== "number" || issue.path.length > 3) continue;
 
     const widgetIndex = seg1;
     const parsedObj = parsed as Record<string, unknown> | null | undefined;
@@ -264,4 +191,128 @@ function resolveWidgetAllowedFields(
     if (Array.isArray(fields)) return fields;
   }
   return undefined;
+}
+
+export async function POST(request: Request): Promise<NextResponse | Response> {
+  const requestId = generateRequestId();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      formatApiError("Cuerpo JSON no válido.", "VALIDATION", undefined, requestId),
+      { status: 400 },
+    );
+  }
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !("prompt" in body) ||
+    typeof (body as Record<string, unknown>).prompt !== "string"
+  ) {
+    return NextResponse.json(
+      formatApiError(
+        "El cuerpo debe incluir un campo 'prompt' de tipo texto.",
+        "VALIDATION",
+        undefined,
+        requestId,
+      ),
+      { status: 400 },
+    );
+  }
+
+  const record = body as Record<string, unknown>;
+  const prompt = (record.prompt as string).trim();
+  if (prompt.length === 0) {
+    return NextResponse.json(
+      formatApiError("El prompt no puede estar vacío.", "VALIDATION", undefined, requestId),
+      { status: 400 },
+    );
+  }
+
+  const wantStream = record.stream === true;
+
+  if (wantStream) {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        const send = (obj: Record<string, unknown>) => {
+          controller.enqueue(encoder.encode(`${JSON.stringify(obj)}\n`));
+        };
+
+        send({
+          type: "meta",
+          requestId,
+          message: "Generación con IA iniciada",
+          promptPreview: prompt.slice(0, 200),
+        });
+
+        let rawResponse: string;
+        try {
+          rawResponse = await generateDashboard(prompt, {
+            requestId,
+            endpoint: "generateDashboard",
+            onAgenticProgress: (ev) => {
+              logAgenticProgress(requestId, ev);
+              send({ type: "progress", requestId, event: ev });
+            },
+          });
+        } catch (err: unknown) {
+          const mapped = mapGenerateLlmError(err, requestId);
+          send({
+            type: "error",
+            requestId,
+            httpStatus: mapped.status,
+            ...mapped.payload,
+          });
+          controller.close();
+          return;
+        }
+
+        send({ type: "phase", requestId, message: "Validando JSON del panel…" });
+        const finish = finishGenerateFromRawLlm(rawResponse, requestId);
+        if (!finish.ok) {
+          send({
+            type: "error",
+            requestId,
+            httpStatus: finish.status,
+            ...finish.payload,
+          });
+          controller.close();
+          return;
+        }
+
+        send({ type: "result", requestId, spec: finish.spec });
+        controller.close();
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "application/x-ndjson; charset=utf-8",
+        "Cache-Control": "no-store",
+        "X-Request-Id": requestId,
+      },
+    });
+  }
+
+  let rawResponse: string;
+  try {
+    rawResponse = await generateDashboard(prompt, {
+      requestId,
+      endpoint: "generateDashboard",
+      onAgenticProgress: (ev) => logAgenticProgress(requestId, ev),
+    });
+  } catch (err: unknown) {
+    const mapped = mapGenerateLlmError(err, requestId);
+    return NextResponse.json(mapped.payload, { status: mapped.status });
+  }
+
+  const finish = finishGenerateFromRawLlm(rawResponse, requestId);
+  if (!finish.ok) {
+    return NextResponse.json(finish.payload, { status: finish.status });
+  }
+  return NextResponse.json(finish.spec, { status: 200 });
 }

--- a/dashboard/app/dashboard/new/page.tsx
+++ b/dashboard/app/dashboard/new/page.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { useState, type KeyboardEvent } from "react";
+import { useState, type KeyboardEvent, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import type { DashboardSpec } from "@/lib/schema";
 import { TEMPLATES, type DashboardTemplate } from "@/lib/templates";
 import { TASK_PROMPTS } from "@/lib/task-prompts";
 import { DASHBOARD_ROLES } from "@/lib/dashboard-roles";
 import { DataFreshnessBanner } from "@/components/DataFreshnessBanner";
+import { DashboardGenerateProgressDialog } from "@/components/DashboardGenerateProgressDialog";
 import { ErrorDisplay } from "@/components/ErrorDisplay";
 import { isApiErrorResponse } from "@/lib/errors";
 import type { ApiErrorResponse } from "@/lib/errors";
+import { runDashboardGenerateStream } from "@/lib/run-dashboard-generate-stream";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -94,6 +96,20 @@ export default function NewDashboard() {
   const [gaps, setGaps] = useState<Gap[] | null>(null);
   const [gapsError, setGapsError] = useState<string | null>(null);
 
+  const [agenticOpen, setAgenticOpen] = useState(false);
+  const [agenticLines, setAgenticLines] = useState<string[]>([]);
+  const [agenticRequestId, setAgenticRequestId] = useState<string | null>(null);
+  const [agenticPhase, setAgenticPhase] = useState<"running" | "error" | "success">("running");
+  const [agenticErrorSummary, setAgenticErrorSummary] = useState<ReactNode>(null);
+
+  const dismissAgenticDialog = () => {
+    setAgenticOpen(false);
+    setAgenticLines([]);
+    setAgenticRequestId(null);
+    setAgenticPhase("running");
+    setAgenticErrorSummary(null);
+  };
+
   const getDashboardList = async (): Promise<DashboardListItem[]> => {
     if (cachedDashboardList !== null) {
       return cachedDashboardList;
@@ -143,32 +159,35 @@ export default function NewDashboard() {
     setLoading(true);
     setError(null);
     setLastErrorSource(null);
+    setAgenticOpen(true);
+    setAgenticLines([]);
+    setAgenticRequestId(null);
+    setAgenticPhase("running");
+    setAgenticErrorSummary(null);
 
     try {
-      const genRes = await fetch("/api/dashboard/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ prompt: trimmed }),
+      const spec = await runDashboardGenerateStream(trimmed, {
+        onMeta: (rid, lines) => {
+          setAgenticRequestId(rid);
+          setAgenticLines((prev) => [...prev, ...lines]);
+        },
+        onLine: (line) => {
+          setAgenticLines((prev) => [...prev, line]);
+        },
       });
 
-      if (!genRes.ok) {
-        const errBody = await genRes.json().catch(() => null);
-        if (isApiErrorResponse(errBody)) {
-          throw errBody;
-        }
-        throw new Error(
-          (errBody?.error as string) || "Error al generar el dashboard",
-        );
-      }
-
-      const spec: DashboardSpec = await genRes.json();
       const name = spec.title || "Dashboard sin título";
+      dismissAgenticDialog();
       await saveAndRedirect(name, spec.description || null, spec);
     } catch (err) {
+      setAgenticPhase("error");
       if (isApiErrorResponse(err)) {
         setError(err);
+        setAgenticErrorSummary(<ErrorDisplay error={err} />);
       } else {
-        setError(err instanceof Error ? err.message : "Error inesperado");
+        const msg = err instanceof Error ? err.message : "Error inesperado";
+        setError(msg);
+        setAgenticErrorSummary(<ErrorDisplay error={msg} />);
       }
       setLastErrorSource(source);
     } finally {
@@ -691,7 +710,7 @@ export default function NewDashboard() {
                 className="w-full resize-none rounded-lg border border-tremor-border bg-tremor-background px-4 py-3 text-sm text-tremor-content-emphasis placeholder:text-tremor-content-subtle focus:outline-none focus:ring-2 focus:ring-violet-500 disabled:opacity-50 dark:border-dark-tremor-border dark:bg-dark-tremor-background dark:text-dark-tremor-content-emphasis dark:placeholder:text-dark-tremor-content-subtle"
               />
 
-              {error && lastErrorSource === "generate" && (
+              {error && lastErrorSource === "generate" && !agenticOpen && (
                 <ErrorDisplay error={error} onRetry={handleGenerate} />
               )}
 
@@ -713,6 +732,16 @@ export default function NewDashboard() {
             </div>
         </div>
       </div>
+
+      <DashboardGenerateProgressDialog
+        open={agenticOpen}
+        title="Generando panel con IA"
+        requestId={agenticRequestId}
+        lines={agenticLines}
+        phase={agenticPhase}
+        errorSummary={agenticErrorSummary}
+        onDismiss={dismissAgenticDialog}
+      />
     </div>
   );
 }

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -32,23 +32,32 @@ function Sidebar() {
           >
             Revisión semanal
           </Link>
+          <div className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+            Administración
+          </div>
           <Link
             href="/etl"
-            className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
+            className="flex items-center rounded-md py-2 pl-6 pr-3 text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
           >
             Monitor ETL
           </Link>
           <Link
             href="/admin/slow-queries"
-            className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
+            className="flex items-center rounded-md py-2 pl-6 pr-3 text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
           >
-            Admin consultas
+            Consultas lentas
           </Link>
           <Link
             href="/admin/tool-calls"
-            className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
+            className="flex items-center rounded-md py-2 pl-6 pr-3 text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
           >
-            Admin herramientas
+            Herramientas LLM
+          </Link>
+          <Link
+            href="/admin/usage"
+            className="flex items-center rounded-md py-2 pl-6 pr-3 text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
+          >
+            Uso LLM
           </Link>
           <Link
             href="/dashboard/new"
@@ -92,19 +101,25 @@ function Sidebar() {
             href="/etl"
             className="text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
           >
-            ETL
+            Admin · ETL
           </Link>
           <Link
             href="/admin/slow-queries"
             className="text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
           >
-            Admin
+            Admin · SQL
           </Link>
           <Link
             href="/admin/tool-calls"
             className="text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
           >
-            Tools
+            Admin · Tools
+          </Link>
+          <Link
+            href="/admin/usage"
+            className="text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
+          >
+            Admin · Uso
           </Link>
           <Link
             href="/dashboard/new"

--- a/dashboard/components/DashboardGenerateProgressDialog.tsx
+++ b/dashboard/components/DashboardGenerateProgressDialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from "@headlessui/react";
+import type { ReactNode } from "react";
+
+export interface DashboardGenerateProgressDialogProps {
+  open: boolean;
+  title: string;
+  requestId: string | null;
+  lines: string[];
+  phase: "running" | "error" | "success";
+  errorSummary?: ReactNode | null;
+  onDismiss: () => void;
+}
+
+export function DashboardGenerateProgressDialog({
+  open,
+  title,
+  requestId,
+  lines,
+  phase,
+  errorSummary = null,
+  onDismiss,
+}: DashboardGenerateProgressDialogProps) {
+  return (
+    <Dialog open={open} onClose={() => {}} className="relative z-50">
+      <DialogBackdrop className="fixed inset-0 bg-black/40 backdrop-blur-[1px]" />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <DialogPanel className="w-full max-w-lg rounded-xl border border-tremor-border bg-tremor-background p-5 shadow-xl dark:border-dark-tremor-border dark:bg-dark-tremor-background">
+          <DialogTitle className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+            {title}
+          </DialogTitle>
+          {requestId ? (
+            <p className="mt-1 font-mono text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+              ID: {requestId}
+            </p>
+          ) : null}
+
+          <div
+            className="mt-4 max-h-72 overflow-y-auto rounded-lg border border-tremor-border bg-tremor-background-muted/80 p-3 font-mono text-xs leading-relaxed text-tremor-content dark:border-dark-tremor-border dark:bg-dark-tremor-background-muted/50 dark:text-dark-tremor-content"
+            role="log"
+            aria-live="polite"
+            aria-relevant="additions"
+          >
+            {lines.length === 0 ? (
+              <span className="text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                Iniciando…
+              </span>
+            ) : (
+              lines.map((line, i) => (
+                <div key={`${i}-${line.slice(0, 24)}`} className="whitespace-pre-wrap break-words">
+                  {line}
+                </div>
+              ))
+            )}
+          </div>
+
+          {phase === "error" && errorSummary ? (
+            <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900 dark:border-red-900/40 dark:bg-red-950/40 dark:text-red-100">
+              {errorSummary}
+            </div>
+          ) : null}
+
+          {phase !== "running" ? (
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                onClick={onDismiss}
+                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+              >
+                Cerrar
+              </button>
+            </div>
+          ) : (
+            <p className="mt-3 text-center text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+              Generando… puedes seguir el progreso arriba. Los mismos pasos se registran en el log
+              del servidor.
+            </p>
+          )}
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+}

--- a/dashboard/lib/__tests__/query-validator.test.ts
+++ b/dashboard/lib/__tests__/query-validator.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { validateQueryCost, QueryTooExpensiveError } from "../query-validator";
+import {
+  validateQueryCost,
+  QueryTooExpensiveError,
+  neutralizeNamedBindPlaceholdersForExplain,
+} from "../query-validator";
 
 vi.mock("@/lib/db", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/db")>();
@@ -53,6 +57,17 @@ function makeSeqScanPlan(totalCost: number, tableName: string): string {
     },
   ]);
 }
+
+describe("neutralizeNamedBindPlaceholdersForExplain", () => {
+  it("replaces Oracle-style :bind with NULL but keeps :: casts", () => {
+    const sql =
+      "SELECT * FROM ps_ventas WHERE fecha >= :from_date AND x::date = CURRENT_DATE";
+    const out = neutralizeNamedBindPlaceholdersForExplain(sql);
+    expect(out).toContain("NULL");
+    expect(out).toContain("::date");
+    expect(out).not.toMatch(/:from_date\b/);
+  });
+});
 
 describe("validateQueryCost", () => {
   beforeEach(() => {
@@ -110,6 +125,20 @@ describe("validateQueryCost", () => {
     expect(text).toContain("EXPLAIN (FORMAT JSON)");
     expect(text).toContain("SELECT * FROM ps_ventas WHERE id = $1");
     expect(values).toEqual([1]);
+  });
+
+  it("neutralizes :named binds in EXPLAIN so PostgreSQL accepts the plan query", async () => {
+    mockQuery.mockResolvedValueOnce({
+      columns: ["QUERY PLAN"],
+      rows: [[makePlan(50)]],
+    });
+    await validateQueryCost(
+      "SELECT 1 FROM ps_ventas WHERE reg_ventas > :min_id AND created::text IS NOT NULL",
+    );
+    const [text] = mockQuery.mock.calls[0] as [string];
+    expect(text).toContain("NULL");
+    expect(text).not.toContain(":min_id");
+    expect(text).toContain("::text");
   });
 
   it("does not throw when QUERY_COST_LIMIT is unset even for very high planner cost", async () => {

--- a/dashboard/lib/admin-slow-queries.ts
+++ b/dashboard/lib/admin-slow-queries.ts
@@ -59,6 +59,16 @@ export async function fetchSlowQueries(): Promise<SlowQueriesResponse> {
       };
     }
 
+    if (pgErr.code === "55000") {
+      return {
+        queries: [],
+        error:
+          "pg_stat_statements no está cargado en PostgreSQL (shared_preload_libraries). " +
+          "Reinicia Postgres con la opción de arranque del compose (p. ej. docker-compose.yml: " +
+          "shared_preload_libraries=pg_stat_statements) y crea la extensión si aplica.",
+      };
+    }
+
     console.error("[slow-queries] Unexpected error:", err);
     return { queries: [], error: "Internal server error" };
   }

--- a/dashboard/lib/format-agentic-progress.ts
+++ b/dashboard/lib/format-agentic-progress.ts
@@ -1,0 +1,23 @@
+import type { AgenticProgressEvent } from "@/lib/llm-tools/types";
+
+/** Human-readable line (Spanish) for dashboard generation UI + logs. */
+export function formatAgenticProgressLineEs(event: AgenticProgressEvent): string {
+  switch (event.type) {
+    case "round":
+      return `Ronda ${event.round}/${event.maxRounds} — llamada al modelo…`;
+    case "assistant_tools":
+      return `Herramientas solicitadas: ${event.tools.join(", ")}`;
+    case "tool_start":
+      return `  → ${event.name}…`;
+    case "tool_done": {
+      const icon = event.ok ? "✓" : "✗";
+      const err = event.errorCode ? ` (${event.errorCode})` : "";
+      return `  ${icon} ${event.name} — ${event.ms} ms${err}`;
+    }
+    case "finalizing":
+      return `Respuesta JSON lista (${event.messageChars} caracteres)`;
+    default: {
+      return JSON.stringify(event);
+    }
+  }
+}

--- a/dashboard/lib/llm-tools/config.ts
+++ b/dashboard/lib/llm-tools/config.ts
@@ -24,8 +24,9 @@ export function isAgenticToolsEnabled(): boolean {
 
 export function getAgenticConfig() {
   return {
-    maxToolRounds: readInt("DASHBOARD_AGENTIC_MAX_TOOL_ROUNDS", 4),
-    maxToolCalls: readInt("DASHBOARD_AGENTIC_MAX_TOOL_CALLS", 12),
+    // Dashboard generation often needs several explore→SQL rounds; defaults are conservative caps.
+    maxToolRounds: readInt("DASHBOARD_AGENTIC_MAX_TOOL_ROUNDS", 8),
+    maxToolCalls: readInt("DASHBOARD_AGENTIC_MAX_TOOL_CALLS", 24),
     toolTimeoutMs: readInt("DASHBOARD_AGENTIC_TOOL_TIMEOUT_MS", 15_000),
     maxRows: readInt("DASHBOARD_AGENTIC_MAX_ROWS", 200),
     maxColumns: readInt("DASHBOARD_AGENTIC_MAX_COLUMNS", 30),

--- a/dashboard/lib/llm-tools/runner.ts
+++ b/dashboard/lib/llm-tools/runner.ts
@@ -15,6 +15,7 @@ import {
   addUsage,
   type AgenticUsageTotals,
   type LlmAgenticContext,
+  type AgenticProgressEvent,
 } from "./types";
 import { stringifyToolPayload, toolError, type ToolResponseBody } from "./tool-payload";
 import {
@@ -116,6 +117,15 @@ async function dispatchTool(
 /**
  * Run a tool-augmented chat loop until the assistant returns plain text or limits hit.
  */
+function emitAgenticProgress(ctx: LlmAgenticContext, event: AgenticProgressEvent): void {
+  try {
+    ctx.onAgenticProgress?.(event);
+  } catch (hookErr) {
+    console.warn("[agentic] onAgenticProgress hook failed:", hookErr);
+  }
+  console.info(`[agentic][${ctx.endpoint}][${ctx.requestId}]`, JSON.stringify(event));
+}
+
 export async function runAgenticChat(
   params: AgenticRunParams,
 ): Promise<AgenticRunResult> {
@@ -134,6 +144,12 @@ export async function runAgenticChat(
   let toolCallsTotal = 0;
 
   for (let round = 0; round < cfg.maxToolRounds; round++) {
+    emitAgenticProgress(ctx, {
+      type: "round",
+      round: round + 1,
+      maxRounds: cfg.maxToolRounds,
+    });
+
     const completion = await client.chat.completions.create({
       model,
       messages,
@@ -164,8 +180,19 @@ export async function runAgenticChat(
           ctx.requestId,
         );
       }
+      emitAgenticProgress(ctx, { type: "finalizing", messageChars: text.length });
       return { content: text, usage };
     }
+
+    const toolNames = toolCalls.map((tc) => {
+      const fn = tc.type === "function" ? tc.function : null;
+      return fn?.name ?? "(missing)";
+    });
+    emitAgenticProgress(ctx, {
+      type: "assistant_tools",
+      round: round + 1,
+      tools: toolNames,
+    });
 
     messages.push(choice as ChatCompletionMessageParam);
 
@@ -182,6 +209,12 @@ export async function runAgenticChat(
       const fn = tc.type === "function" ? tc.function : null;
       const name = fn?.name ?? "";
       const rawArgs = fn?.arguments ?? "{}";
+      emitAgenticProgress(ctx, {
+        type: "tool_start",
+        round: round + 1,
+        name: name || "(missing)",
+        toolCallId: tc.id,
+      });
       const t0 = Date.now();
       let body: ToolResponseBody;
       let telemetryStatus: "ok" | "error" = "ok";
@@ -218,6 +251,16 @@ export async function runAgenticChat(
         latencyMs: latency,
         payloadInBytes: Buffer.byteLength(rawArgs, "utf8"),
         payloadOutBytes: Buffer.byteLength(payload, "utf8"),
+        errorCode,
+      });
+
+      emitAgenticProgress(ctx, {
+        type: "tool_done",
+        round: round + 1,
+        name: name || "(missing)",
+        toolCallId: tc.id,
+        ok: body.ok,
+        ms: latency,
         errorCode,
       });
 

--- a/dashboard/lib/llm-tools/types.ts
+++ b/dashboard/lib/llm-tools/types.ts
@@ -2,6 +2,22 @@
  * Shared types for the agentic LLM tool layer.
  */
 
+/** High-level events from the tool loop (UI streaming + server logs). */
+export type AgenticProgressEvent =
+  | { type: "round"; round: number; maxRounds: number }
+  | { type: "assistant_tools"; round: number; tools: string[] }
+  | { type: "tool_start"; round: number; name: string; toolCallId: string }
+  | {
+      type: "tool_done";
+      round: number;
+      name: string;
+      toolCallId: string;
+      ok: boolean;
+      ms: number;
+      errorCode?: string | null;
+    }
+  | { type: "finalizing"; messageChars: number };
+
 export interface LlmAgenticContext {
   /** API correlation id (also sent to the model in tool error payloads). */
   requestId: string;
@@ -9,6 +25,8 @@ export interface LlmAgenticContext {
   endpoint: string;
   /** Optional saved dashboard id (analyze flow) for dashboard-scoped tools. */
   dashboardId?: number;
+  /** Optional hook for NDJSON streaming UI and diagnostics. */
+  onAgenticProgress?: (event: AgenticProgressEvent) => void;
 }
 
 export interface AgenticUsageTotals {

--- a/dashboard/lib/llm.ts
+++ b/dashboard/lib/llm.ts
@@ -24,7 +24,7 @@ import type { LlmAgenticContext } from "./llm-tools/types";
 export { BudgetExceededError } from "./llm-usage";
 export { CircuitBreakerOpenError } from "./llm-circuit-breaker";
 export { AgenticRunnerError };
-export type { LlmAgenticContext };
+export type { LlmAgenticContext, AgenticProgressEvent } from "./llm-tools/types";
 
 const EMPTY_USAGE = {
   prompt_tokens: 0,

--- a/dashboard/lib/query-validator.ts
+++ b/dashboard/lib/query-validator.ts
@@ -59,6 +59,14 @@ function safeEquals(a: string, b: string): boolean {
   return timingSafeEqual(bufA, bufB);
 }
 
+/**
+ * Replace Oracle-style `:name` bind markers (invalid in PostgreSQL) with NULL so
+ * EXPLAIN can parse. Does not touch casts (`::type`).
+ */
+export function neutralizeNamedBindPlaceholdersForExplain(sql: string): string {
+  return sql.replace(/(?<!:):(?!:)([a-zA-Z_][\w]*)\b/g, "NULL");
+}
+
 export async function validateQueryCost(
   sql: string,
   options?: {
@@ -82,7 +90,7 @@ export async function validateQueryCost(
   }
 
   try {
-    const explainSql = `EXPLAIN (FORMAT JSON) ${sql}`; // safe: sql validated to start with SELECT/WITH above; validateReadOnly() also rejects semicolons and write keywords
+    const explainSql = `EXPLAIN (FORMAT JSON) ${neutralizeNamedBindPlaceholdersForExplain(sql)}`; // safe: sql validated to start with SELECT/WITH above; validateReadOnly() also rejects semicolons and write keywords
     const params = options?.params ?? [];
     const result =
       options?.statementTimeoutMs !== undefined

--- a/dashboard/lib/run-dashboard-generate-stream.ts
+++ b/dashboard/lib/run-dashboard-generate-stream.ts
@@ -1,0 +1,113 @@
+import type { DashboardSpec } from "@/lib/schema";
+import type { AgenticProgressEvent } from "@/lib/llm-tools/types";
+import { formatAgenticProgressLineEs } from "@/lib/format-agentic-progress";
+import {
+  isApiErrorResponse,
+  type ApiErrorResponse,
+  type ErrorCode,
+} from "@/lib/errors";
+
+export interface DashboardGenerateStreamHandlers {
+  onMeta?: (requestId: string, lines: string[]) => void;
+  onLine?: (line: string) => void;
+}
+
+/**
+ * Calls POST /api/dashboard/generate with `{ stream: true }` and consumes NDJSON
+ * until a `result` line. Falls back to a plain JSON body if the server returns
+ * `application/json` (older deployments).
+ */
+export async function runDashboardGenerateStream(
+  prompt: string,
+  handlers: DashboardGenerateStreamHandlers,
+): Promise<DashboardSpec> {
+  const res = await fetch("/api/dashboard/generate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ prompt, stream: true }),
+  });
+
+  const ct = res.headers.get("content-type") ?? "";
+
+  if (!res.ok) {
+    const data = (await res.json().catch(() => null)) as unknown;
+    if (isApiErrorResponse(data)) {
+      throw data;
+    }
+    throw new Error(
+      typeof data === "object" && data !== null && "error" in data
+        ? String((data as { error: unknown }).error)
+        : `HTTP ${res.status}`,
+    );
+  }
+
+  if (ct.includes("application/json")) {
+    return (await res.json()) as DashboardSpec;
+  }
+
+  const reader = res.body?.getReader();
+  if (!reader) {
+    throw new Error("No se pudo leer la respuesta del servidor");
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let finalSpec: DashboardSpec | null = null;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let nl: number;
+    while ((nl = buffer.indexOf("\n")) >= 0) {
+      const line = buffer.slice(0, nl).trim();
+      buffer = buffer.slice(nl + 1);
+      if (!line) continue;
+
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+
+      if (msg.type === "meta" && typeof msg.requestId === "string") {
+        const lines: string[] = [];
+        if (typeof msg.message === "string") lines.push(msg.message);
+        if (typeof msg.promptPreview === "string") {
+          lines.push(`Resumen del prompt: ${msg.promptPreview}`);
+        }
+        handlers.onMeta?.(msg.requestId, lines);
+      }
+
+      if (msg.type === "progress" && msg.event) {
+        handlers.onLine?.(formatAgenticProgressLineEs(msg.event as AgenticProgressEvent));
+      }
+
+      if (msg.type === "phase" && typeof msg.message === "string") {
+        handlers.onLine?.(String(msg.message));
+      }
+
+      if (msg.type === "result" && msg.spec) {
+        finalSpec = msg.spec as DashboardSpec;
+      }
+
+      if (msg.type === "error") {
+        const payload: ApiErrorResponse = {
+          error: String(msg.error ?? "Error"),
+          code:
+            typeof msg.code === "string" ? (msg.code as ErrorCode) : ("UNKNOWN" as ErrorCode),
+          ...(typeof msg.details === "string" ? { details: msg.details } : {}),
+          timestamp: typeof msg.timestamp === "string" ? msg.timestamp : new Date().toISOString(),
+          requestId: typeof msg.requestId === "string" ? msg.requestId : "",
+        };
+        throw payload;
+      }
+    }
+  }
+
+  if (!finalSpec) {
+    throw new Error("La generación terminó sin resultado del panel");
+  }
+  return finalSpec;
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,6 +28,7 @@ services:
   postgres:
     image: postgres:16-alpine
     restart: unless-stopped
+    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change_me_in_production}
@@ -219,6 +220,9 @@ services:
       POSTGRES_PORT: 5432
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       DASHBOARD_LLM_MODEL: ${DASHBOARD_LLM_MODEL:-anthropic/claude-sonnet-4}
+      ADMIN_API_KEY: ${ADMIN_API_KEY:-}
+      # Set true only behind HTTPS; on plain HTTP (e.g. LAN) leave unset so the admin cookie is stored.
+      ADMIN_COOKIE_SECURE: ${ADMIN_COOKIE_SECURE:-}
     ports:
       - "${HOST_BIND:-0.0.0.0}:${DASHBOARD_PORT:-4000}:4000"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,6 +221,7 @@ services:
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       DASHBOARD_LLM_MODEL: ${DASHBOARD_LLM_MODEL:-anthropic/claude-sonnet-4}
       ADMIN_API_KEY: ${ADMIN_API_KEY:-}
+      ADMIN_COOKIE_SECURE: ${ADMIN_COOKIE_SECURE:-}
     ports:
       - "${DASHBOARD_PORT:-4000}:4000"
     networks:

--- a/etl/db/postgres.py
+++ b/etl/db/postgres.py
@@ -349,6 +349,40 @@ def get_watermark(conn, table_name: str) -> datetime | None:
 # ---------------------------------------------------------------------------
 
 
+def fail_orphan_running_runs(conn) -> int:
+    """Mark every ``running`` row as ``failed`` (previous worker died or was replaced).
+
+    Safe only when a single ETL worker is expected. Call once at process startup
+    before ``create_run`` so restarts do not leave multiple ``running`` rows.
+    """
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE etl_sync_runs
+                   SET finished_at = NOW(),
+                       status = 'failed',
+                       duration_ms = COALESCE(
+                           duration_ms,
+                           (EXTRACT(EPOCH FROM (NOW() - started_at)) * 1000)::INTEGER
+                       ),
+                       tables_ok = COALESCE(tables_ok, 0),
+                       tables_failed = GREATEST(COALESCE(tables_failed, 0), 1),
+                       total_tables = COALESCE(
+                           total_tables,
+                           COALESCE(tables_ok, 0) + GREATEST(COALESCE(tables_failed, 0), 1)
+                       )
+                 WHERE status = 'running'
+                """
+            )
+            n = cur.rowcount
+        conn.commit()
+        return int(n)
+    except Exception:
+        conn.rollback()
+        raise
+
+
 def create_run(conn, trigger: str) -> int:
     """Insert an etl_sync_runs record with status='running' and return its id."""
     try:

--- a/etl/main.py
+++ b/etl/main.py
@@ -477,6 +477,21 @@ def main() -> None:
             pass
         sys.exit(1)
 
+    from etl.db.postgres import fail_orphan_running_runs
+
+    try:
+        n_orphan = fail_orphan_running_runs(conn_pg)
+        if n_orphan:
+            logger.warning(
+                "Reconciled %d orphan etl_sync_runs row(s) stuck in running — "
+                "likely a previous ETL process exited before finish_run",
+                n_orphan,
+            )
+    except Exception:
+        logger.exception(
+            "Could not reconcile orphan etl_sync_runs rows; continuing anyway"
+        )
+
     logger.info("Testing 4D connection to %s:%d ...", config.p4d_host, config.p4d_port)
     try:
         conn_4d = fourd.get_connection(config)

--- a/etl/tests/test_run_tracking.py
+++ b/etl/tests/test_run_tracking.py
@@ -68,6 +68,49 @@ class TestCreateRun:
             _cleanup_run(pg_conn, run_id)
 
 
+class TestFailOrphanRunningRuns:
+    @_requires_monitoring
+    def test_marks_all_running_rows_failed(self, pg_conn):
+        """fail_orphan_running_runs closes stuck running rows (e.g. after a worker crash)."""
+        _apply_monitoring_schema(pg_conn)
+        run_id_a = postgres.create_run(pg_conn, "scheduled")
+        run_id_b = postgres.create_run(pg_conn, "manual")
+        try:
+            n = postgres.fail_orphan_running_runs(pg_conn)
+            assert n == 2
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    "SELECT id, status, finished_at FROM etl_sync_runs WHERE id IN (%s, %s) ORDER BY id",
+                    (run_id_a, run_id_b),
+                )
+                rows = cur.fetchall()
+            assert len(rows) == 2
+            for _rid, status, finished_at in rows:
+                assert status == "failed"
+                assert finished_at is not None
+        finally:
+            _cleanup_run(pg_conn, run_id_a)
+            _cleanup_run(pg_conn, run_id_b)
+
+    @_requires_monitoring
+    def test_no_rows_updated_when_nothing_running(self, pg_conn):
+        _apply_monitoring_schema(pg_conn)
+        run_id = postgres.create_run(pg_conn, "scheduled")
+        try:
+            postgres.finish_run(
+                pg_conn,
+                run_id,
+                "success",
+                tables_ok=1,
+                tables_failed=0,
+                total_rows_synced=0,
+            )
+            n = postgres.fail_orphan_running_runs(pg_conn)
+            assert n == 0
+        finally:
+            _cleanup_run(pg_conn, run_id)
+
+
 class TestFinishRun:
     @_requires_monitoring
     def test_finish_run_updates_status(self, pg_conn):


### PR DESCRIPTION
## Summary
- **Admin over HTTP**: `ADMIN_COOKIE_SECURE` (default off) so the admin cookie is not `Secure` unless explicitly enabled; unified Administración navigation; prod Postgres `pg_stat_statements` preload; `55000` slow-queries message.
- **ETL**: `fail_orphan_running_runs` on startup to clear stuck `running` rows; tests added.
- **AI dashboard generation**: higher default agentic limits (8 rounds / 24 tool calls); NDJSON stream + progress dialog on **Nuevo dashboard**; structured `[agentic][generateDashboard][requestId]` server logs.
- **EXPLAIN / query validator**: neutralize Oracle `:bind` placeholders for PostgreSQL EXPLAIN (fixes log noise `syntax error at or near ":"`).

## Verification
- `cd dashboard && npm test && npm run build`

## Ops
- After pulling compose changes, restart Postgres so `shared_preload_libraries` applies; set `ADMIN_COOKIE_SECURE=true` only behind HTTPS.


Made with [Cursor](https://cursor.com)