### PR TITLE
fix(dashboard): readable amber pills & clearer regenerate wording in weekly review

### DIFF
--- a/dashboard/app/__tests__/ReviewDisplay.test.tsx
+++ b/dashboard/app/__tests__/ReviewDisplay.test.tsx
@@ -212,4 +212,41 @@ describe("ReviewDisplay", () => {
       expect(screen.getByText("Copiado")).toBeInTheDocument();
     });
   });
+
+  // ─── Contrast / amber palette regression tests (issue #399) ────────────────
+  // The previous palette used `text-amber-200` on a translucent amber tint,
+  // which failed WCAG AA on light theme. Lock in a palette that sits on a
+  // darker amber text for light mode and a lighter amber text for dark mode.
+
+  it("renders the 'Calidad de datos degradada' badge with accessible amber classes", () => {
+    const degraded: ReviewContent & { id: number; week_start: string } = {
+      ...sampleReview,
+      quality_status: "degraded",
+    };
+    render(<ReviewDisplay review={degraded} />);
+    const badge = screen.getByTestId("quality-degraded");
+    const className = badge.className;
+    // Must carry a dark-ink amber text token for light mode.
+    expect(className).toMatch(/\btext-amber-(800|900)\b/);
+    // Must keep a light-ink amber text token for dark mode.
+    expect(className).toMatch(/\bdark:text-amber-(50|100)\b/);
+    // Must NOT keep the broken light amber text on light mode.
+    expect(className).not.toMatch(/(^|\s)text-amber-(100|200)(\s|$)/);
+  });
+
+  it("renders the data-quality-notes panel with accessible amber classes", () => {
+    const withNotes: ReviewContent & { id: number; week_start: string } = {
+      ...sampleReview,
+      data_quality_notes: ["Faltan ventas de la tienda 07 para el lunes"],
+    };
+    render(<ReviewDisplay review={withNotes} />);
+    const panel = screen.getByTestId("data-quality-notes");
+    const className = panel.className;
+    // Dark ink for light mode.
+    expect(className).toMatch(/\btext-amber-(800|900)\b/);
+    // Light ink for dark mode.
+    expect(className).toMatch(/\bdark:text-amber-(50|100)\b/);
+    // Must NOT keep the broken light amber text on light mode.
+    expect(className).not.toMatch(/(^|\s)text-amber-(100|200)(\s|$)/);
+  });
 });

--- a/dashboard/app/__tests__/review-page.test.tsx
+++ b/dashboard/app/__tests__/review-page.test.tsx
@@ -441,7 +441,7 @@ describe("ReviewPage", () => {
     expect(refreshOption?.textContent).toMatch(/Actualizar datos/);
   });
 
-  // ─── Accessible regenerate hint (Copilot review on PR #402) ───────────────
+  // ─── Accessible regenerate hint ───────────────────────────────────────────
   // Native `<option title>` tooltips are not reliably announced by screen
   // readers and not available on touch. Expose the meaning of the options via
   // a visible hint that is wired to the <select> with aria-describedby, plus

--- a/dashboard/app/__tests__/review-page.test.tsx
+++ b/dashboard/app/__tests__/review-page.test.tsx
@@ -440,4 +440,50 @@ describe("ReviewPage", () => {
     const refreshOption = options.find((o) => o.value === "refresh_data");
     expect(refreshOption?.textContent).toMatch(/Actualizar datos/);
   });
+
+  // ─── Accessible regenerate hint (Copilot review on PR #402) ───────────────
+  // Native `<option title>` tooltips are not reliably announced by screen
+  // readers and not available on touch. Expose the meaning of the options via
+  // a visible hint that is wired to the <select> with aria-describedby, plus
+  // an accessible name on the select itself.
+
+  it("regenerate select exposes an accessible name + describedby hint", async () => {
+    installGenerateSuccessFetch();
+
+    render(<ReviewPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No hay revisiones anteriores")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("generate-button"));
+    });
+
+    const select = await screen.findByTestId("regen-mode-select");
+    // Accessible name must not rely solely on the native title attribute.
+    expect(select.getAttribute("aria-label")).toBeTruthy();
+    // aria-describedby must point at an existing element with a useful hint.
+    const describedById = select.getAttribute("aria-describedby");
+    expect(describedById).toBeTruthy();
+    const hint = document.getElementById(describedById!);
+    expect(hint).not.toBeNull();
+    expect(hint?.textContent ?? "").toMatch(/Elige cómo regenerar/);
+
+    // Hint updates with the selected mode so screen readers + touch users
+    // understand what each mode does without relying on option tooltips.
+    await act(async () => {
+      fireEvent.change(select, { target: { value: "alternate_angle" } });
+    });
+    expect(screen.getByTestId("regen-mode-hint").textContent ?? "").toMatch(
+      /Reformular análisis/,
+    );
+
+    await act(async () => {
+      fireEvent.change(select, { target: { value: "refresh_data" } });
+    });
+    expect(screen.getByTestId("regen-mode-hint").textContent ?? "").toMatch(
+      /Actualizar datos/,
+    );
+  });
 });

