### PR TITLE
feat(dashboard): click-to-explore drill-down (#245)

### DIFF
--- a/dashboard/app/__tests__/view-page.test.tsx
+++ b/dashboard/app/__tests__/view-page.test.tsx
@@ -5,6 +5,11 @@ import "@testing-library/jest-dom/vitest";
 import ViewDashboard from "../dashboard/[id]/page";
 import type { DashboardSpec } from "@/lib/schema";
 
+const chatSidebarCapture = vi.hoisted(() => ({
+  pendingModifyInput: undefined as string | undefined,
+  pendingModifyTriggerId: undefined as number | undefined,
+}));
+
 // ---------------------------------------------------------------------------
 // Mock next/navigation
 // ---------------------------------------------------------------------------
@@ -30,14 +35,35 @@ vi.mock("@/components/DashboardRenderer", () => ({
   DashboardRenderer: ({
     spec,
     refreshKey,
+    onDataPointClick,
   }: {
     spec: DashboardSpec;
     refreshKey?: number;
+    onDataPointClick?: (ctx: {
+      label: string;
+      value: string;
+      widgetTitle: string;
+      widgetType: string;
+    }) => void;
   }) => {
     rendererProps.push({ refreshKey });
     return (
       <div data-testid="dashboard-renderer" data-refresh-key={refreshKey}>
         {spec.title}
+        <button
+          type="button"
+          data-testid="sim-chart-click"
+          onClick={() =>
+            onDataPointClick?.({
+              label: "Tienda 05",
+              value: "999",
+              widgetTitle: "Ventas por tienda",
+              widgetType: "bar_chart",
+            })
+          }
+        >
+          Sim click
+        </button>
       </div>
     );
   },
@@ -47,17 +73,30 @@ vi.mock("@/components/ChatSidebar", () => ({
   default: ({
     isOpen,
     onToggle,
+    pendingModifyInput,
+    pendingModifyTriggerId,
   }: {
     spec: DashboardSpec;
     onSpecUpdate: (s: DashboardSpec, prompt: string) => void;
     isOpen: boolean;
     onToggle: () => void;
-  }) =>
-    isOpen ? (
-      <div data-testid="chat-sidebar">
-        <button onClick={onToggle}>Cerrar</button>
+    pendingModifyInput?: string;
+    pendingModifyTriggerId?: number;
+  }) => {
+    chatSidebarCapture.pendingModifyInput = pendingModifyInput;
+    chatSidebarCapture.pendingModifyTriggerId = pendingModifyTriggerId;
+    return isOpen ? (
+      <div
+        data-testid="chat-sidebar"
+        data-pending={pendingModifyInput ?? ""}
+        data-trigger-id={pendingModifyTriggerId ?? ""}
+      >
+        <button type="button" onClick={onToggle}>
+          Cerrar
+        </button>
       </div>
-    ) : null,
+    ) : null;
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -94,6 +133,8 @@ describe("ViewDashboard page", () => {
     mockPush.mockReset();
     rendererProps.length = 0;
     mockSearchParamsRef.current = new URLSearchParams();
+    chatSidebarCapture.pendingModifyInput = undefined;
+    chatSidebarCapture.pendingModifyTriggerId = undefined;
   });
 
   afterEach(() => {
@@ -138,6 +179,30 @@ describe("ViewDashboard page", () => {
 
     // Last refreshed timestamp
     expect(screen.getByTestId("last-refreshed")).toBeInTheDocument();
+  });
+
+  it("chart drill-down opens chat sidebar with Spanish Modificar prefill", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(dashboardRecord),
+    });
+
+    render(<ViewDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dashboard-renderer")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("sim-chart-click"));
+
+    const expected =
+      "Detalle de Tienda 05 en Ventas por tienda: desglose por categoría, top artículos y tendencia";
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-sidebar")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("chat-sidebar")).toHaveAttribute("data-pending", expected);
+    expect(screen.getByTestId("chat-sidebar")).toHaveAttribute("data-trigger-id", "1");
   });
 
   it("shows 404 when dashboard not found", async () => {

--- a/dashboard/app/dashboard/[id]/page.tsx
+++ b/dashboard/app/dashboard/[id]/page.tsx
@@ -401,6 +401,8 @@ export default function ViewDashboard() {
     } else {
       prompt = `Más información sobre ${ctx.label}`;
     }
+    setGlossaryOpen(false);
+    setHistoryOpen(false);
     drillDownIdRef.current += 1;
     setPendingModify({ prompt, id: drillDownIdRef.current });
     setChatOpen(true);

--- a/dashboard/app/dashboard/[id]/page.tsx
+++ b/dashboard/app/dashboard/[id]/page.tsx
@@ -22,6 +22,7 @@ import { ErrorDisplay } from "@/components/ErrorDisplay";
 import { isApiErrorResponse } from "@/lib/errors";
 import type { DashboardSpec } from "@/lib/schema";
 import type { ApiErrorResponse } from "@/lib/errors";
+import type { DrillDownContext } from "@/components/widgets/types";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -109,6 +110,8 @@ export default function ViewDashboard() {
   const [error, setError] = useState<ApiErrorResponse | string | null>(null);
   const [notFound, setNotFound] = useState(false);
   const [chatOpen, setChatOpen] = useState(false);
+  const [pendingModify, setPendingModify] = useState<{ prompt: string; id: number } | null>(null);
+  const drillDownIdRef = useRef(0);
   const [glossaryOpen, setGlossaryOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [widgetData, setWidgetData] = useState<Map<number, WidgetState>>(new Map());
@@ -384,6 +387,41 @@ export default function ViewDashboard() {
     },
     [id],
   );
+
+  const handlePendingModifyInputConsumed = useCallback(() => {
+    setPendingModify(null);
+  }, []);
+
+  const handleDataPointClick = useCallback((ctx: DrillDownContext) => {
+    let prompt: string;
+    if (ctx.widgetType === "bar_chart" || ctx.widgetType === "donut_chart") {
+      prompt = `Detalle de ${ctx.label} en ${ctx.widgetTitle}: desglose por categoría, top artículos y tendencia`;
+    } else if (ctx.widgetType === "line_chart" || ctx.widgetType === "area_chart") {
+      prompt = `¿Qué ocurrió en ${ctx.label} en ${ctx.widgetTitle}? Detalle por tienda y categoría`;
+    } else {
+      prompt = `Más información sobre ${ctx.label}`;
+    }
+    drillDownIdRef.current += 1;
+    setPendingModify({ prompt, id: drillDownIdRef.current });
+    setChatOpen(true);
+  }, []);
+
+  const handleChatToggle = useCallback(() => {
+    setChatOpen((prev) => {
+      const nextOpen = !prev;
+      if (nextOpen) {
+        setGlossaryOpen(false);
+        setHistoryOpen(false);
+      }
+      return nextOpen;
+    });
+  }, []);
+
+  const handleOpenChatSidebar = useCallback(() => {
+    setGlossaryOpen(false);
+    setHistoryOpen(false);
+    setChatOpen(true);
+  }, []);
 
   // Handle chat modification
   const handleSpecUpdate = useCallback(
@@ -774,16 +812,7 @@ export default function ViewDashboard() {
           </button>
           <button
             type="button"
-            onClick={() =>
-              setChatOpen((prev) => {
-                const nextOpen = !prev;
-                if (nextOpen) {
-                  setGlossaryOpen(false);
-                  setHistoryOpen(false);
-                }
-                return nextOpen;
-              })
-            }
+            onClick={handleChatToggle}
             className="rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-600 transition-colors"
           >
             {chatOpen ? "Cerrar chat" : "Modificar"}
@@ -812,6 +841,7 @@ export default function ViewDashboard() {
         comparisonRange={comparisonRange}
         globalFilterValues={globalFilterValues}
         onWidgetDataChange={setWidgetData}
+        onDataPointClick={handleDataPointClick}
       />
 
       {/* Chat sidebar — close glossary panel when opening chat to avoid overlap */}
@@ -820,19 +850,14 @@ export default function ViewDashboard() {
         onSpecUpdate={handleSpecUpdate}
         isOpen={chatOpen}
         dashboardId={dashboard.id}
-        onToggle={() =>
-          setChatOpen((prev) => {
-            const nextOpen = !prev;
-            if (nextOpen) {
-              setGlossaryOpen(false);
-              setHistoryOpen(false);
-            }
-            return nextOpen;
-          })
-        }
+        onToggle={handleChatToggle}
+        onOpenSidebar={handleOpenChatSidebar}
         widgetData={widgetData}
         initialAnalyzeMessages={dashboard.chat_messages_analyze ?? []}
         onAnalyzeMessagesChange={handleAnalyzeMessagesChange}
+        pendingModifyInput={pendingModify?.prompt}
+        pendingModifyTriggerId={pendingModify?.id}
+        onPendingModifyInputConsumed={handlePendingModifyInputConsumed}
       />
 
       {/* Glossary panel — close chat sidebar when opening glossary to avoid overlap */}

--- a/dashboard/components/ChatSidebar.tsx
+++ b/dashboard/components/ChatSidebar.tsx
@@ -36,6 +36,19 @@ export interface ChatSidebarProps {
   initialAnalyzeMessages?: ChatMessage[];
   /** Callback fired when analyze messages change (for persistence). */
   onAnalyzeMessagesChange?: (messages: ChatMessage[]) => void;
+  /**
+   * When `pendingModifyTriggerId` changes with a non-empty `pendingModifyInput`,
+   * the Modificar tab is selected, the textarea is filled, focused, and the sidebar opens if needed.
+   */
+  pendingModifyInput?: string;
+  pendingModifyTriggerId?: number;
+  /** Called once the pre-fill has been applied so the parent can clear state (enables repeated identical clicks). */
+  onPendingModifyInputConsumed?: () => void;
+  /**
+   * Idempotent open when drill-down fires while the sidebar is collapsed.
+   * Prefer this over `onToggle` here to avoid double-toggle if an effect runs twice.
+   */
+  onOpenSidebar?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -290,12 +303,16 @@ function ModificarTab({
   messages,
   setMessages,
   isActive,
+  prefillRequest,
+  onPrefillApplied,
 }: {
   spec: DashboardSpec;
   onSpecUpdate: (newSpec: DashboardSpec, prompt: string) => void;
   messages: ChatMessage[];
   setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
   isActive: boolean;
+  prefillRequest?: { text: string; id: number } | null;
+  onPrefillApplied?: () => void;
 }) {
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
@@ -315,6 +332,21 @@ function ModificarTab({
       textareaRef.current?.focus();
     }
   }, [isActive]);
+
+  const appliedPrefillIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!prefillRequest?.text.trim()) return;
+    if (appliedPrefillIdRef.current === prefillRequest.id) return;
+    appliedPrefillIdRef.current = prefillRequest.id;
+    setInput(prefillRequest.text);
+    onPrefillApplied?.();
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+    });
+    // onPrefillApplied omitted from deps: parent uses useCallback; avoids duplicate consume on identity churn.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefillRequest?.id, prefillRequest?.text]);
 
   const handleSend = useCallback(async () => {
     const trimmed = input.trim();
@@ -765,6 +797,10 @@ export default function ChatSidebar({
   widgetData,
   initialAnalyzeMessages,
   onAnalyzeMessagesChange,
+  pendingModifyInput,
+  pendingModifyTriggerId,
+  onPendingModifyInputConsumed,
+  onOpenSidebar,
 }: ChatSidebarProps) {
   const [activeTab, setActiveTab] = useState<"modificar" | "analizar">("modificar");
   const [modifyMessages, setModifyMessages] = useState<ChatMessage[]>([]);
@@ -780,6 +816,15 @@ export default function ChatSidebar({
       initializedRef.current = true;
     }
   }, [initialAnalyzeMessages]);
+
+  useEffect(() => {
+    if (!pendingModifyInput?.trim() || pendingModifyTriggerId === undefined) return;
+    if (!isOpen) {
+      (onOpenSidebar ?? onToggle)();
+      return;
+    }
+    setActiveTab("modificar");
+  }, [pendingModifyInput, pendingModifyTriggerId, isOpen, onOpenSidebar, onToggle]);
 
   // -------------------------------------------------------------------------
   // Collapsed state: show a small tab to reopen
@@ -865,6 +910,12 @@ export default function ChatSidebar({
             messages={modifyMessages}
             setMessages={setModifyMessages}
             isActive={activeTab === "modificar"}
+            prefillRequest={
+              pendingModifyInput?.trim() && pendingModifyTriggerId !== undefined
+                ? { text: pendingModifyInput, id: pendingModifyTriggerId }
+                : null
+            }
+            onPrefillApplied={onPendingModifyInputConsumed}
           />
         ) : (
           <AnalizarTab

--- a/dashboard/components/ChatSidebar.tsx
+++ b/dashboard/components/ChatSidebar.tsx
@@ -344,9 +344,7 @@ function ModificarTab({
     requestAnimationFrame(() => {
       textareaRef.current?.focus();
     });
-    // onPrefillApplied omitted from deps: parent uses useCallback; avoids duplicate consume on identity churn.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [prefillRequest?.id, prefillRequest?.text]);
+  }, [prefillRequest?.id, prefillRequest?.text, onPrefillApplied]);
 
   const handleSend = useCallback(async () => {
     const trimmed = input.trim();

--- a/dashboard/components/DashboardRenderer.tsx
+++ b/dashboard/components/DashboardRenderer.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@headlessui/react";
 import type { DashboardSpec, Widget, GlossaryItem } from "@/lib/schema";
-import type { WidgetData } from "./widgets/types";
+import type { OnDataPointClick, WidgetData } from "./widgets/types";
 import type { DateRange, ComparisonRange } from "./DateRangePicker";
 import { substituteDateParams } from "@/lib/date-params";
 import { compileGlobalFilterSql } from "@/lib/sql-filters";
@@ -65,6 +65,8 @@ export interface DashboardRendererProps {
    * unnecessary calls during the initial empty state.
    */
   onWidgetDataChange?: (data: Map<number, WidgetState>) => void;
+  /** Drill-down: invoked when the user clicks a chart point or table row (widgets pass context up). */
+  onDataPointClick?: OnDataPointClick;
 }
 
 // ---------------------------------------------------------------------------
@@ -171,6 +173,7 @@ export function DashboardRenderer({
   comparisonRange,
   globalFilterValues,
   onWidgetDataChange,
+  onDataPointClick,
 }: DashboardRendererProps) {
   const [widgetStates, setWidgetStates] = useState<Map<number, WidgetState>>(
     new Map()
@@ -619,6 +622,7 @@ export function DashboardRenderer({
                     specChanged={specChanged}
                     onRetry={retryWidget}
                     glossary={spec.glossary}
+                    onDataPointClick={onDataPointClick}
                   />
                 </TabPanel>
               );
@@ -634,6 +638,7 @@ export function DashboardRenderer({
           specChanged={specChanged}
           onRetry={retryWidget}
           glossary={spec.glossary}
+          onDataPointClick={onDataPointClick}
         />
       )}
     </div>
@@ -651,9 +656,18 @@ interface WidgetGridProps {
   specChanged: boolean;
   onRetry: (widget: Widget, idx: number) => void;
   glossary?: GlossaryItem[];
+  onDataPointClick?: OnDataPointClick;
 }
 
-function WidgetGrid({ widgets, widgetIndices, widgetStates, specChanged, onRetry, glossary }: WidgetGridProps) {
+function WidgetGrid({
+  widgets,
+  widgetIndices,
+  widgetStates,
+  specChanged,
+  onRetry,
+  glossary,
+  onDataPointClick,
+}: WidgetGridProps) {
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
       {widgetIndices.map((idx) => {
@@ -692,7 +706,12 @@ function WidgetGrid({ widgets, widgetIndices, widgetStates, specChanged, onRetry
 
             {/* Success state */}
             {state && !state.loading && !state.error && (
-              <WidgetSwitch widget={widget} state={state} glossary={glossary} />
+              <WidgetSwitch
+                widget={widget}
+                state={state}
+                glossary={glossary}
+                onDataPointClick={onDataPointClick}
+              />
             )}
           </div>
         );
@@ -847,10 +866,12 @@ function WidgetSwitch({
   widget,
   state,
   glossary,
+  onDataPointClick,
 }: {
   widget: Widget;
   state: WidgetState;
   glossary?: GlossaryItem[];
+  onDataPointClick?: OnDataPointClick;
 }) {
   switch (widget.type) {
     case "kpi_row":
@@ -865,23 +886,52 @@ function WidgetSwitch({
       );
     case "bar_chart":
       return (
-        <BarChartWidget widget={widget} data={state.data as WidgetData | null} comparisonData={state.comparisonData} glossary={glossary} />
+        <BarChartWidget
+          widget={widget}
+          data={state.data as WidgetData | null}
+          comparisonData={state.comparisonData}
+          glossary={glossary}
+          onDataPointClick={onDataPointClick}
+        />
       );
     case "line_chart":
       return (
-        <LineChartWidget widget={widget} data={state.data as WidgetData | null} comparisonData={state.comparisonData} glossary={glossary} />
+        <LineChartWidget
+          widget={widget}
+          data={state.data as WidgetData | null}
+          comparisonData={state.comparisonData}
+          glossary={glossary}
+          onDataPointClick={onDataPointClick}
+        />
       );
     case "area_chart":
       return (
-        <AreaChartWidget widget={widget} data={state.data as WidgetData | null} comparisonData={state.comparisonData} glossary={glossary} />
+        <AreaChartWidget
+          widget={widget}
+          data={state.data as WidgetData | null}
+          comparisonData={state.comparisonData}
+          glossary={glossary}
+          onDataPointClick={onDataPointClick}
+        />
       );
     case "donut_chart":
       return (
-        <DonutChartWidget widget={widget} data={state.data as WidgetData | null} comparisonData={state.comparisonData} glossary={glossary} />
+        <DonutChartWidget
+          widget={widget}
+          data={state.data as WidgetData | null}
+          comparisonData={state.comparisonData}
+          glossary={glossary}
+          onDataPointClick={onDataPointClick}
+        />
       );
     case "table":
       return (
-        <TableWidget widget={widget} data={state.data as WidgetData | null} glossary={glossary} />
+        <TableWidget
+          widget={widget}
+          data={state.data as WidgetData | null}
+          glossary={glossary}
+          onDataPointClick={onDataPointClick}
+        />
       );
     case "number":
       return (

--- a/dashboard/components/__tests__/ChatSidebar.test.tsx
+++ b/dashboard/components/__tests__/ChatSidebar.test.tsx
@@ -89,6 +89,60 @@ describe("ChatSidebar", () => {
     expect(screen.getByTestId("tab-analizar")).toBeInTheDocument();
   });
 
+  it("pre-fills Modificar textarea when pendingModifyInput and pendingModifyTriggerId are set", async () => {
+    const onConsumed = vi.fn();
+    render(
+      <ChatSidebar
+        spec={baseSpec}
+        onSpecUpdate={onSpecUpdate}
+        isOpen={true}
+        onToggle={onToggle}
+        pendingModifyInput="Detalle de Tienda 05"
+        pendingModifyTriggerId={1}
+        onPendingModifyInputConsumed={onConsumed}
+      />,
+    );
+
+    const textarea = screen.getByLabelText(/Mensaje para modificar el dashboard/i);
+    await waitFor(() => {
+      expect(textarea).toHaveValue("Detalle de Tienda 05");
+    });
+    expect(screen.getByTestId("tab-modificar")).toHaveAttribute("aria-selected", "true");
+    await waitFor(() => expect(onConsumed).toHaveBeenCalled());
+  });
+
+  it("switches to Modificar tab when drill-down prefill arrives while Analizar is active", async () => {
+    const onConsumed = vi.fn();
+    const { rerender } = render(
+      <ChatSidebar
+        spec={baseSpec}
+        onSpecUpdate={onSpecUpdate}
+        isOpen={true}
+        onToggle={onToggle}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("tab-analizar"));
+    expect(screen.getByTestId("tab-analizar")).toHaveAttribute("aria-selected", "true");
+
+    rerender(
+      <ChatSidebar
+        spec={baseSpec}
+        onSpecUpdate={onSpecUpdate}
+        isOpen={true}
+        onToggle={onToggle}
+        pendingModifyInput="Detalle de Tienda 05"
+        pendingModifyTriggerId={42}
+        onPendingModifyInputConsumed={onConsumed}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("tab-modificar")).toHaveAttribute("aria-selected", "true"),
+    );
+    const textarea = screen.getByLabelText(/Mensaje para modificar el dashboard/i);
+    await waitFor(() => expect(textarea).toHaveValue("Detalle de Tienda 05"));
+  });
+
   it("shows reopen button when closed", () => {
     render(
       <ChatSidebar

--- a/dashboard/components/widgets/AreaChartWidget.tsx
+++ b/dashboard/components/widgets/AreaChartWidget.tsx
@@ -2,7 +2,7 @@
 
 import { Card, AreaChart } from "@tremor/react";
 import type { AreaChartWidget as AreaChartWidgetSpec, GlossaryItem } from "@/lib/schema";
-import type { WidgetData } from "./types";
+import type { OnDataPointClick, WidgetData } from "./types";
 import { EMPTY_MESSAGE, resolveXY, safeNumber } from "./types";
 import { CHART_COLORS } from "./chart-colors";
 import { applyGlossary } from "@/lib/glossary";
@@ -16,9 +16,16 @@ interface AreaChartWidgetProps {
   comparisonData?: WidgetData | null;
   /** Optional glossary entries for contextual tooltips on the title. */
   glossary?: GlossaryItem[];
+  onDataPointClick?: OnDataPointClick;
 }
 
-export function AreaChartWidget({ widget, data, comparisonData, glossary }: AreaChartWidgetProps) {
+export function AreaChartWidget({
+  widget,
+  data,
+  comparisonData,
+  glossary,
+  onDataPointClick,
+}: AreaChartWidgetProps) {
   const titleNode = applyGlossary(widget.title, glossary);
 
   if (data === null) {
@@ -73,13 +80,42 @@ export function AreaChartWidget({ widget, data, comparisonData, glossary }: Area
 
   const categories = hasComparison ? ["Actual", "Anterior"] : [yCol];
 
+  const handleValueChange = (v: Record<string, unknown> | null | undefined) => {
+    if (!onDataPointClick || !v) return;
+    const label = String(v[xCol] ?? "");
+    const seriesKey = v.categoryClicked;
+    let raw: unknown;
+    if (typeof seriesKey === "string" && seriesKey in v) {
+      raw = v[seriesKey];
+    } else {
+      for (const c of categories) {
+        if (c in v) {
+          raw = v[c];
+          break;
+        }
+      }
+    }
+    const value = raw !== undefined && raw !== null ? String(raw) : "";
+    onDataPointClick({
+      label,
+      value,
+      widgetTitle: widget.title,
+      widgetType: "area_chart",
+    });
+  };
+
   return (
     <Card className="p-4" aria-live="polite" aria-busy={false}>
       <h3 className="mb-4 text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
         {titleNode}
       </h3>
 
-      <div role="img" aria-label={`Gráfico de área: ${widget.title}.`}>
+      <div
+        role="img"
+        aria-label={`Gráfico de área: ${widget.title}.`}
+        className={onDataPointClick ? "cursor-pointer" : undefined}
+        title={onDataPointClick ? "Clic para explorar" : undefined}
+      >
         <span className="sr-only">Gráfico de área.</span>
 
         <div className="sm:hidden">
@@ -90,6 +126,11 @@ export function AreaChartWidget({ widget, data, comparisonData, glossary }: Area
             colors={CHART_COLORS}
             showYAxis={false}
             showLegend={hasComparison}
+            onValueChange={
+              onDataPointClick
+                ? (v) => handleValueChange(v as unknown as Record<string, unknown>)
+                : undefined
+            }
           />
         </div>
 
@@ -101,6 +142,11 @@ export function AreaChartWidget({ widget, data, comparisonData, glossary }: Area
             colors={CHART_COLORS}
             yAxisWidth={60}
             showLegend={hasComparison}
+            onValueChange={
+              onDataPointClick
+                ? (v) => handleValueChange(v as unknown as Record<string, unknown>)
+                : undefined
+            }
           />
         </div>
       </div>

--- a/dashboard/components/widgets/BarChartWidget.tsx
+++ b/dashboard/components/widgets/BarChartWidget.tsx
@@ -2,7 +2,7 @@
 
 import { Card, BarChart } from "@tremor/react";
 import type { BarChartWidget as BarChartWidgetSpec, GlossaryItem } from "@/lib/schema";
-import type { WidgetData } from "./types";
+import type { OnDataPointClick, WidgetData } from "./types";
 import { EMPTY_MESSAGE, resolveXY, safeNumber } from "./types";
 import { CHART_COLORS } from "./chart-colors";
 import { applyGlossary } from "@/lib/glossary";
@@ -15,6 +15,8 @@ interface BarChartWidgetProps {
   comparisonData?: WidgetData | null;
   /** Optional glossary entries for contextual tooltips on the title. */
   glossary?: GlossaryItem[];
+  /** When set, clicking a bar invokes this with label/value context (Tremor `onValueChange`). */
+  onDataPointClick?: OnDataPointClick;
 }
 
 /** Merge primary and comparison datasets into a two-series format for Tremor charts. */
@@ -41,7 +43,13 @@ export function mergeComparisonSeries(
     }));
 }
 
-export function BarChartWidget({ widget, data, comparisonData, glossary }: BarChartWidgetProps) {
+export function BarChartWidget({
+  widget,
+  data,
+  comparisonData,
+  glossary,
+  onDataPointClick,
+}: BarChartWidgetProps) {
   const titleNode = applyGlossary(widget.title, glossary);
 
   if (data === null) {
@@ -96,6 +104,30 @@ export function BarChartWidget({ widget, data, comparisonData, glossary }: BarCh
 
   const categories = hasComparison ? ["Actual", "Anterior"] : [yCol];
 
+  const handleValueChange = (v: Record<string, unknown> | null | undefined) => {
+    if (!onDataPointClick || !v) return;
+    const label = String(v[xCol] ?? "");
+    const seriesKey = v.categoryClicked;
+    let raw: unknown;
+    if (typeof seriesKey === "string" && seriesKey in v) {
+      raw = v[seriesKey];
+    } else {
+      for (const c of categories) {
+        if (c in v) {
+          raw = v[c];
+          break;
+        }
+      }
+    }
+    const value = raw !== undefined && raw !== null ? String(raw) : "";
+    onDataPointClick({
+      label,
+      value,
+      widgetTitle: widget.title,
+      widgetType: "bar_chart",
+    });
+  };
+
   return (
     <Card className="p-4" aria-live="polite" aria-busy={false}>
       <h3 className="mb-4 text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
@@ -105,6 +137,8 @@ export function BarChartWidget({ widget, data, comparisonData, glossary }: BarCh
       <div
         role="img"
         aria-label={`Gráfico de barras: ${widget.title}. ${chartData.length} categorías.`}
+        className={onDataPointClick ? "cursor-pointer" : undefined}
+        title={onDataPointClick ? "Clic para explorar" : undefined}
       >
         <span className="sr-only">
           Gráfico de barras con {chartData.length} categorías.
@@ -119,6 +153,11 @@ export function BarChartWidget({ widget, data, comparisonData, glossary }: BarCh
             colors={CHART_COLORS}
             showYAxis={false}
             showLegend={hasComparison}
+            onValueChange={
+              onDataPointClick
+                ? (v) => handleValueChange(v as unknown as Record<string, unknown>)
+                : undefined
+            }
           />
         </div>
 
@@ -131,6 +170,11 @@ export function BarChartWidget({ widget, data, comparisonData, glossary }: BarCh
             colors={CHART_COLORS}
             yAxisWidth={60}
             showLegend={hasComparison}
+            onValueChange={
+              onDataPointClick
+                ? (v) => handleValueChange(v as unknown as Record<string, unknown>)
+                : undefined
+            }
           />
         </div>
       </div>

--- a/dashboard/components/widgets/DonutChartWidget.tsx
+++ b/dashboard/components/widgets/DonutChartWidget.tsx
@@ -2,7 +2,7 @@
 
 import { Card, DonutChart } from "@tremor/react";
 import type { DonutChartWidget as DonutChartWidgetSpec, GlossaryItem } from "@/lib/schema";
-import type { WidgetData } from "./types";
+import type { OnDataPointClick, WidgetData } from "./types";
 import { EMPTY_MESSAGE, resolveXY, safeNumber } from "./types";
 import { CHART_COLORS } from "./chart-colors";
 import { applyGlossary } from "@/lib/glossary";
@@ -15,9 +15,16 @@ interface DonutChartWidgetProps {
   comparisonData?: WidgetData | null;
   /** Optional glossary entries for contextual tooltips on the title. */
   glossary?: GlossaryItem[];
+  onDataPointClick?: OnDataPointClick;
 }
 
-export function DonutChartWidget({ widget, data, comparisonData, glossary }: DonutChartWidgetProps) {
+export function DonutChartWidget({
+  widget,
+  data,
+  comparisonData,
+  glossary,
+  onDataPointClick,
+}: DonutChartWidgetProps) {
   const titleNode = applyGlossary(widget.title, glossary);
 
   if (data === null) {
@@ -77,6 +84,16 @@ export function DonutChartWidget({ widget, data, comparisonData, glossary }: Don
 
   const currentTotal = chartData.reduce((s, d) => s + d.value, 0);
 
+  const handleValueChange = (v: Record<string, unknown> | null | undefined) => {
+    if (!onDataPointClick || !v) return;
+    onDataPointClick({
+      label: String(v.name ?? ""),
+      value: v.value !== undefined && v.value !== null ? String(v.value) : "",
+      widgetTitle: widget.title,
+      widgetType: "donut_chart",
+    });
+  };
+
   return (
     <Card className="p-4" aria-live="polite" aria-busy={false}>
       <h3 className="mb-4 text-sm font-medium text-tremor-content dark:text-dark-tremor-content">{titleNode}</h3>
@@ -84,6 +101,8 @@ export function DonutChartWidget({ widget, data, comparisonData, glossary }: Don
       <div
         role="img"
         aria-label={`Gráfico de donut: ${widget.title}. ${chartData.length} categorías.`}
+        className={onDataPointClick ? "cursor-pointer" : undefined}
+        title={onDataPointClick ? "Clic para explorar" : undefined}
       >
         <span className="sr-only">Gráfico de donut con {chartData.length} categorías.</span>
         <DonutChart
@@ -93,6 +112,11 @@ export function DonutChartWidget({ widget, data, comparisonData, glossary }: Don
           colors={CHART_COLORS}
           showLabel
           showAnimation
+          onValueChange={
+            onDataPointClick
+              ? (v) => handleValueChange(v as unknown as Record<string, unknown>)
+              : undefined
+          }
         />
       </div>
 

--- a/dashboard/components/widgets/LineChartWidget.tsx
+++ b/dashboard/components/widgets/LineChartWidget.tsx
@@ -2,7 +2,7 @@
 
 import { Card, LineChart } from "@tremor/react";
 import type { LineChartWidget as LineChartWidgetSpec, GlossaryItem } from "@/lib/schema";
-import type { WidgetData } from "./types";
+import type { OnDataPointClick, WidgetData } from "./types";
 import { EMPTY_MESSAGE, resolveXY, safeNumber } from "./types";
 import { CHART_COLORS } from "./chart-colors";
 import { applyGlossary } from "@/lib/glossary";
@@ -16,9 +16,16 @@ interface LineChartWidgetProps {
   comparisonData?: WidgetData | null;
   /** Optional glossary entries for contextual tooltips on the title. */
   glossary?: GlossaryItem[];
+  onDataPointClick?: OnDataPointClick;
 }
 
-export function LineChartWidget({ widget, data, comparisonData, glossary }: LineChartWidgetProps) {
+export function LineChartWidget({
+  widget,
+  data,
+  comparisonData,
+  glossary,
+  onDataPointClick,
+}: LineChartWidgetProps) {
   const titleNode = applyGlossary(widget.title, glossary);
 
   if (data === null) {
@@ -73,13 +80,42 @@ export function LineChartWidget({ widget, data, comparisonData, glossary }: Line
 
   const categories = hasComparison ? ["Actual", "Anterior"] : [yCol];
 
+  const handleValueChange = (v: Record<string, unknown> | null | undefined) => {
+    if (!onDataPointClick || !v) return;
+    const label = String(v[xCol] ?? "");
+    const seriesKey = v.categoryClicked;
+    let raw: unknown;
+    if (typeof seriesKey === "string" && seriesKey in v) {
+      raw = v[seriesKey];
+    } else {
+      for (const c of categories) {
+        if (c in v) {
+          raw = v[c];
+          break;
+        }
+      }
+    }
+    const value = raw !== undefined && raw !== null ? String(raw) : "";
+    onDataPointClick({
+      label,
+      value,
+      widgetTitle: widget.title,
+      widgetType: "line_chart",
+    });
+  };
+
   return (
     <Card className="p-4" aria-live="polite" aria-busy={false}>
       <h3 className="mb-4 text-sm font-medium text-tremor-content dark:text-dark-tremor-content-emphasis">
         {titleNode}
       </h3>
 
-      <div role="img" aria-label={`Gráfico de líneas: ${widget.title}.`}>
+      <div
+        role="img"
+        aria-label={`Gráfico de líneas: ${widget.title}.`}
+        className={onDataPointClick ? "cursor-pointer" : undefined}
+        title={onDataPointClick ? "Clic para explorar" : undefined}
+      >
         <span className="sr-only">Gráfico de líneas.</span>
 
         <div className="sm:hidden">
@@ -90,6 +126,11 @@ export function LineChartWidget({ widget, data, comparisonData, glossary }: Line
             colors={CHART_COLORS}
             showYAxis={false}
             showLegend={hasComparison}
+            onValueChange={
+              onDataPointClick
+                ? (v) => handleValueChange(v as unknown as Record<string, unknown>)
+                : undefined
+            }
           />
         </div>
 
@@ -101,6 +142,11 @@ export function LineChartWidget({ widget, data, comparisonData, glossary }: Line
             colors={CHART_COLORS}
             yAxisWidth={60}
             showLegend={hasComparison}
+            onValueChange={
+              onDataPointClick
+                ? (v) => handleValueChange(v as unknown as Record<string, unknown>)
+                : undefined
+            }
           />
         </div>
       </div>

--- a/dashboard/components/widgets/TableWidget.tsx
+++ b/dashboard/components/widgets/TableWidget.tsx
@@ -118,8 +118,8 @@ export function TableWidget({ widget, data, glossary, onDataPointClick }: TableW
                 key={rIdx}
                 className={
                   onDataPointClick
-                    ? "border-b border-tremor-border dark:border-dark-tremor-border cursor-pointer hover:bg-tremor-background-muted"
-                    : "border-b border-tremor-border dark:border-dark-tremor-border hover:bg-dark-tremor-background-subtle"
+                    ? "border-b border-tremor-border dark:border-dark-tremor-border cursor-pointer hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle"
+                    : "border-b border-tremor-border dark:border-dark-tremor-border hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle"
                 }
                 onClick={
                   onDataPointClick

--- a/dashboard/components/widgets/TableWidget.tsx
+++ b/dashboard/components/widgets/TableWidget.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import { Card } from "@tremor/react";
 import type { TableWidget as TableWidgetSpec, GlossaryItem } from "@/lib/schema";
-import type { WidgetData } from "./types";
+import type { OnDataPointClick, WidgetData } from "./types";
 import { EMPTY_MESSAGE } from "./types";
 import { applyGlossary } from "@/lib/glossary";
 
@@ -12,6 +12,7 @@ interface TableWidgetProps {
   data: WidgetData | null;
   /** Optional glossary entries for contextual tooltips on the title. */
   glossary?: GlossaryItem[];
+  onDataPointClick?: OnDataPointClick;
 }
 
 type SortDir = "asc" | "desc";
@@ -23,7 +24,7 @@ function isNullish(v: unknown): boolean {
   return v === null || v === undefined || v === "";
 }
 
-export function TableWidget({ widget, data, glossary }: TableWidgetProps) {
+export function TableWidget({ widget, data, glossary, onDataPointClick }: TableWidgetProps) {
   const titleNode = applyGlossary(widget.title, glossary);
   const [sortCol, setSortCol] = useState<number | null>(null);
   const [sortDir, setSortDir] = useState<SortDir>("asc");
@@ -80,7 +81,7 @@ export function TableWidget({ widget, data, glossary }: TableWidgetProps) {
     <Card className="p-4">
       <h3 className="mb-4 text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis">{titleNode}</h3>
       <div className="overflow-x-auto">
-        <table className="min-w-full text-sm">
+        <table className="min-w-full text-sm" title={onDataPointClick ? "Clic para explorar" : undefined}>
           <thead>
             <tr className="border-b border-tremor-border dark:border-dark-tremor-border">
               {data.columns.map((col, idx) => (
@@ -113,7 +114,25 @@ export function TableWidget({ widget, data, glossary }: TableWidgetProps) {
           </thead>
           <tbody>
             {sortedRows.map((row, rIdx) => (
-              <tr key={rIdx} className="border-b border-tremor-border dark:border-dark-tremor-border hover:bg-dark-tremor-background-subtle">
+              <tr
+                key={rIdx}
+                className={
+                  onDataPointClick
+                    ? "border-b border-tremor-border dark:border-dark-tremor-border cursor-pointer hover:bg-tremor-background-muted"
+                    : "border-b border-tremor-border dark:border-dark-tremor-border hover:bg-dark-tremor-background-subtle"
+                }
+                onClick={
+                  onDataPointClick
+                    ? () =>
+                        onDataPointClick({
+                          label: String(row[0] ?? ""),
+                          value: "",
+                          widgetTitle: widget.title,
+                          widgetType: "table",
+                        })
+                    : undefined
+                }
+              >
                 {row.map((cell, cIdx) => (
                   <td key={cIdx} className="px-3 py-2 text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis">
                     {formatCell(cell)}

--- a/dashboard/components/widgets/__tests__/BarChartWidget.test.tsx
+++ b/dashboard/components/widgets/__tests__/BarChartWidget.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import type { ReactNode } from "react";
+import { BarChartWidget } from "../BarChartWidget";
+import type { BarChartWidget as BarChartSpec } from "@/lib/schema";
+import type { WidgetData } from "../types";
+
+vi.mock("@tremor/react", () => ({
+  Card: ({
+    children,
+    className,
+    title,
+    ...rest
+  }: {
+    children: ReactNode;
+    className?: string;
+    title?: string;
+  }) => (
+    <div className={className} title={title} {...rest}>
+      {children}
+    </div>
+  ),
+  BarChart: ({
+    onValueChange,
+    index,
+  }: {
+    onValueChange?: (v: Record<string, unknown>) => void;
+    index: string;
+  }) => (
+    <button
+      type="button"
+      data-testid="mock-bar"
+      onClick={() =>
+        onValueChange?.({
+          eventType: "bar",
+          categoryClicked: "Ventas",
+          [index]: "Tienda 05",
+          Ventas: 1234,
+        })
+      }
+    >
+      bar
+    </button>
+  ),
+}));
+
+describe("BarChartWidget drill-down", () => {
+  it("invokes onDataPointClick when Tremor onValueChange fires", () => {
+    const onDataPointClick = vi.fn();
+    const widget: BarChartSpec = {
+      type: "bar_chart",
+      title: "Ventas por tienda",
+      sql: "SELECT 1",
+      x: "tienda",
+      y: "Ventas",
+    };
+    const data: WidgetData = {
+      columns: ["tienda", "Ventas"],
+      rows: [
+        ["Tienda 05", 1234],
+        ["Tienda 01", 500],
+      ],
+    };
+    render(<BarChartWidget widget={widget} data={data} onDataPointClick={onDataPointClick} />);
+    fireEvent.click(screen.getAllByTestId("mock-bar")[0]);
+    expect(onDataPointClick).toHaveBeenCalledTimes(1);
+    expect(onDataPointClick).toHaveBeenCalledWith({
+      label: "Tienda 05",
+      value: "1234",
+      widgetTitle: "Ventas por tienda",
+      widgetType: "bar_chart",
+    });
+  });
+});

--- a/dashboard/components/widgets/__tests__/TableWidget.test.tsx
+++ b/dashboard/components/widgets/__tests__/TableWidget.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import type { ReactNode } from "react";
+import { TableWidget } from "../TableWidget";
+import type { TableWidget as TableSpec } from "@/lib/schema";
+import type { WidgetData } from "../types";
+
+vi.mock("@tremor/react", () => ({
+  Card: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
+describe("TableWidget drill-down", () => {
+  it("invokes onDataPointClick with first column as label when a row is clicked", () => {
+    const onDataPointClick = vi.fn();
+    const widget: TableSpec = {
+      type: "table",
+      title: "Detalle por tienda",
+      sql: "SELECT 1",
+    };
+    const data: WidgetData = {
+      columns: ["Tienda", "Ventas"],
+      rows: [
+        ["Tienda 05", 100],
+        ["Tienda 01", 200],
+      ],
+    };
+    render(<TableWidget widget={widget} data={data} onDataPointClick={onDataPointClick} />);
+    fireEvent.click(screen.getByText("Tienda 05"));
+    expect(onDataPointClick).toHaveBeenCalledTimes(1);
+    expect(onDataPointClick).toHaveBeenCalledWith({
+      label: "Tienda 05",
+      value: "",
+      widgetTitle: "Detalle por tienda",
+      widgetType: "table",
+    });
+  });
+});

--- a/dashboard/components/widgets/types.ts
+++ b/dashboard/components/widgets/types.ts
@@ -2,6 +2,20 @@
  * Shared types for widget components.
  */
 
+/** Context passed when the user clicks a chart point or table row to explore further. */
+export interface DrillDownContext {
+  /** The clicked data point label (e.g. store name). */
+  label: string;
+  /** Display string for the clicked value (e.g. formatted number). */
+  value: string;
+  /** Parent widget title. */
+  widgetTitle: string;
+  /** Widget kind for prompt shaping upstream. */
+  widgetType: "bar_chart" | "line_chart" | "area_chart" | "donut_chart" | "table";
+}
+
+export type OnDataPointClick = (ctx: DrillDownContext) => void;
+
 /** Query result format returned by the /api/query endpoint. */
 export interface WidgetData {
   columns: string[];

--- a/dashboard/lib/errors.ts
+++ b/dashboard/lib/errors.ts
@@ -26,6 +26,7 @@ export type ErrorCode =
   | "TIMEOUT"
   | "COST_LIMIT"
   | "REVIEW_EXISTS"
+  | "REVIEW_PERSISTENCE"
   | "UNKNOWN"
   | "AGENTIC_RUNNER";
 


### PR DESCRIPTION
## Summary
Implements GitHub issue #245: chart and table drill-down pre-fills the Modificar tab with a contextual Spanish prompt and opens the chat sidebar.

## Changes
- `DrillDownContext` / `OnDataPointClick` in `dashboard/components/widgets/types.ts`
- Bar, line, area, and donut widgets: Tremor `onValueChange`, `cursor-pointer`, `title="Clic para explorar"`
- `TableWidget`: row click uses first column as label
- Prop threading: `DashboardRenderer` → `WidgetGrid` → `WidgetSwitch`
- `ChatSidebar`: `pendingModifyInput` + `pendingModifyTriggerId`, Modificar prefill, `onOpenSidebar` for idempotent open when collapsed
- `ViewDashboard`: prompt templates per widget type; clears pending after prefill via `onPendingModifyInputConsumed`
- Tests: `BarChartWidget.test.tsx`, ChatSidebar prefill/tab switch, view page drill integration
- `REVIEW_PERSISTENCE` added to `ErrorCode` so `npm run typecheck` passes (used by review generate route)

## Verification
- `cd dashboard && npm run typecheck && npm test && npm run build`

Closes #245

Made with [Cursor](https://cursor.com)