### PR TITLE
Dashboard version history with restore UI (#391)

### DIFF
--- a/dashboard/app/api/dashboard/[id]/restore/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/[id]/restore/__tests__/route.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPoolQuery = vi.fn();
+const mockEnd = vi.fn().mockResolvedValue(undefined);
+const mockClientQuery = vi.fn();
+const mockClientRelease = vi.fn();
+
+vi.mock("pg", () => {
+  return {
+    Pool: class MockPool {
+      query = mockPoolQuery;
+      end = mockEnd;
+      connect = vi.fn().mockResolvedValue({
+        query: mockClientQuery,
+        release: mockClientRelease,
+      });
+    },
+  };
+});
+
+import { POST } from "../route";
+import { resetPool } from "@/lib/db-write";
+import { NextRequest } from "next/server";
+
+const TARGET_SPEC = {
+  title: "Restored",
+  widgets: [{ type: "table" as const, title: "T", sql: "SELECT 1" }],
+};
+
+const CURRENT_SPEC = {
+  title: "Current",
+  widgets: [{ type: "table" as const, title: "T2", sql: "SELECT 2" }],
+};
+
+const RETURNING_ROW = {
+  id: 1,
+  name: "Sales",
+  description: null,
+  spec: TARGET_SPEC,
+  chat_messages_analyze: null,
+  created_at: "2026-04-01T10:00:00Z",
+  updated_at: "2026-04-18T12:00:00Z",
+};
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:4000/api/dashboard/1/restore", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/dashboard/[id]/restore", () => {
+  beforeEach(async () => {
+    mockPoolQuery.mockReset();
+    mockClientQuery.mockReset();
+    mockClientRelease.mockClear();
+    mockEnd.mockClear();
+    await resetPool();
+  });
+
+  it("restores spec, appends current spec as new version, and returns dashboard", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [{ id: 10, spec: TARGET_SPEC, version_number: 2 }],
+      }) // target version
+      .mockResolvedValueOnce({
+        rows: [{ spec: CURRENT_SPEC }],
+      }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // INSERT version
+      .mockResolvedValueOnce({ rows: [RETURNING_ROW] }) // UPDATE RETURNING
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await POST(makePostRequest({ version_id: 10 }), makeContext("1"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.spec).toEqual(TARGET_SPEC);
+
+    expect(mockClientQuery.mock.calls[0][0]).toBe("BEGIN");
+
+    const insertCall = mockClientQuery.mock.calls[3];
+    expect(insertCall[0]).toContain("INSERT INTO dashboard_versions");
+    expect(insertCall[1][0]).toBe(1);
+    expect(JSON.parse(insertCall[1][1] as string)).toEqual(CURRENT_SPEC);
+    expect(insertCall[1][2]).toBe("Restauración a versión 2");
+
+    const updateCall = mockClientQuery.mock.calls[4];
+    expect(updateCall[0]).toContain("UPDATE dashboards");
+    expect(JSON.parse(updateCall[1][0] as string)).toEqual(TARGET_SPEC);
+
+    expect(mockClientQuery.mock.calls[5][0]).toBe("COMMIT");
+    expect(mockClientRelease).toHaveBeenCalled();
+  });
+
+  it("returns 404 when version not found or wrong dashboard", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // target
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await POST(makePostRequest({ version_id: 99 }), makeContext("1"));
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.code).toBe("NOT_FOUND");
+    expect(mockClientQuery.mock.calls[2][0]).toBe("ROLLBACK");
+  });
+
+  it("returns 404 when dashboard row missing after version found", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ id: 10, spec: TARGET_SPEC, version_number: 1 }],
+      })
+      .mockResolvedValueOnce({ rows: [] }) // dashboard missing
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await POST(makePostRequest({ version_id: 10 }), makeContext("1"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when version_id is missing", async () => {
+    const res = await POST(makePostRequest({}), makeContext("1"));
+    expect(res.status).toBe(400);
+    expect(mockClientRelease).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when version_id is not a positive integer", async () => {
+    const res = await POST(makePostRequest({ version_id: "10" }), makeContext("1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid dashboard id", async () => {
+    const res = await POST(makePostRequest({ version_id: 1 }), makeContext("abc"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const req = new NextRequest("http://localhost:4000/api/dashboard/1/restore", {
+      method: "POST",
+      body: "not json",
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req, makeContext("1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 on database error", async () => {
+    mockClientQuery.mockRejectedValue(new Error("db error"));
+
+    const res = await POST(makePostRequest({ version_id: 1 }), makeContext("1"));
+    expect(res.status).toBe(500);
+    expect(mockClientRelease).toHaveBeenCalled();
+  });
+});

--- a/dashboard/app/api/dashboard/[id]/restore/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/[id]/restore/__tests__/route.test.ts
@@ -136,6 +136,48 @@ describe("POST /api/dashboard/[id]/restore", () => {
     expect(res.status).toBe(400);
   });
 
+  it("returns 400 when stored spec fails schema validation", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ id: 10, spec: { title: "Sin widgets" }, version_number: 1 }],
+      })
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await POST(makePostRequest({ version_id: 10 }), makeContext("1"));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.code).toBe("VALIDATION");
+    expect(mockClientQuery.mock.calls[2][0]).toBe("ROLLBACK");
+  });
+
+  it("returns 400 when stored spec fails SQL lint", async () => {
+    const badLintSpec = {
+      title: "Lint",
+      widgets: [
+        {
+          type: "table" as const,
+          title: "T",
+          sql: "SELECT EXTRACT(days FROM CURRENT_DATE)",
+        },
+      ],
+    };
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ id: 10, spec: badLintSpec, version_number: 1 }],
+      })
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await POST(makePostRequest({ version_id: 10 }), makeContext("1"));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.code).toBe("SQL_LINT");
+    expect(mockClientQuery.mock.calls[2][0]).toBe("ROLLBACK");
+  });
+
   it("returns 400 for invalid dashboard id", async () => {
     const res = await POST(makePostRequest({ version_id: 1 }), makeContext("abc"));
     expect(res.status).toBe(400);

--- a/dashboard/app/api/dashboard/[id]/restore/route.ts
+++ b/dashboard/app/api/dashboard/[id]/restore/route.ts
@@ -1,0 +1,205 @@
+/**
+ * POST /api/dashboard/[id]/restore — Restore a prior spec (append-only history).
+ *
+ * Saves the current spec as a new version row, then sets dashboards.spec to the
+ * target version's spec. Returns the updated dashboard (same shape as GET).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getPool } from "@/lib/db-write";
+import {
+  formatApiError,
+  generateRequestId,
+  sanitizeErrorMessage,
+} from "@/lib/errors";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+function parseId(raw: string): number | null {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) return null;
+  return n;
+}
+
+export async function POST(
+  request: NextRequest,
+  context: RouteContext,
+): Promise<NextResponse> {
+  const requestId = generateRequestId();
+  const { id: rawId } = await context.params;
+  const dashboardId = parseId(rawId);
+  if (dashboardId === null) {
+    return NextResponse.json(
+      formatApiError(
+        "El identificador del dashboard no es válido (debe ser un entero positivo).",
+        "VALIDATION",
+        undefined,
+        requestId,
+      ),
+      { status: 400 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      formatApiError("Cuerpo JSON no válido.", "VALIDATION", undefined, requestId),
+      { status: 400 },
+    );
+  }
+
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return NextResponse.json(
+      formatApiError(
+        "El cuerpo JSON debe ser un objeto.",
+        "VALIDATION",
+        undefined,
+        requestId,
+      ),
+      { status: 400 },
+    );
+  }
+
+  const versionId = (body as { version_id?: unknown }).version_id;
+  if (
+    typeof versionId !== "number" ||
+    !Number.isInteger(versionId) ||
+    versionId <= 0
+  ) {
+    return NextResponse.json(
+      formatApiError(
+        "El campo 'version_id' debe ser un entero positivo.",
+        "VALIDATION",
+        undefined,
+        requestId,
+      ),
+      { status: 400 },
+    );
+  }
+
+  let client;
+  try {
+    client = await getPool().connect();
+  } catch (err) {
+    console.error(
+      `[${requestId}] Error de conexión al restaurar dashboard ${dashboardId}:`,
+      err,
+    );
+    return NextResponse.json(
+      formatApiError(
+        "No se pudo conectar a la base de datos. Inténtalo de nuevo.",
+        "DB_CONNECTION",
+        sanitizeErrorMessage(err),
+        requestId,
+      ),
+      { status: 503 },
+    );
+  }
+
+  try {
+    await client.query("BEGIN");
+
+    const targetResult = await client.query<{
+      id: number;
+      spec: unknown;
+      version_number: string | number;
+    }>(
+      `SELECT id, spec, version_number
+       FROM (
+         SELECT id,
+                spec,
+                ROW_NUMBER() OVER (PARTITION BY dashboard_id ORDER BY created_at) AS version_number
+         FROM dashboard_versions
+         WHERE dashboard_id = $1
+       ) sub
+       WHERE id = $2`,
+      [dashboardId, versionId],
+    );
+
+    if (targetResult.rows.length === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        formatApiError(
+          "Versión no encontrada.",
+          "NOT_FOUND",
+          "La versión indicada no existe o no pertenece a este dashboard.",
+          requestId,
+        ),
+        { status: 404 },
+      );
+    }
+
+    const targetRow = targetResult.rows[0];
+    const versionNumber = Number(targetRow.version_number);
+
+    const existingResult = await client.query<{ spec: unknown }>(
+      `SELECT spec FROM dashboards WHERE id = $1 FOR UPDATE`,
+      [dashboardId],
+    );
+
+    if (existingResult.rows.length === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        formatApiError(
+          "Dashboard no encontrado.",
+          "NOT_FOUND",
+          `No existe ningún dashboard con ID ${dashboardId}.`,
+          requestId,
+        ),
+        { status: 404 },
+      );
+    }
+
+    const currentSpec = existingResult.rows[0].spec;
+
+    await client.query(
+      `INSERT INTO dashboard_versions (dashboard_id, spec, prompt)
+       VALUES ($1, $2, $3)`,
+      [
+        dashboardId,
+        JSON.stringify(currentSpec),
+        `Restauración a versión ${versionNumber}`,
+      ],
+    );
+
+    const updateResult = await client.query(
+      `UPDATE dashboards
+       SET spec = $1, updated_at = NOW()
+       WHERE id = $2
+       RETURNING id, name, description, spec, chat_messages_analyze, created_at, updated_at`,
+      [JSON.stringify(targetRow.spec), dashboardId],
+    );
+
+    await client.query("COMMIT");
+
+    if (updateResult.rows.length === 0) {
+      return NextResponse.json(
+        formatApiError(
+          "Dashboard no encontrado.",
+          "NOT_FOUND",
+          `No existe ningún dashboard con ID ${dashboardId}.`,
+          requestId,
+        ),
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(updateResult.rows[0]);
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    console.error(`[${requestId}] Error al restaurar dashboard ${dashboardId}:`, err);
+    return NextResponse.json(
+      formatApiError(
+        "No se pudo restaurar la versión. Inténtalo de nuevo.",
+        "DB_QUERY",
+        sanitizeErrorMessage(err),
+        requestId,
+      ),
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+  }
+}

--- a/dashboard/app/api/dashboard/[id]/restore/route.ts
+++ b/dashboard/app/api/dashboard/[id]/restore/route.ts
@@ -6,12 +6,15 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { ZodError } from "zod";
 import { getPool } from "@/lib/db-write";
 import {
   formatApiError,
   generateRequestId,
   sanitizeErrorMessage,
 } from "@/lib/errors";
+import { validateSpec } from "@/lib/schema";
+import { lintDashboardSpec } from "@/lib/sql-heuristics";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -110,7 +113,9 @@ export async function POST(
        FROM (
          SELECT id,
                 spec,
-                ROW_NUMBER() OVER (PARTITION BY dashboard_id ORDER BY created_at) AS version_number
+                ROW_NUMBER() OVER (
+                  PARTITION BY dashboard_id ORDER BY created_at ASC, id ASC
+                ) AS version_number
          FROM dashboard_versions
          WHERE dashboard_id = $1
        ) sub
@@ -133,6 +138,39 @@ export async function POST(
 
     const targetRow = targetResult.rows[0];
     const versionNumber = Number(targetRow.version_number);
+
+    let validatedSpec: ReturnType<typeof validateSpec>;
+    try {
+      validatedSpec = validateSpec(targetRow.spec);
+    } catch (err) {
+      await client.query("ROLLBACK");
+      if (err instanceof ZodError) {
+        return NextResponse.json(
+          formatApiError(
+            "La versión seleccionada no cumple el esquema actual del dashboard.",
+            "VALIDATION",
+            err.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
+            requestId,
+          ),
+          { status: 400 },
+        );
+      }
+      throw err;
+    }
+
+    const sqlLint = lintDashboardSpec(validatedSpec);
+    if (sqlLint.length > 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        formatApiError(
+          "Las consultas SQL de la versión restaurada contienen patrones inválidos para PostgreSQL.",
+          "SQL_LINT",
+          sqlLint.join(" | "),
+          requestId,
+        ),
+        { status: 400 },
+      );
+    }
 
     const existingResult = await client.query<{ spec: unknown }>(
       `SELECT spec FROM dashboards WHERE id = $1 FOR UPDATE`,
@@ -169,7 +207,7 @@ export async function POST(
        SET spec = $1, updated_at = NOW()
        WHERE id = $2
        RETURNING id, name, description, spec, chat_messages_analyze, created_at, updated_at`,
-      [JSON.stringify(targetRow.spec), dashboardId],
+      [JSON.stringify(validatedSpec), dashboardId],
     );
 
     await client.query("COMMIT");

--- a/dashboard/app/api/dashboard/[id]/versions/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/[id]/versions/__tests__/route.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPoolQuery = vi.fn();
+const mockEnd = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("pg", () => {
+  return {
+    Pool: class MockPool {
+      query = mockPoolQuery;
+      end = mockEnd;
+      connect = vi.fn();
+    },
+  };
+});
+
+import { GET } from "../route";
+import { resetPool } from "@/lib/db-write";
+import { NextRequest } from "next/server";
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function makeRequest(): NextRequest {
+  return new NextRequest("http://localhost:4000/api/dashboard/1/versions", {
+    method: "GET",
+  });
+}
+
+describe("GET /api/dashboard/[id]/versions", () => {
+  beforeEach(async () => {
+    mockPoolQuery.mockReset();
+    mockEnd.mockClear();
+    await resetPool();
+  });
+
+  it("returns version list when dashboard exists", async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 3,
+            version_number: 3,
+            prompt: "Añade el margen por familia",
+            widget_count: 5,
+            created_at: new Date("2026-04-18T10:23:00.000Z"),
+          },
+          {
+            id: 2,
+            version_number: 2,
+            prompt: null,
+            widget_count: 2,
+            created_at: new Date("2026-04-17T10:00:00.000Z"),
+          },
+        ],
+      });
+
+    const res = await GET(makeRequest(), makeContext("1"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(json)).toBe(true);
+    expect(json).toHaveLength(2);
+    expect(json[0].id).toBe(3);
+    expect(json[0].version_number).toBe(3);
+    expect(json[0].widget_count).toBe(5);
+    expect(json[0].created_at).toBe("2026-04-18T10:23:00.000Z");
+    expect(mockPoolQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns empty array when dashboard exists but has no versions", async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await GET(makeRequest(), makeContext("1"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual([]);
+  });
+
+  it("returns 404 when dashboard not found", async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await GET(makeRequest(), makeContext("999"));
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.code).toBe("NOT_FOUND");
+    expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 400 for invalid ID", async () => {
+    const res = await GET(makeRequest(), makeContext("abc"));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.code).toBe("VALIDATION");
+    expect(mockPoolQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for zero ID", async () => {
+    const res = await GET(makeRequest(), makeContext("0"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 on database error", async () => {
+    mockPoolQuery.mockRejectedValue(new Error("db down"));
+
+    const res = await GET(makeRequest(), makeContext("1"));
+    expect(res.status).toBe(500);
+  });
+});

--- a/dashboard/app/api/dashboard/[id]/versions/route.ts
+++ b/dashboard/app/api/dashboard/[id]/versions/route.ts
@@ -1,0 +1,107 @@
+/**
+ * GET /api/dashboard/[id]/versions — List saved spec versions (newest first).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@/lib/db-write";
+import {
+  formatApiError,
+  generateRequestId,
+  sanitizeErrorMessage,
+} from "@/lib/errors";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+function parseId(raw: string): number | null {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) return null;
+  return n;
+}
+
+export async function GET(
+  _request: NextRequest,
+  context: RouteContext,
+): Promise<NextResponse> {
+  const requestId = generateRequestId();
+  const { id: rawId } = await context.params;
+  const id = parseId(rawId);
+  if (id === null) {
+    return NextResponse.json(
+      formatApiError(
+        "El identificador del dashboard no es válido (debe ser un entero positivo).",
+        "VALIDATION",
+        undefined,
+        requestId,
+      ),
+      { status: 400 },
+    );
+  }
+
+  try {
+    const dash = await sql<{ id: number }>(
+      `SELECT id FROM dashboards WHERE id = $1`,
+      [id],
+    );
+    if (dash.length === 0) {
+      return NextResponse.json(
+        formatApiError(
+          "Dashboard no encontrado.",
+          "NOT_FOUND",
+          `No existe ningún dashboard con ID ${id}.`,
+          requestId,
+        ),
+        { status: 404 },
+      );
+    }
+
+    const rows = await sql<{
+      id: number;
+      version_number: number;
+      prompt: string | null;
+      widget_count: number;
+      created_at: Date;
+    }>(
+      `WITH ranked AS (
+         SELECT id,
+                spec,
+                prompt,
+                created_at,
+                ROW_NUMBER() OVER (PARTITION BY dashboard_id ORDER BY created_at) AS version_number
+         FROM dashboard_versions
+         WHERE dashboard_id = $1
+       )
+       SELECT id,
+              version_number,
+              prompt,
+              COALESCE(jsonb_array_length(spec->'widgets'), 0)::int AS widget_count,
+              created_at
+       FROM ranked
+       ORDER BY created_at DESC`,
+      [id],
+    );
+
+    const payload = rows.map((r) => ({
+      id: r.id,
+      version_number: r.version_number,
+      prompt: r.prompt,
+      widget_count: r.widget_count,
+      created_at:
+        r.created_at instanceof Date
+          ? r.created_at.toISOString()
+          : String(r.created_at),
+    }));
+
+    return NextResponse.json(payload);
+  } catch (err) {
+    console.error(`[${requestId}] Error al listar versiones del dashboard ${id}:`, err);
+    return NextResponse.json(
+      formatApiError(
+        "No se pudo cargar el historial de versiones. Inténtalo de nuevo.",
+        "DB_QUERY",
+        sanitizeErrorMessage(err),
+        requestId,
+      ),
+      { status: 500 },
+    );
+  }
+}

--- a/dashboard/app/api/dashboard/[id]/versions/route.ts
+++ b/dashboard/app/api/dashboard/[id]/versions/route.ts
@@ -61,22 +61,28 @@ export async function GET(
       widget_count: number;
       created_at: Date;
     }>(
-      `WITH ranked AS (
+      `       WITH ranked AS (
          SELECT id,
                 spec,
                 prompt,
                 created_at,
-                ROW_NUMBER() OVER (PARTITION BY dashboard_id ORDER BY created_at) AS version_number
+                ROW_NUMBER() OVER (
+                  PARTITION BY dashboard_id ORDER BY created_at ASC, id ASC
+                ) AS version_number
          FROM dashboard_versions
          WHERE dashboard_id = $1
        )
        SELECT id,
               version_number,
               prompt,
-              COALESCE(jsonb_array_length(spec->'widgets'), 0)::int AS widget_count,
+              CASE
+                WHEN jsonb_typeof(spec -> 'widgets') = 'array'
+                  THEN jsonb_array_length(spec -> 'widgets')
+                ELSE 0
+              END::int AS widget_count,
               created_at
        FROM ranked
-       ORDER BY created_at DESC`,
+       ORDER BY created_at DESC, id DESC`,
       [id],
     );
 

--- a/dashboard/app/api/dashboard/[id]/versions/route.ts
+++ b/dashboard/app/api/dashboard/[id]/versions/route.ts
@@ -18,6 +18,19 @@ function parseId(raw: string): number | null {
   return n;
 }
 
+/** `pg` may return int8 as string without custom parsers — normalize for JSON. */
+function toVersionNumber(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) return 1;
+  return n;
+}
+
+function toWidgetCount(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) return 0;
+  return n;
+}
+
 export async function GET(
   _request: NextRequest,
   context: RouteContext,
@@ -56,12 +69,12 @@ export async function GET(
 
     const rows = await sql<{
       id: number;
-      version_number: number;
+      version_number: number | string;
       prompt: string | null;
-      widget_count: number;
+      widget_count: number | string;
       created_at: Date;
     }>(
-      `       WITH ranked AS (
+      `WITH ranked AS (
          SELECT id,
                 spec,
                 prompt,
@@ -73,7 +86,7 @@ export async function GET(
          WHERE dashboard_id = $1
        )
        SELECT id,
-              version_number,
+              version_number::int AS version_number,
               prompt,
               CASE
                 WHEN jsonb_typeof(spec -> 'widgets') = 'array'
@@ -88,9 +101,9 @@ export async function GET(
 
     const payload = rows.map((r) => ({
       id: r.id,
-      version_number: r.version_number,
+      version_number: toVersionNumber(r.version_number),
       prompt: r.prompt,
-      widget_count: r.widget_count,
+      widget_count: toWidgetCount(r.widget_count),
       created_at:
         r.created_at instanceof Date
           ? r.created_at.toISOString()

--- a/dashboard/app/dashboard/[id]/page.tsx
+++ b/dashboard/app/dashboard/[id]/page.tsx
@@ -12,6 +12,7 @@ import type { ChatMessage } from "@/components/ChatSidebar";
 import { DateRangePicker, computeComparisonRange } from "@/components/DateRangePicker";
 import type { DateRange, ComparisonRange } from "@/components/DateRangePicker";
 import { GlossaryPanel } from "@/components/GlossaryPanel";
+import { VersionHistory } from "@/components/VersionHistory";
 import { ErrorDisplay } from "@/components/ErrorDisplay";
 import { isApiErrorResponse } from "@/lib/errors";
 import type { DashboardSpec } from "@/lib/schema";
@@ -98,6 +99,7 @@ export default function ViewDashboard() {
   const [notFound, setNotFound] = useState(false);
   const [chatOpen, setChatOpen] = useState(false);
   const [glossaryOpen, setGlossaryOpen] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
   const [widgetData, setWidgetData] = useState<Map<number, WidgetState>>(new Map());
   const [editingName, setEditingName] = useState(false);
   const [nameValue, setNameValue] = useState("");
@@ -674,13 +676,35 @@ export default function ViewDashboard() {
             )}
           </div>
 
+          <button
+            type="button"
+            onClick={() =>
+              setHistoryOpen((prev) => {
+                const nextOpen = !prev;
+                if (nextOpen) {
+                  setChatOpen(false);
+                  setGlossaryOpen(false);
+                }
+                return nextOpen;
+              })
+            }
+            className="rounded-lg border border-tremor-border dark:border-dark-tremor-border px-3 py-2 text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle transition-colors"
+            aria-label={historyOpen ? "Cerrar historial" : "Abrir historial"}
+            data-testid="history-button"
+          >
+            Historial
+          </button>
+
           {/* Glosario button — only shown when glossary has entries */}
           {dashboard.spec.glossary && dashboard.spec.glossary.length > 0 && (
             <button
               onClick={() =>
                 setGlossaryOpen((prev) => {
                   const nextOpen = !prev;
-                  if (nextOpen) setChatOpen(false);
+                  if (nextOpen) {
+                    setChatOpen(false);
+                    setHistoryOpen(false);
+                  }
                   return nextOpen;
                 })
               }
@@ -708,7 +732,17 @@ export default function ViewDashboard() {
             Guardar
           </button>
           <button
-            onClick={() => setChatOpen((prev) => !prev)}
+            type="button"
+            onClick={() =>
+              setChatOpen((prev) => {
+                const nextOpen = !prev;
+                if (nextOpen) {
+                  setGlossaryOpen(false);
+                  setHistoryOpen(false);
+                }
+                return nextOpen;
+              })
+            }
             className="rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-600 transition-colors"
           >
             {chatOpen ? "Cerrar chat" : "Modificar"}
@@ -748,7 +782,10 @@ export default function ViewDashboard() {
         onToggle={() =>
           setChatOpen((prev) => {
             const nextOpen = !prev;
-            if (nextOpen) setGlossaryOpen(false);
+            if (nextOpen) {
+              setGlossaryOpen(false);
+              setHistoryOpen(false);
+            }
             return nextOpen;
           })
         }
@@ -765,6 +802,16 @@ export default function ViewDashboard() {
           onClose={() => setGlossaryOpen(false)}
         />
       )}
+
+      <VersionHistory
+        dashboardId={dashboard.id}
+        isOpen={historyOpen}
+        onClose={() => setHistoryOpen(false)}
+        onRestore={(spec) => {
+          setDashboard((prev) => (prev ? { ...prev, spec } : prev));
+          setHistoryOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/dashboard/components/VersionHistory.tsx
+++ b/dashboard/components/VersionHistory.tsx
@@ -126,10 +126,17 @@ export function VersionHistory({
         setError(msg);
         return;
       }
-      const record = data as { spec: DashboardSpec };
-      if (record && record.spec && typeof record.spec === "object") {
-        onRestore(record.spec);
+      if (
+        !data ||
+        typeof data !== "object" ||
+        !("spec" in data) ||
+        !data.spec ||
+        typeof data.spec !== "object"
+      ) {
+        setError("Respuesta del servidor no válida.");
+        return;
       }
+      onRestore(data.spec as DashboardSpec);
     } catch {
       setError("Error de red al restaurar.");
     } finally {

--- a/dashboard/components/VersionHistory.tsx
+++ b/dashboard/components/VersionHistory.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+/**
+ * VersionHistory — slide-out listing dashboard spec versions with restore.
+ */
+
+import { useEffect, useCallback, useState } from "react";
+import type { DashboardSpec } from "@/lib/schema";
+import { isApiErrorResponse } from "@/lib/errors";
+
+export interface VersionHistoryProps {
+  dashboardId: number;
+  isOpen: boolean;
+  onClose: () => void;
+  onRestore: (spec: DashboardSpec) => void;
+}
+
+interface VersionRow {
+  id: number;
+  version_number: number;
+  prompt: string | null;
+  widget_count: number;
+  created_at: string;
+}
+
+function formatRelativePast(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diffSec = Math.round((then - now) / 1000);
+  const rtf = new Intl.RelativeTimeFormat("es", { numeric: "auto" });
+  const absSec = Math.abs(diffSec);
+  if (absSec < 60) return rtf.format(diffSec, "second");
+  if (absSec < 3600) return rtf.format(Math.round(diffSec / 60), "minute");
+  if (absSec < 86400) return rtf.format(Math.round(diffSec / 3600), "hour");
+  if (absSec < 604800) return rtf.format(Math.round(diffSec / 86400), "day");
+  if (absSec < 2_592_000) return rtf.format(Math.round(diffSec / 604800), "week");
+  if (absSec < 31_536_000) return rtf.format(Math.round(diffSec / 2_592_000), "month");
+  return rtf.format(Math.round(diffSec / 31_536_000), "year");
+}
+
+function truncatePrompt(text: string | null, max = 80): string {
+  const s = (text ?? "").trim();
+  if (s.length <= max) return s || "—";
+  return `${s.slice(0, max)}…`;
+}
+
+export function VersionHistory({
+  dashboardId,
+  isOpen,
+  onClose,
+  onRestore,
+}: VersionHistoryProps) {
+  const [rows, setRows] = useState<VersionRow[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [restoringId, setRestoringId] = useState<number | null>(null);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+    }
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, handleKeyDown]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setRows(null);
+
+    (async () => {
+      try {
+        const res = await fetch(`/api/dashboard/${dashboardId}/versions`);
+        const data: unknown = await res.json();
+        if (!res.ok) {
+          const msg =
+            isApiErrorResponse(data) && typeof data.error === "string"
+              ? data.error
+              : "No se pudo cargar el historial.";
+          if (!cancelled) setError(msg);
+          return;
+        }
+        if (!Array.isArray(data)) {
+          if (!cancelled) setError("Respuesta del servidor no válida.");
+          return;
+        }
+        if (!cancelled) setRows(data as VersionRow[]);
+      } catch {
+        if (!cancelled) setError("Error de red al cargar el historial.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, dashboardId]);
+
+  async function handleRestore(versionId: number) {
+    setRestoringId(versionId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/dashboard/${dashboardId}/restore`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ version_id: versionId }),
+      });
+      const data: unknown = await res.json();
+      if (!res.ok) {
+        const msg =
+          isApiErrorResponse(data) && typeof data.error === "string"
+            ? data.error
+            : "No se pudo restaurar la versión.";
+        setError(msg);
+        return;
+      }
+      const record = data as { spec: DashboardSpec };
+      if (record && record.spec && typeof record.spec === "object") {
+        onRestore(record.spec);
+      }
+    } catch {
+      setError("Error de red al restaurar.");
+    } finally {
+      setRestoringId(null);
+    }
+  }
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40 bg-black/30"
+        aria-hidden="true"
+        onClick={onClose}
+        data-testid="version-history-backdrop"
+      />
+
+      <div
+        role="dialog"
+        aria-label="Historial de versiones"
+        className={[
+          "fixed right-0 top-0 h-full w-80 z-50",
+          "bg-tremor-background dark:bg-dark-tremor-background",
+          "border-l border-tremor-border dark:border-dark-tremor-border",
+          "shadow-xl flex flex-col",
+        ].join(" ")}
+        data-testid="version-history-panel"
+      >
+        <div className="flex items-center justify-between border-b border-tremor-border dark:border-dark-tremor-border px-4 py-3">
+          <h2 className="text-base font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+            Historial de versiones
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Cerrar historial"
+            className="rounded p-1 text-tremor-content dark:text-dark-tremor-content hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle transition-colors"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
+          {error && (
+            <p className="text-sm text-red-500" data-testid="version-history-error">
+              {error}
+            </p>
+          )}
+
+          {loading && (
+            <div className="space-y-3 animate-pulse" data-testid="version-history-skeleton">
+              <div className="h-4 rounded bg-tremor-background-subtle dark:bg-dark-tremor-background-subtle" />
+              <div className="h-16 rounded bg-tremor-background-subtle dark:bg-dark-tremor-background-subtle" />
+              <div className="h-16 rounded bg-tremor-background-subtle dark:bg-dark-tremor-background-subtle" />
+            </div>
+          )}
+
+          {!loading && rows && rows.length === 0 && (
+            <p className="text-sm text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+              Sin historial de versiones.
+            </p>
+          )}
+
+          {!loading &&
+            rows &&
+            rows.map((v) => (
+              <div
+                key={v.id}
+                className="rounded-lg border border-tremor-border dark:border-dark-tremor-border p-3 space-y-2"
+                data-testid="version-history-entry"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="text-xs font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                    v{v.version_number}
+                  </span>
+                  <span className="text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle shrink-0">
+                    {formatRelativePast(v.created_at)}
+                  </span>
+                </div>
+                <p className="text-xs text-tremor-content dark:text-dark-tremor-content leading-snug">
+                  {truncatePrompt(v.prompt)}
+                </p>
+                <p className="text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                  {v.widget_count === 1 ? "1 widget" : `${v.widget_count} widgets`}
+                </p>
+                <button
+                  type="button"
+                  disabled={restoringId !== null}
+                  onClick={() => void handleRestore(v.id)}
+                  className="w-full rounded-md border border-tremor-border dark:border-dark-tremor-border px-2 py-1.5 text-xs font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle disabled:opacity-50 transition-colors"
+                >
+                  {restoringId === v.id ? "Restaurando…" : "Restaurar"}
+                </button>
+              </div>
+            ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/dashboard/components/VersionHistory.tsx
+++ b/dashboard/components/VersionHistory.tsx
@@ -4,7 +4,7 @@
  * VersionHistory — slide-out listing dashboard spec versions with restore.
  */
 
-import { useEffect, useCallback, useState } from "react";
+import { useEffect, useCallback, useState, useRef } from "react";
 import type { DashboardSpec } from "@/lib/schema";
 import { isApiErrorResponse } from "@/lib/errors";
 
@@ -54,12 +54,27 @@ export function VersionHistory({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [restoringId, setRestoringId] = useState<number | null>(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const restoreBusy = restoringId !== null;
+
+  const safeClose = useCallback(() => {
+    if (restoreBusy) return;
+    onClose();
+  }, [onClose, restoreBusy]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") safeClose();
     },
-    [onClose],
+    [safeClose],
   );
 
   useEffect(() => {
@@ -109,6 +124,7 @@ export function VersionHistory({
   }, [isOpen, dashboardId]);
 
   async function handleRestore(versionId: number) {
+    if (!isMountedRef.current) return;
     setRestoringId(versionId);
     setError(null);
     try {
@@ -123,7 +139,7 @@ export function VersionHistory({
           isApiErrorResponse(data) && typeof data.error === "string"
             ? data.error
             : "No se pudo restaurar la versión.";
-        setError(msg);
+        if (isMountedRef.current) setError(msg);
         return;
       }
       if (
@@ -133,14 +149,14 @@ export function VersionHistory({
         !data.spec ||
         typeof data.spec !== "object"
       ) {
-        setError("Respuesta del servidor no válida.");
+        if (isMountedRef.current) setError("Respuesta del servidor no válida.");
         return;
       }
-      onRestore(data.spec as DashboardSpec);
+      if (isMountedRef.current) onRestore(data.spec as DashboardSpec);
     } catch {
-      setError("Error de red al restaurar.");
+      if (isMountedRef.current) setError("Error de red al restaurar.");
     } finally {
-      setRestoringId(null);
+      if (isMountedRef.current) setRestoringId(null);
     }
   }
 
@@ -151,7 +167,7 @@ export function VersionHistory({
       <div
         className="fixed inset-0 z-40 bg-black/30"
         aria-hidden="true"
-        onClick={onClose}
+        onClick={safeClose}
         data-testid="version-history-backdrop"
       />
 
@@ -172,9 +188,10 @@ export function VersionHistory({
           </h2>
           <button
             type="button"
-            onClick={onClose}
+            onClick={safeClose}
+            disabled={restoreBusy}
             aria-label="Cerrar historial"
-            className="rounded p-1 text-tremor-content dark:text-dark-tremor-content hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle transition-colors"
+            className="rounded p-1 text-tremor-content dark:text-dark-tremor-content hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle transition-colors disabled:opacity-40 disabled:pointer-events-none"
           >
             <svg
               className="h-4 w-4"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,6 +10,7 @@
     "build": "next build",
     "start": "next start -p ${DASHBOARD_PORT:-4000}",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest"

--- a/dashboard/tsconfig.typecheck.json
+++ b/dashboard/tsconfig.typecheck.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false
+  },
+  "exclude": ["node_modules", "**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
## Summary
Implements issue #391: browse `dashboard_versions` via API, restore a prior spec (forward-append only), and a Spanish **Historial** slide-out on the dashboard view page.

## Changes
- **GET** `/api/dashboard/[id]/versions` — newest-first list with `version_number` from `ROW_NUMBER()`, `widget_count` via `jsonb_array_length(spec->'widgets')`, 404 if dashboard missing, 200 with `[]` if no versions.
- **POST** `/api/dashboard/[id]/restore` — body `{ version_id }`; transaction saves current spec as a new version (`Restauración a versión N`), updates `dashboards.spec`, returns same shape as GET.
- **VersionHistory** client component — right slide-out (GlossaryPanel pattern), loading / empty / error states, **Restaurar** calls restore then `onRestore(spec)`.
- **View page** — **Historial** toolbar button (plain text, matches Glosario styling); mutual exclusion with chat and glossary.
- **Tests** — Vitest unit tests for both routes (pg mock pattern).
- **typecheck** — `npm run typecheck` runs `tsc -p tsconfig.typecheck.json` (app sources only; existing `__tests__` files have pre-existing strict TS issues under root `tsconfig.json`).

## How to verify
```bash
cd dashboard && npm test && npm run lint && npm run typecheck
```

Manual: open a dashboard, use **Historial**, restore an older version, confirm spec updates without full reload and versions list grows.

Closes #391.

Made with [Cursor](https://cursor.com)