--- a/dashboard/app/__tests__/review-page.test.tsx
+++ b/dashboard/app/__tests__/review-page.test.tsx
@@ -407,4 +407,37 @@ describe("ReviewPage", () => {
 
     expect(screen.getByTestId("generate-button")).toBeInTheDocument();
   });
+
+  // ─── Regenerate dropdown wording (issue #399) ─────────────────────────────
+  // The "Ángulo alternativo" label was ambiguous. Rename to
+  // "Reformular análisis (nuevo enfoque)" while preserving the legacy
+  // `alternate_angle` value so the API/DB schema stays stable.
+
+  it("regenerate dropdown shows the new label while keeping the legacy value", async () => {
+    installGenerateSuccessFetch();
+
+    render(<ReviewPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No hay revisiones anteriores")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("generate-button"));
+    });
+
+    const select = await screen.findByTestId("regen-mode-select");
+    const options = Array.from(select.querySelectorAll("option"));
+    const altOption = options.find((o) => o.value === "alternate_angle");
+    expect(altOption).toBeDefined();
+    expect(altOption?.textContent).toMatch(/Reformular análisis/);
+    // Make sure the old ambiguous label is gone.
+    expect(altOption?.textContent).not.toMatch(/Ángulo alternativo/);
+    // Tooltip explains what the mode does.
+    expect(altOption?.getAttribute("title")).toMatch(/mismos datos/i);
+
+    // The "Actualizar datos" option must survive the rename.
+    const refreshOption = options.find((o) => o.value === "refresh_data");
+    expect(refreshOption?.textContent).toMatch(/Actualizar datos/);
+  });
 });

--- a/dashboard/app/review/page.tsx
+++ b/dashboard/app/review/page.tsx
@@ -68,6 +68,41 @@ function formatRelativeTime(isoStr: string): string {
   }
 }
 
+// ─── Regenerate-mode copy (single source of truth) ───────────────────────────
+// Describes each regenerate mode for the select `title`, the option `title`s,
+// and the accessible visible hint below the <select>. Keeping one map prevents
+// these strings from drifting out of sync.
+
+type RegenMode = "refresh_data" | "alternate_angle";
+
+interface RegenModeCopy {
+  label: string;
+  /** Short description used in option/select tooltips and the hint text. */
+  description: string;
+}
+
+const REGEN_MODE_COPY: Record<RegenMode, RegenModeCopy> = {
+  refresh_data: {
+    label: "Actualizar datos",
+    description: "Vuelve a ejecutar las consultas SQL para traer datos actualizados.",
+  },
+  alternate_angle: {
+    label: "Reformular análisis (nuevo enfoque)",
+    description:
+      "Vuelve a analizar los mismos datos con un enfoque distinto; no vuelve a ejecutar SQL.",
+  },
+};
+
+/** Fallback hint shown when no mode is selected. */
+const REGEN_MODE_DEFAULT_HINT =
+  "Elige cómo regenerar: actualizar datos reejecuta SQL; reformular análisis pide al modelo otro enfoque sobre los mismos datos.";
+
+function regenModeHint(mode: RegenMode | null): string {
+  if (mode === null) return REGEN_MODE_DEFAULT_HINT;
+  const copy = REGEN_MODE_COPY[mode];
+  return `${copy.label}: ${copy.description}`;
+}
+
 function ReviewSkeleton() {
   return (
     <div className="space-y-4 animate-pulse" aria-busy="true" role="status">
@@ -95,7 +130,7 @@ export default function ReviewPage() {
   const [revisions, setRevisions] = useState<RevisionMeta[]>([]);
   const [priorContent, setPriorContent] = useState<ReviewContent | null>(null);
   const [reviewError, setReviewError] = useState<ApiErrorResponse | string | null>(null);
-  const [regenMode, setRegenMode] = useState<"refresh_data" | "alternate_angle" | null>(null);
+  const [regenMode, setRegenMode] = useState<RegenMode | null>(null);
 
   const fetchPastReviews = useCallback(async () => {
     setListLoading(true);
@@ -360,30 +395,23 @@ export default function ReviewPage() {
                   className="text-xs rounded border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1"
                   value={regenMode ?? ""}
                   onChange={(e) =>
-                    setRegenMode(
-                      e.target.value === ""
-                        ? null
-                        : (e.target.value as "refresh_data" | "alternate_angle"),
-                    )
+                    setRegenMode(e.target.value === "" ? null : (e.target.value as RegenMode))
                   }
                   data-testid="regen-mode-select"
                   aria-label="Modo de regeneración de la revisión semanal"
                   aria-describedby="regen-mode-hint"
-                  title="Elige cómo regenerar: reejecuta SQL o pide al modelo otro enfoque sobre los mismos datos."
+                  title={REGEN_MODE_DEFAULT_HINT}
                 >
                   <option value="">Regenerar…</option>
-                  <option
-                    value="refresh_data"
-                    title="Vuelve a ejecutar las consultas SQL para traer datos actualizados."
-                  >
-                    Actualizar datos
-                  </option>
-                  <option
-                    value="alternate_angle"
-                    title="Vuelve a analizar los mismos datos con un enfoque distinto; no vuelve a ejecutar SQL."
-                  >
-                    Reformular análisis (nuevo enfoque)
-                  </option>
+                  {(Object.keys(REGEN_MODE_COPY) as RegenMode[]).map((mode) => (
+                    <option
+                      key={mode}
+                      value={mode}
+                      title={REGEN_MODE_COPY[mode].description}
+                    >
+                      {REGEN_MODE_COPY[mode].label}
+                    </option>
+                  ))}
                 </select>
                 <button
                   type="button"
@@ -400,18 +428,13 @@ export default function ReviewPage() {
                 `<option title>` tooltips are unreliable across browsers/touch
                 devices and not announced by screen readers, so we expose the
                 current mode's meaning here and wire it via `aria-describedby`.
-                See PR #402 Copilot feedback.
               */}
               <p
                 id="regen-mode-hint"
                 data-testid="regen-mode-hint"
                 className="text-[11px] leading-tight text-tremor-content dark:text-dark-tremor-content"
               >
-                {regenMode === "refresh_data"
-                  ? "Actualizar datos: vuelve a ejecutar las consultas SQL para traer datos actualizados."
-                  : regenMode === "alternate_angle"
-                    ? "Reformular análisis: vuelve a analizar los mismos datos con un enfoque distinto; no vuelve a ejecutar SQL."
-                    : "Elige cómo regenerar: actualizar datos reejecuta SQL; reformular análisis pide al modelo otro enfoque sobre los mismos datos."}
+                {regenModeHint(regenMode)}
               </p>
             </div>
           </div>

--- a/dashboard/app/review/page.tsx
+++ b/dashboard/app/review/page.tsx
@@ -93,12 +93,20 @@ const REGEN_MODE_COPY: Record<RegenMode, RegenModeCopy> = {
   },
 };
 
-/** Fallback hint shown when no mode is selected. */
+/** Fallback hint shown when no mode is selected or an unknown value slips in. */
 const REGEN_MODE_DEFAULT_HINT =
   "Elige cómo regenerar: actualizar datos reejecuta SQL; reformular análisis pide al modelo otro enfoque sobre los mismos datos.";
 
+/** Type guard — true iff `value` is a recognised regenerate mode. */
+function isRegenMode(value: string): value is RegenMode {
+  return Object.prototype.hasOwnProperty.call(REGEN_MODE_COPY, value);
+}
+
 function regenModeHint(mode: RegenMode | null): string {
-  if (mode === null) return REGEN_MODE_DEFAULT_HINT;
+  // Defensive: if an unexpected DOM value ever reaches state (e.g. a stale
+  // option from a previous build), fall back to the default hint rather than
+  // crashing on `REGEN_MODE_COPY[mode]` returning `undefined`.
+  if (mode === null || !isRegenMode(mode)) return REGEN_MODE_DEFAULT_HINT;
   const copy = REGEN_MODE_COPY[mode];
   return `${copy.label}: ${copy.description}`;
 }
@@ -394,9 +402,12 @@ export default function ReviewPage() {
                   id="regen-mode-select"
                   className="text-xs rounded border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1"
                   value={regenMode ?? ""}
-                  onChange={(e) =>
-                    setRegenMode(e.target.value === "" ? null : (e.target.value as RegenMode))
-                  }
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    // Only accept recognised modes; anything else resets to null
+                    // so downstream consumers (hint, regenerate) stay consistent.
+                    setRegenMode(v === "" || !isRegenMode(v) ? null : v);
+                  }}
                   data-testid="regen-mode-select"
                   aria-label="Modo de regeneración de la revisión semanal"
                   aria-describedby="regen-mode-hint"

--- a/dashboard/app/review/page.tsx
+++ b/dashboard/app/review/page.tsx
@@ -362,10 +362,21 @@ export default function ReviewPage() {
                   )
                 }
                 data-testid="regen-mode-select"
+                title="Elige cómo regenerar: reejecuta SQL o pide al modelo otro enfoque sobre los mismos datos."
               >
                 <option value="">Regenerar…</option>
-                <option value="refresh_data">Actualizar datos</option>
-                <option value="alternate_angle">Ángulo alternativo</option>
+                <option
+                  value="refresh_data"
+                  title="Vuelve a ejecutar las consultas SQL para traer datos actualizados."
+                >
+                  Actualizar datos
+                </option>
+                <option
+                  value="alternate_angle"
+                  title="Vuelve a analizar los mismos datos con un enfoque distinto; no vuelve a ejecutar SQL."
+                >
+                  Reformular análisis (nuevo enfoque)
+                </option>
               </select>
               <button
                 type="button"

--- a/dashboard/app/review/page.tsx
+++ b/dashboard/app/review/page.tsx
@@ -400,7 +400,7 @@ export default function ReviewPage() {
                   data-testid="regen-mode-select"
                   aria-label="Modo de regeneración de la revisión semanal"
                   aria-describedby="regen-mode-hint"
-                  title={REGEN_MODE_DEFAULT_HINT}
+                  title={regenModeHint(regenMode)}
                 >
                   <option value="">Regenerar…</option>
                   {(Object.keys(REGEN_MODE_COPY) as RegenMode[]).map((mode) => (

--- a/dashboard/app/review/page.tsx
+++ b/dashboard/app/review/page.tsx
@@ -350,43 +350,69 @@ export default function ReviewPage() {
                 })();
               }}
             />
-            <div className="flex items-center gap-2">
-              <select
-                className="text-xs rounded border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1"
-                value={regenMode ?? ""}
-                onChange={(e) =>
-                  setRegenMode(
-                    e.target.value === ""
-                      ? null
-                      : (e.target.value as "refresh_data" | "alternate_angle"),
-                  )
-                }
-                data-testid="regen-mode-select"
-                title="Elige cómo regenerar: reejecuta SQL o pide al modelo otro enfoque sobre los mismos datos."
-              >
-                <option value="">Regenerar…</option>
-                <option
-                  value="refresh_data"
-                  title="Vuelve a ejecutar las consultas SQL para traer datos actualizados."
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <label htmlFor="regen-mode-select" className="sr-only">
+                  Modo de regeneración
+                </label>
+                <select
+                  id="regen-mode-select"
+                  className="text-xs rounded border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1"
+                  value={regenMode ?? ""}
+                  onChange={(e) =>
+                    setRegenMode(
+                      e.target.value === ""
+                        ? null
+                        : (e.target.value as "refresh_data" | "alternate_angle"),
+                    )
+                  }
+                  data-testid="regen-mode-select"
+                  aria-label="Modo de regeneración de la revisión semanal"
+                  aria-describedby="regen-mode-hint"
+                  title="Elige cómo regenerar: reejecuta SQL o pide al modelo otro enfoque sobre los mismos datos."
                 >
-                  Actualizar datos
-                </option>
-                <option
-                  value="alternate_angle"
-                  title="Vuelve a analizar los mismos datos con un enfoque distinto; no vuelve a ejecutar SQL."
+                  <option value="">Regenerar…</option>
+                  <option
+                    value="refresh_data"
+                    title="Vuelve a ejecutar las consultas SQL para traer datos actualizados."
+                  >
+                    Actualizar datos
+                  </option>
+                  <option
+                    value="alternate_angle"
+                    title="Vuelve a analizar los mismos datos con un enfoque distinto; no vuelve a ejecutar SQL."
+                  >
+                    Reformular análisis (nuevo enfoque)
+                  </option>
+                </select>
+                <button
+                  type="button"
+                  disabled={!regenMode}
+                  onClick={() => void handleRegenerate()}
+                  className="rounded-md border border-tremor-border dark:border-dark-tremor-border px-3 py-1 text-xs font-medium disabled:opacity-40"
+                  data-testid="regenerate-button"
                 >
-                  Reformular análisis (nuevo enfoque)
-                </option>
-              </select>
-              <button
-                type="button"
-                disabled={!regenMode}
-                onClick={() => void handleRegenerate()}
-                className="rounded-md border border-tremor-border dark:border-dark-tremor-border px-3 py-1 text-xs font-medium disabled:opacity-40"
-                data-testid="regenerate-button"
+                  Regenerar
+                </button>
+              </div>
+              {/*
+                Accessible hint — visible to all users (not just hover). Native
+                `<option title>` tooltips are unreliable across browsers/touch
+                devices and not announced by screen readers, so we expose the
+                current mode's meaning here and wire it via `aria-describedby`.
+                See PR #402 Copilot feedback.
+              */}
+              <p
+                id="regen-mode-hint"
+                data-testid="regen-mode-hint"
+                className="text-[11px] leading-tight text-tremor-content dark:text-dark-tremor-content"
               >
-                Regenerar
-              </button>
+                {regenMode === "refresh_data"
+                  ? "Actualizar datos: vuelve a ejecutar las consultas SQL para traer datos actualizados."
+                  : regenMode === "alternate_angle"
+                    ? "Reformular análisis: vuelve a analizar los mismos datos con un enfoque distinto; no vuelve a ejecutar SQL."
+                    : "Elige cómo regenerar: actualizar datos reejecuta SQL; reformular análisis pide al modelo otro enfoque sobre los mismos datos."}
+              </p>
             </div>
           </div>
 

--- a/dashboard/components/ReviewDisplay.tsx
+++ b/dashboard/components/ReviewDisplay.tsx
@@ -214,7 +214,7 @@ export function ReviewDisplay({ review }: ReviewDisplayProps) {
           )}
           {review.quality_status === "degraded" && (
             <span
-              className="rounded px-2 py-0.5 bg-amber-500/20 text-amber-200 border border-amber-500/30"
+              className="rounded px-2 py-0.5 bg-amber-100 text-amber-900 border border-amber-300 dark:bg-amber-900/30 dark:text-amber-100 dark:border-amber-500/30"
               data-testid="quality-degraded"
             >
               Calidad de datos degradada
@@ -245,7 +245,7 @@ export function ReviewDisplay({ review }: ReviewDisplayProps) {
 
       {review.data_quality_notes.length > 0 && (
         <div
-          className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-100"
+          className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/50 dark:text-amber-100"
           data-testid="data-quality-notes"
         >
           <p className="font-semibold mb-1">Notas de calidad de datos</p>


### PR DESCRIPTION
Closes #399.

## Summary
- Swap low-contrast amber pill colors in `ReviewDisplay` for a dual palette (dark-ink amber on light mode, light-ink amber on dark mode) so both themes hit WCAG AA on the "Calidad de datos degradada" badge and the data-quality-notes panel.
- Rename the `alternate_angle` regenerate option from "Ángulo alternativo" to "Reformular análisis (nuevo enfoque)" and add tooltips on the select + both options. Legacy `alternate_angle` value is preserved so the API / `generation_mode` column is unchanged.
- Add vitest regression tests locking in the accessible amber classes and the new label + legacy value.

## Test plan
- [x] `npm run lint` clean.
- [x] `npm run test` — 1084 tests pass.
- [x] `npm run build` green.
- [ ] Manual: load `/review`, verify amber badge + notes are readable in both themes; hover the Regenerar dropdown to confirm the new label and tooltips surface correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)