### PR TITLE
feat(dashboard): searchable multi-select filters & expanded template filter set

### DIFF
--- a/dashboard/components/DashboardFiltersBar.tsx
+++ b/dashboard/components/DashboardFiltersBar.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { DashboardSpec, GlobalFilter } from "@/lib/schema";
 import type { GlobalFilterValues } from "@/lib/sql-filters";
 import type { DateRange } from "./DateRangePicker";
+import { FilterCombobox } from "./FilterCombobox";
 
 export interface DashboardFiltersBarProps {
   dashboardId: number;
@@ -15,7 +16,7 @@ export interface DashboardFiltersBarProps {
 
 type OptionRow = { value: string; label: string };
 
-/** HTML `<select>` value is always string — coerce stored numbers for controlled value. */
+/** HTML form value is always string — coerce stored numbers for controlled value. */
 function singleSelectFormValue(
   filter: GlobalFilter,
   value: GlobalFilterValues,
@@ -130,78 +131,64 @@ export function DashboardFiltersBar({
       <span className="text-xs font-semibold uppercase tracking-wide text-tremor-content-subtle dark:text-dark-tremor-content-subtle w-full sm:w-auto">
         Filtros
       </span>
-      {filters.map((f) => (
-        <div key={f.id} className="flex min-w-[160px] flex-col gap-1">
-          <label
-            htmlFor={`gf-${f.id}`}
-            className="text-xs text-tremor-content dark:text-dark-tremor-content"
-          >
-            {f.label}
-          </label>
-          {f.type === "single_select" ? (
-            <select
-              id={`gf-${f.id}`}
-              aria-label={f.label}
-              aria-busy={!!loading[f.id]}
-              className="rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1.5 text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis"
-              value={singleSelectFormValue(f, value)}
-              disabled={!!loading[f.id]}
-              onChange={(ev) => {
-                const v = ev.target.value;
-                const next = { ...value };
-                if (!v) delete next[f.id];
-                else if (f.value_type === "numeric") {
-                  const n = Number(v);
-                  next[f.id] = Number.isFinite(n) ? n : v;
-                } else {
-                  next[f.id] = v;
-                }
-                onChange(next);
-              }}
+      {filters.map((f) => {
+        const fOptions = optionsById[f.id] ?? [];
+        const fError = errors[f.id];
+        const fLoading = !!loading[f.id];
+        return (
+          <div key={f.id} className="flex min-w-[200px] flex-col gap-1">
+            <label
+              htmlFor={`gf-${f.id}`}
+              className="text-xs text-tremor-content dark:text-dark-tremor-content"
             >
-              <option value="">Todos</option>
-              {(optionsById[f.id] ?? []).map((o) => (
-                <option key={o.value} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </select>
-          ) : (
-            <select
-              id={`gf-${f.id}`}
-              multiple
-              aria-label={f.label}
-              aria-busy={!!loading[f.id]}
-              size={Math.min(6, Math.max(3, (optionsById[f.id] ?? []).length || 3))}
-              className="rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1.5 text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis min-h-[72px]"
-              disabled={!!loading[f.id]}
-              value={multiSelectFormValue(f, value)}
-              onChange={(ev) => {
-                const selected = Array.from(ev.target.selectedOptions).map((o) => o.value);
-                const next = { ...value };
-                if (selected.length === 0) delete next[f.id];
-                else if (f.value_type === "numeric") {
-                  next[f.id] = selected
-                    .map((s) => Number(s))
-                    .filter((n) => Number.isFinite(n));
-                } else {
-                  next[f.id] = selected;
-                }
-                onChange(next);
-              }}
-            >
-              {(optionsById[f.id] ?? []).map((o) => (
-                <option key={o.value} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </select>
-          )}
-          {errors[f.id] && (
-            <span className="text-xs text-red-500">{errors[f.id]}</span>
-          )}
-        </div>
-      ))}
+              {f.label}
+            </label>
+            {f.type === "single_select" ? (
+              <FilterCombobox
+                id={f.id}
+                label={f.label}
+                options={fOptions}
+                loading={fLoading}
+                error={fError ?? null}
+                value={singleSelectFormValue(f, value)}
+                onChange={(v) => {
+                  const next = { ...value };
+                  if (!v) delete next[f.id];
+                  else if (f.value_type === "numeric") {
+                    const n = Number(v);
+                    next[f.id] = Number.isFinite(n) ? n : v;
+                  } else {
+                    next[f.id] = v;
+                  }
+                  onChange(next);
+                }}
+              />
+            ) : (
+              <FilterCombobox
+                id={f.id}
+                label={f.label}
+                multiple
+                options={fOptions}
+                loading={fLoading}
+                error={fError ?? null}
+                value={multiSelectFormValue(f, value)}
+                onChange={(selected) => {
+                  const next = { ...value };
+                  if (selected.length === 0) delete next[f.id];
+                  else if (f.value_type === "numeric") {
+                    next[f.id] = selected
+                      .map((s) => Number(s))
+                      .filter((n) => Number.isFinite(n));
+                  } else {
+                    next[f.id] = selected;
+                  }
+                  onChange(next);
+                }}
+              />
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/dashboard/components/FilterCombobox.tsx
+++ b/dashboard/components/FilterCombobox.tsx
@@ -172,9 +172,18 @@ function MultiCombobox(props: MultiFilterComboboxProps) {
             className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background py-1 text-sm shadow-lg focus:outline-none"
           >
             {filtered.length === 0 ? (
-              <li className="px-3 py-2 text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+              // Intentionally a <div>, not a <li>: Headless UI
+              // ComboboxOptions is a <ul>, but the empty state is not an
+              // option (no role=option, no value) — keeping it as a <li>
+              // would pollute listbox semantics and trigger invalid-nesting
+              // warnings when the container tag changes.
+              <div
+                role="status"
+                aria-live="polite"
+                className="px-3 py-2 text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle"
+              >
                 {loading ? "Cargando…" : "Sin resultados"}
-              </li>
+              </div>
             ) : (
               filtered.map((opt) => (
                 <ComboboxOption
@@ -305,9 +314,18 @@ function SingleCombobox(props: SingleFilterComboboxProps) {
               Todos
             </ComboboxOption>
             {filtered.length === 0 ? (
-              <li className="px-3 py-2 text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+              // Intentionally a <div>, not a <li>: Headless UI
+              // ComboboxOptions is a <ul>, but the empty state is not an
+              // option (no role=option, no value) — keeping it as a <li>
+              // would pollute listbox semantics and trigger invalid-nesting
+              // warnings when the container tag changes.
+              <div
+                role="status"
+                aria-live="polite"
+                className="px-3 py-2 text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle"
+              >
                 {loading ? "Cargando…" : "Sin resultados"}
-              </li>
+              </div>
             ) : (
               filtered.map((opt) => (
                 <ComboboxOption

--- a/dashboard/components/FilterCombobox.tsx
+++ b/dashboard/components/FilterCombobox.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+/**
+ * FilterCombobox — searchable multi-select (or single-select) input for
+ * dashboard global filters.
+ *
+ * Built on @headlessui/react Combobox v2. In multi-select mode, selected
+ * values render as removable chips above the list of options. A search box
+ * filters options by their label client-side.
+ */
+import {
+  Combobox,
+  ComboboxButton,
+  ComboboxInput,
+  ComboboxOption,
+  ComboboxOptions,
+} from "@headlessui/react";
+import { useId, useMemo, useState } from "react";
+
+export interface FilterComboboxOption {
+  value: string;
+  label: string;
+}
+
+export interface FilterComboboxBaseProps {
+  id: string;
+  label: string;
+  options: FilterComboboxOption[];
+  placeholder?: string;
+  loading?: boolean;
+  disabled?: boolean;
+  error?: string | null;
+}
+
+export interface MultiFilterComboboxProps extends FilterComboboxBaseProps {
+  multiple: true;
+  value: string[];
+  onChange: (next: string[]) => void;
+}
+
+export interface SingleFilterComboboxProps extends FilterComboboxBaseProps {
+  multiple?: false;
+  value: string;
+  onChange: (next: string) => void;
+}
+
+export type FilterComboboxProps =
+  | MultiFilterComboboxProps
+  | SingleFilterComboboxProps;
+
+const CHIP_CLASS =
+  "inline-flex items-center gap-1 rounded-full bg-tremor-brand/10 dark:bg-dark-tremor-brand/20 px-2 py-0.5 text-xs text-tremor-brand dark:text-dark-tremor-brand";
+
+function filterOptions(
+  options: FilterComboboxOption[],
+  query: string,
+): FilterComboboxOption[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return options;
+  return options.filter((o) => o.label.toLowerCase().includes(q));
+}
+
+function labelByValue(options: FilterComboboxOption[], value: string): string {
+  const match = options.find((o) => o.value === value);
+  return match ? match.label : value;
+}
+
+/**
+ * Multi-select variant. Renders chips + search input + option list.
+ */
+function MultiCombobox(props: MultiFilterComboboxProps) {
+  const {
+    id,
+    label,
+    options,
+    value,
+    onChange,
+    placeholder,
+    loading,
+    disabled,
+    error,
+  } = props;
+  const [query, setQuery] = useState("");
+  const listId = useId();
+
+  const filtered = useMemo(() => filterOptions(options, query), [options, query]);
+
+  const handleRemove = (v: string) => {
+    onChange(value.filter((x) => x !== v));
+  };
+
+  const handleClear = () => {
+    onChange([]);
+    setQuery("");
+  };
+
+  return (
+    <div className="flex min-w-[200px] flex-col gap-1" data-testid={`filter-combobox-${id}`}>
+      <Combobox
+        multiple
+        value={value}
+        onChange={(next: string[]) => {
+          onChange(next);
+          setQuery("");
+        }}
+        disabled={disabled || loading}
+      >
+        <div className="relative">
+          <div
+            className={`flex min-h-[36px] w-full flex-wrap items-center gap-1 rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1.5 text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis ${
+              disabled || loading ? "opacity-60" : ""
+            }`}
+          >
+            {value.map((v) => (
+              <span key={v} className={CHIP_CLASS} data-testid={`filter-chip-${id}-${v}`}>
+                {labelByValue(options, v)}
+                <button
+                  type="button"
+                  aria-label={`Quitar ${labelByValue(options, v)}`}
+                  className="leading-none text-tremor-brand hover:text-tremor-brand-emphasis dark:text-dark-tremor-brand"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleRemove(v);
+                  }}
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+            <ComboboxInput
+              id={`gf-${id}`}
+              aria-label={label}
+              aria-busy={!!loading}
+              aria-controls={listId}
+              className="min-w-[120px] flex-1 bg-transparent text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis outline-none placeholder:text-tremor-content-subtle dark:placeholder:text-dark-tremor-content-subtle"
+              placeholder={value.length === 0 ? (placeholder ?? "Buscar…") : ""}
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  setQuery("");
+                }
+              }}
+              displayValue={() => query}
+            />
+            {value.length > 0 && !disabled && !loading ? (
+              <button
+                type="button"
+                aria-label="Limpiar selección"
+                className="ml-1 text-xs text-tremor-content-subtle hover:text-tremor-content-emphasis dark:text-dark-tremor-content-subtle dark:hover:text-dark-tremor-content-emphasis"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleClear();
+                }}
+              >
+                Limpiar
+              </button>
+            ) : null}
+            <ComboboxButton
+              aria-label={`Abrir opciones de ${label}`}
+              className="ml-1 text-tremor-content-subtle dark:text-dark-tremor-content-subtle"
+            >
+              ▾
+            </ComboboxButton>
+          </div>
+          <ComboboxOptions
+            id={listId}
+            className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background py-1 text-sm shadow-lg focus:outline-none"
+          >
+            {filtered.length === 0 ? (
+              <li className="px-3 py-2 text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                {loading ? "Cargando…" : "Sin resultados"}
+              </li>
+            ) : (
+              filtered.map((opt) => (
+                <ComboboxOption
+                  key={opt.value}
+                  value={opt.value}
+                  className={({ focus, selected }) =>
+                    `flex cursor-pointer items-center gap-2 px-3 py-1.5 ${
+                      focus
+                        ? "bg-tremor-background-muted dark:bg-dark-tremor-background-muted"
+                        : ""
+                    } ${selected ? "font-semibold" : ""}`
+                  }
+                >
+                  {({ selected }) => (
+                    <>
+                      <span
+                        aria-hidden="true"
+                        className={`inline-block h-3 w-3 shrink-0 rounded-sm border ${
+                          selected
+                            ? "border-tremor-brand bg-tremor-brand dark:border-dark-tremor-brand dark:bg-dark-tremor-brand"
+                            : "border-tremor-border dark:border-dark-tremor-border"
+                        }`}
+                      />
+                      <span>{opt.label}</span>
+                    </>
+                  )}
+                </ComboboxOption>
+              ))
+            )}
+          </ComboboxOptions>
+        </div>
+      </Combobox>
+      {error ? (
+        <span className="text-xs text-red-500">{error}</span>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Single-select variant. Renders a search input + option list.
+ */
+function SingleCombobox(props: SingleFilterComboboxProps) {
+  const {
+    id,
+    label,
+    options,
+    value,
+    onChange,
+    placeholder,
+    loading,
+    disabled,
+    error,
+  } = props;
+  const [query, setQuery] = useState("");
+  const listId = useId();
+
+  const filtered = useMemo(() => filterOptions(options, query), [options, query]);
+
+  return (
+    <div className="flex min-w-[200px] flex-col gap-1" data-testid={`filter-combobox-${id}`}>
+      <Combobox
+        value={value}
+        onChange={(next: string | null) => {
+          onChange(next ?? "");
+          setQuery("");
+        }}
+        disabled={disabled || loading}
+      >
+        <div className="relative">
+          <div
+            className={`flex min-h-[36px] w-full items-center gap-1 rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1.5 text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis ${
+              disabled || loading ? "opacity-60" : ""
+            }`}
+          >
+            <ComboboxInput
+              id={`gf-${id}`}
+              aria-label={label}
+              aria-busy={!!loading}
+              aria-controls={listId}
+              className="flex-1 bg-transparent text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis outline-none placeholder:text-tremor-content-subtle dark:placeholder:text-dark-tremor-content-subtle"
+              placeholder={placeholder ?? "Buscar…"}
+              onChange={(event) => setQuery(event.target.value)}
+              displayValue={(v: string) => labelByValue(options, v || "")}
+            />
+            {value && !disabled && !loading ? (
+              <button
+                type="button"
+                aria-label="Limpiar selección"
+                className="ml-1 text-xs text-tremor-content-subtle hover:text-tremor-content-emphasis dark:text-dark-tremor-content-subtle dark:hover:text-dark-tremor-content-emphasis"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onChange("");
+                  setQuery("");
+                }}
+              >
+                Limpiar
+              </button>
+            ) : null}
+            <ComboboxButton
+              aria-label={`Abrir opciones de ${label}`}
+              className="ml-1 text-tremor-content-subtle dark:text-dark-tremor-content-subtle"
+            >
+              ▾
+            </ComboboxButton>
+          </div>
+          <ComboboxOptions
+            id={listId}
+            className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background py-1 text-sm shadow-lg focus:outline-none"
+          >
+            <ComboboxOption
+              value=""
+              className={({ focus }) =>
+                `cursor-pointer px-3 py-1.5 italic text-tremor-content-subtle dark:text-dark-tremor-content-subtle ${
+                  focus ? "bg-tremor-background-muted dark:bg-dark-tremor-background-muted" : ""
+                }`
+              }
+            >
+              Todos
+            </ComboboxOption>
+            {filtered.length === 0 ? (
+              <li className="px-3 py-2 text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                {loading ? "Cargando…" : "Sin resultados"}
+              </li>
+            ) : (
+              filtered.map((opt) => (
+                <ComboboxOption
+                  key={opt.value}
+                  value={opt.value}
+                  className={({ focus, selected }) =>
+                    `cursor-pointer px-3 py-1.5 ${
+                      focus
+                        ? "bg-tremor-background-muted dark:bg-dark-tremor-background-muted"
+                        : ""
+                    } ${selected ? "font-semibold" : ""}`
+                  }
+                >
+                  {opt.label}
+                </ComboboxOption>
+              ))
+            )}
+          </ComboboxOptions>
+        </div>
+      </Combobox>
+      {error ? (
+        <span className="text-xs text-red-500">{error}</span>
+      ) : null}
+    </div>
+  );
+}
+
+export function FilterCombobox(props: FilterComboboxProps) {
+  if (props.multiple) {
+    return <MultiCombobox {...props} />;
+  }
+  return <SingleCombobox {...props} />;
+}

--- a/dashboard/components/FilterCombobox.tsx
+++ b/dashboard/components/FilterCombobox.tsx
@@ -85,11 +85,15 @@ function MultiCombobox(props: MultiFilterComboboxProps) {
 
   const filtered = useMemo(() => filterOptions(options, query), [options, query]);
 
+  const isLocked = Boolean(disabled || loading);
+
   const handleRemove = (v: string) => {
+    if (isLocked) return;
     onChange(value.filter((x) => x !== v));
   };
 
   const handleClear = () => {
+    if (isLocked) return;
     onChange([]);
     setQuery("");
   };
@@ -117,7 +121,8 @@ function MultiCombobox(props: MultiFilterComboboxProps) {
                 <button
                   type="button"
                   aria-label={`Quitar ${labelByValue(options, v)}`}
-                  className="leading-none text-tremor-brand hover:text-tremor-brand-emphasis dark:text-dark-tremor-brand"
+                  className="leading-none text-tremor-brand hover:text-tremor-brand-emphasis dark:text-dark-tremor-brand disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={isLocked}
                   onClick={(e) => {
                     e.stopPropagation();
                     handleRemove(v);
@@ -253,6 +258,15 @@ function SingleCombobox(props: SingleFilterComboboxProps) {
               className="flex-1 bg-transparent text-sm text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis outline-none placeholder:text-tremor-content-subtle dark:placeholder:text-dark-tremor-content-subtle"
               placeholder={placeholder ?? "Buscar…"}
               onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={(event) => {
+                // Headless UI owns Escape for closing the listbox; we only
+                // consume it here when the user has typed a query so that
+                // Esc clears the in-progress search text without preventing
+                // the default close behavior.
+                if (event.key === "Escape" && query) {
+                  setQuery("");
+                }
+              }}
               displayValue={(v: string) => labelByValue(options, v || "")}
             />
             {value && !disabled && !loading ? (

--- a/dashboard/components/__tests__/DashboardFiltersBar.test.tsx
+++ b/dashboard/components/__tests__/DashboardFiltersBar.test.tsx
@@ -1,9 +1,17 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { DashboardFiltersBar } from "../DashboardFiltersBar";
 import type { DashboardSpec } from "@/lib/schema";
+
+// Headless UI Combobox uses ResizeObserver internally
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 
 const baseSpec: DashboardSpec = {
   title: "T",
@@ -34,6 +42,27 @@ const numericSpec: DashboardSpec = {
   ],
 };
 
+const multiSpec: DashboardSpec = {
+  ...baseSpec,
+  filters: [
+    {
+      id: "familia",
+      type: "multi_select",
+      label: "Familia",
+      bind_expr: `fm."fami_grup_marc"`,
+      value_type: "text",
+      options_sql: "SELECT 1",
+    },
+  ],
+};
+
+function mockOptions(opts: { value: string; label: string }[]) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ options: opts }),
+  } as unknown as Response);
+}
+
 describe("DashboardFiltersBar", () => {
   const originalFetch = globalThis.fetch;
 
@@ -45,11 +74,11 @@ describe("DashboardFiltersBar", () => {
     globalThis.fetch = originalFetch;
   });
 
-  it("loads options and calls onChange when selection changes", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ options: [{ value: "A", label: "Alfa" }] }),
-    } as unknown as Response);
+  it("loads options and calls onChange when single selection changes", async () => {
+    mockOptions([
+      { value: "A", label: "Alfa" },
+      { value: "B", label: "Beta" },
+    ]);
 
     const onChange = vi.fn();
 
@@ -66,22 +95,31 @@ describe("DashboardFiltersBar", () => {
       expect(screen.getByTestId("global-filters-bar")).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByLabelText("Tienda"), { target: { value: "A" } });
+    // Wait for options to actually be loaded into the UI, then open + click.
+    const input = screen.getByLabelText("Tienda") as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      fireEvent.click(screen.getByLabelText(/Abrir opciones de Tienda/));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Alfa")).toBeInTheDocument();
+    });
+    await act(async () => {
+      const el = screen.getByText("Alfa");
+      fireEvent.pointerDown(el);
+      fireEvent.mouseDown(el);
+      fireEvent.mouseUp(el);
+      fireEvent.click(el);
+    });
 
     expect(onChange).toHaveBeenCalledWith({ tienda: "A" });
   });
 
   it("shows numeric single_select selection and emits a number", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          options: [
-            { value: "42", label: "42" },
-            { value: "7", label: "7" },
-          ],
-        }),
-    } as unknown as Response);
+    mockOptions([
+      { value: "42", label: "42" },
+      { value: "7", label: "7" },
+    ]);
 
     const onChange = vi.fn();
 
@@ -98,10 +136,61 @@ describe("DashboardFiltersBar", () => {
       expect(screen.getByTestId("global-filters-bar")).toBeInTheDocument();
     });
 
-    const sel = screen.getByLabelText("N") as HTMLSelectElement;
-    expect(sel.value).toBe("42");
-
-    fireEvent.change(sel, { target: { value: "7" } });
+    const nInput = screen.getByLabelText("N") as HTMLInputElement;
+    await act(async () => {
+      nInput.focus();
+      fireEvent.click(screen.getByLabelText(/Abrir opciones de N/));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("7")).toBeInTheDocument();
+    });
+    await act(async () => {
+      const el = screen.getByText("7");
+      fireEvent.pointerDown(el);
+      fireEvent.mouseDown(el);
+      fireEvent.mouseUp(el);
+      fireEvent.click(el);
+    });
     expect(onChange).toHaveBeenCalledWith({ n: 7 });
+  });
+
+  it("multi_select emits an array of string values", async () => {
+    mockOptions([
+      { value: "CAMI", label: "Camisetas" },
+      { value: "PAN", label: "Pantalones" },
+    ]);
+
+    const onChange = vi.fn();
+
+    render(
+      <DashboardFiltersBar
+        dashboardId={1}
+        spec={multiSpec}
+        value={{}}
+        onChange={onChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("global-filters-bar")).toBeInTheDocument();
+    });
+
+    const famInput = screen.getByLabelText("Familia") as HTMLInputElement;
+    await act(async () => {
+      famInput.focus();
+      fireEvent.click(screen.getByLabelText(/Abrir opciones de Familia/));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Camisetas")).toBeInTheDocument();
+    });
+    await act(async () => {
+      const el = screen.getByText("Camisetas");
+      fireEvent.pointerDown(el);
+      fireEvent.mouseDown(el);
+      fireEvent.mouseUp(el);
+      fireEvent.click(el);
+    });
+
+    expect(onChange).toHaveBeenCalledWith({ familia: ["CAMI"] });
   });
 });

--- a/dashboard/components/__tests__/FilterCombobox.test.tsx
+++ b/dashboard/components/__tests__/FilterCombobox.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, within, act } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { FilterCombobox, type FilterComboboxOption } from "../FilterCombobox";
+
+// Headless UI Combobox uses ResizeObserver internally
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+const OPTIONS: FilterComboboxOption[] = [
+  { value: "CAMI", label: "Camisetas" },
+  { value: "PAN", label: "Pantalones" },
+  { value: "ZAP", label: "Zapatos" },
+];
+
+async function openAndType(labelText: string, typed?: string) {
+  const input = screen.getByLabelText(labelText) as HTMLInputElement;
+  await act(async () => {
+    input.focus();
+    fireEvent.focus(input);
+    fireEvent.click(screen.getByLabelText(`Abrir opciones de ${labelText}`));
+    if (typed !== undefined) fireEvent.change(input, { target: { value: typed } });
+  });
+  return input;
+}
+
+async function clickOption(text: string) {
+  const opt = screen.getByText(text);
+  // Headless UI's ComboboxOption uses pointer + click. Mousedown then click
+  // matches the real browser flow better than click alone.
+  await act(async () => {
+    fireEvent.pointerDown(opt);
+    fireEvent.mouseDown(opt);
+    fireEvent.mouseUp(opt);
+    fireEvent.click(opt);
+  });
+}
+
+describe("FilterCombobox (multi)", () => {
+  it("renders the search input with the filter label", () => {
+    render(
+      <FilterCombobox
+        id="familia"
+        label="Familia"
+        multiple
+        options={OPTIONS}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText("Familia")).toBeInTheDocument();
+  });
+
+  it("filters options client-side when the user types", async () => {
+    render(
+      <FilterCombobox
+        id="familia"
+        label="Familia"
+        multiple
+        options={OPTIONS}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    await openAndType("Familia", "cami");
+    expect(screen.getByText("Camisetas")).toBeInTheDocument();
+    expect(screen.queryByText("Pantalones")).not.toBeInTheDocument();
+    expect(screen.queryByText("Zapatos")).not.toBeInTheDocument();
+  });
+
+  it("selecting an option emits an array with the new value", async () => {
+    const onChange = vi.fn();
+    render(
+      <FilterCombobox
+        id="familia"
+        label="Familia"
+        multiple
+        options={OPTIONS}
+        value={[]}
+        onChange={onChange}
+      />,
+    );
+    await openAndType("Familia");
+    await clickOption("Camisetas");
+    expect(onChange).toHaveBeenCalledWith(["CAMI"]);
+  });
+
+  it("selecting adds to an existing selection", async () => {
+    const onChange = vi.fn();
+    render(
+      <FilterCombobox
+        id="familia"
+        label="Familia"
+        multiple
+        options={OPTIONS}
+        value={["CAMI"]}
+        onChange={onChange}
+      />,
+    );
+    await openAndType("Familia");
+    await clickOption("Pantalones");
+    expect(onChange).toHaveBeenCalledWith(["CAMI", "PAN"]);
+  });
+
+  it("clicking the chip × button removes that value", () => {
+    const onChange = vi.fn();
+    render(
+      <FilterCombobox
+        id="familia"
+        label="Familia"
+        multiple
+        options={OPTIONS}
+        value={["CAMI", "PAN"]}
+        onChange={onChange}
+      />,
+    );
+    const chip = screen.getByTestId("filter-chip-familia-CAMI");
+    fireEvent.click(within(chip).getByRole("button", { name: /Quitar Camisetas/ }));
+    expect(onChange).toHaveBeenCalledWith(["PAN"]);
+  });
+
+  it("Limpiar clears all selections", () => {
+    const onChange = vi.fn();
+    render(
+      <FilterCombobox
+        id="familia"
+        label="Familia"
+        multiple
+        options={OPTIONS}
+        value={["CAMI", "PAN"]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Limpiar selección/ }));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("pressing Escape resets the search query", async () => {
+    render(
+      <FilterCombobox
+        id="familia"
+        label="Familia"
+        multiple
+        options={OPTIONS}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    const input = await openAndType("Familia", "cami");
+    expect(input.value).toBe("cami");
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(input.value).toBe("");
+  });
+
+  it("shows 'Sin resultados' when no option matches the query", async () => {
+    render(
+      <FilterCombobox
+        id="familia"
+        label="Familia"
+        multiple
+        options={OPTIONS}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    await openAndType("Familia", "xxyyzz");
+    expect(screen.getByText("Sin resultados")).toBeInTheDocument();
+  });
+});
+
+describe("FilterCombobox (single)", () => {
+  it("emits empty string when 'Todos' is picked", async () => {
+    const onChange = vi.fn();
+    render(
+      <FilterCombobox
+        id="tienda"
+        label="Tienda"
+        options={OPTIONS}
+        value="CAMI"
+        onChange={onChange}
+      />,
+    );
+    await openAndType("Tienda");
+    await clickOption("Todos");
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("emits the selected option's value", async () => {
+    const onChange = vi.fn();
+    render(
+      <FilterCombobox
+        id="tienda"
+        label="Tienda"
+        options={OPTIONS}
+        value=""
+        onChange={onChange}
+      />,
+    );
+    await openAndType("Tienda");
+    await clickOption("Pantalones");
+    expect(onChange).toHaveBeenCalledWith("PAN");
+  });
+});

--- a/dashboard/lib/__tests__/template-global-filters.test.ts
+++ b/dashboard/lib/__tests__/template-global-filters.test.ts
@@ -21,8 +21,8 @@ const ALL_SETS = {
 };
 
 describe.each(Object.entries(ALL_SETS))("template-global-filters: %s set", (name, set) => {
-  it(`${name} set has at least two filters`, () => {
-    expect(set.length).toBeGreaterThanOrEqual(2);
+  it(`${name} set has at least one filter`, () => {
+    expect(set.length).toBeGreaterThanOrEqual(1);
   });
 
   it(`${name} filters each pass GlobalFilterSchema`, () => {
@@ -82,9 +82,19 @@ describe("stock filter coverage", () => {
 });
 
 describe("compras filter coverage", () => {
-  it("includes proveedor_compras and familia", () => {
+  it("includes proveedor_compras", () => {
     const ids = templateGlobalFiltersCompras.map((f) => f.id);
-    expect(ids).toEqual(expect.arrayContaining(["proveedor_compras", "familia"]));
+    expect(ids).toEqual(expect.arrayContaining(["proveedor_compras"]));
+  });
+
+  // Guardrail: we removed familia/temporada from compras because no compras
+  // widget joins ps_lineas_compras → ps_articulos → ps_familias. If someone
+  // wires those joins in later, they should add the filter AND remove this
+  // exclusion rather than silently reintroducing dead chrome.
+  it("does NOT include familia or temporada (no compras widget joins articulos)", () => {
+    const ids = templateGlobalFiltersCompras.map((f) => f.id);
+    expect(ids).not.toContain("familia");
+    expect(ids).not.toContain("temporada");
   });
 });
 

--- a/dashboard/lib/__tests__/template-global-filters.test.ts
+++ b/dashboard/lib/__tests__/template-global-filters.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import {
+  templateGlobalFiltersRetail,
+  templateGlobalFiltersMayorista,
+  templateGlobalFiltersStock,
+  templateGlobalFiltersCompras,
+} from "../template-global-filters";
+import { compileGlobalFilterSql, listReferencedGlobalFilterIds } from "../sql-filters";
+import { TEMPLATES } from "../templates";
+import { GlobalFilterSchema } from "../schema";
+
+// ---------------------------------------------------------------------------
+// Catalog shape
+// ---------------------------------------------------------------------------
+
+const ALL_SETS = {
+  retail: templateGlobalFiltersRetail,
+  mayorista: templateGlobalFiltersMayorista,
+  stock: templateGlobalFiltersStock,
+  compras: templateGlobalFiltersCompras,
+};
+
+describe.each(Object.entries(ALL_SETS))("template-global-filters: %s set", (name, set) => {
+  it(`${name} set has at least two filters`, () => {
+    expect(set.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it(`${name} filters each pass GlobalFilterSchema`, () => {
+    for (const f of set) {
+      const res = GlobalFilterSchema.safeParse(f);
+      expect(res.success, `${f.id} should be valid`).toBe(true);
+    }
+  });
+
+  it(`${name} filter ids are unique within the set`, () => {
+    const ids = set.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it(`${name} options_sql returns value + label (lexical check)`, () => {
+    for (const f of set) {
+      expect(f.options_sql).toMatch(/\bAS\s+value\b/i);
+      expect(f.options_sql).toMatch(/\bAS\s+label\b/i);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retail set must cover issue #401 requirements
+// ---------------------------------------------------------------------------
+
+describe("retail filter coverage", () => {
+  it("includes tienda, familia, temporada, marca, sexo, departamento", () => {
+    const ids = templateGlobalFiltersRetail.map((f) => f.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "tienda",
+        "familia",
+        "temporada",
+        "marca",
+        "sexo",
+        "departamento",
+      ]),
+    );
+  });
+});
+
+describe("mayorista filter coverage", () => {
+  it("includes cliente_mayorista, familia, temporada, marca", () => {
+    const ids = templateGlobalFiltersMayorista.map((f) => f.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(["cliente_mayorista", "familia", "temporada", "marca"]),
+    );
+  });
+});
+
+describe("stock filter coverage", () => {
+  it("includes tienda, familia, temporada", () => {
+    const ids = templateGlobalFiltersStock.map((f) => f.id);
+    expect(ids).toEqual(expect.arrayContaining(["tienda", "familia", "temporada"]));
+  });
+});
+
+describe("compras filter coverage", () => {
+  it("includes proveedor_compras and familia", () => {
+    const ids = templateGlobalFiltersCompras.map((f) => f.id);
+    expect(ids).toEqual(expect.arrayContaining(["proveedor_compras", "familia"]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compileGlobalFilterSql integration: every filter in every set behaves right
+// both when inactive (TRUE) and active (IN fragment). This catches any typo
+// in bind_expr or value_type that would break the pipeline at runtime.
+// ---------------------------------------------------------------------------
+
+describe("filter compilation — inactive yields TRUE, active yields parameterized WHERE", () => {
+  for (const [setName, filters] of Object.entries(ALL_SETS)) {
+    for (const filter of filters) {
+      const token = `__gf_${filter.id}__`;
+      const baseSql = `SELECT 1 WHERE ${token}`;
+
+      it(`${setName}.${filter.id}: inactive → TRUE`, () => {
+        const { sql, params } = compileGlobalFilterSql(baseSql, filters, {});
+        expect(sql).toBe("SELECT 1 WHERE TRUE");
+        expect(params).toEqual([]);
+      });
+
+      it(`${setName}.${filter.id}: active emits parameterized fragment`, () => {
+        const sample =
+          filter.type === "single_select"
+            ? filter.value_type === "numeric"
+              ? 42
+              : "SAMPLE"
+            : filter.value_type === "numeric"
+              ? [1, 2]
+              : ["A", "B"];
+        const { sql, params } = compileGlobalFilterSql(baseSql, filters, {
+          [filter.id]: sample,
+        });
+        expect(sql).not.toContain(token);
+        expect(sql).toContain("$1");
+        expect(params).toHaveLength(1);
+        if (filter.type === "multi_select") {
+          expect(Array.isArray(params[0])).toBe(true);
+        }
+      });
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Every widget SQL in every template compiles cleanly with every declared
+// template-filter inactive. This guarantees that adding new `__gf_*__` tokens
+// doesn't break widgets that don't reference them (they remain untouched)
+// and tokens present in widget SQL resolve to TRUE without parameters.
+// ---------------------------------------------------------------------------
+
+describe("widget SQL + filter pipeline — empty selections keep SQL valid", () => {
+  for (const template of TEMPLATES) {
+    it(`${template.slug}: every widget SQL compiles with no active filters`, () => {
+      const filters = template.spec.filters ?? [];
+      for (const widget of template.spec.widgets) {
+        const sqlStrings: string[] =
+          widget.type === "kpi_row"
+            ? widget.items.map((i) => i.sql)
+            : [widget.sql];
+        for (const rawSql of sqlStrings) {
+          const { sql, params } = compileGlobalFilterSql(rawSql, filters, {});
+          // Every token referenced in the widget SQL must belong to the
+          // template filter set — otherwise it would remain unreplaced.
+          const remaining = listReferencedGlobalFilterIds(sql);
+          expect(remaining, `widget with orphan filter tokens: ${remaining.join(",")}`).toEqual([]);
+          // Inactive compile never emits params.
+          expect(params).toEqual([]);
+        }
+      }
+    });
+  }
+});
+
+describe("widget SQL references only known template filter ids", () => {
+  for (const template of TEMPLATES) {
+    it(`${template.slug}: every __gf_<id>__ token in widget SQL is declared in spec.filters`, () => {
+      const declared = new Set((template.spec.filters ?? []).map((f) => f.id));
+      for (const widget of template.spec.widgets) {
+        const sqlStrings: string[] =
+          widget.type === "kpi_row"
+            ? widget.items.map((i) => i.sql)
+            : [widget.sql];
+        for (const sql of sqlStrings) {
+          for (const id of listReferencedGlobalFilterIds(sql)) {
+            expect(declared.has(id), `${template.slug} references undeclared filter id ${id}`).toBe(true);
+          }
+        }
+      }
+    });
+  }
+});

--- a/dashboard/lib/template-global-filters.ts
+++ b/dashboard/lib/template-global-filters.ts
@@ -1,32 +1,56 @@
 import type { GlobalFilter } from "./schema";
 
 /**
- * Default global filters for retail-heavy dashboard templates (v1).
- * Widget SQL must alias `ps_ventas` as `v` where `__gf_tienda__` is used, and
- * include joins to `ps_familias` as `fm` where `__gf_familia__` is used.
+ * Global filters for pre-built dashboard templates.
+ *
+ * Each filter declaration wires a combobox in the dashboard chrome to a
+ * `__gf_<id>__` token that widget SQL can reference inside a WHERE clause.
+ * When a filter is inactive (no selection) the token expands to `TRUE`,
+ * so widgets that don't use a given filter don't need to change.
+ *
+ * ## Alias conventions used by the widget SQL
+ * Widgets that opt into each filter MUST use these aliases (or an equivalent
+ * joined column) so that `bind_expr` matches:
+ *
+ *   v   — "public"."ps_ventas"
+ *   lv  — "public"."ps_lineas_ventas"
+ *   p   — "public"."ps_articulos"   (alias `pa` is also tolerated by aliasing bind_expr)
+ *   fm  — "public"."ps_familias"
+ *   pr  — "public"."ps_proveedores"
+ *   lf  — "public"."ps_gc_lin_facturas"
+ *   f   — "public"."ps_gc_facturas"
+ *   c   — "public"."ps_clientes"
+ *   s   — "public"."ps_stock_tienda"
+ *   lc  — "public"."ps_lineas_compras"
+ *   co  — "public"."ps_compras"
  */
-export const templateGlobalFiltersRetail: GlobalFilter[] = [
-  {
-    id: "tienda",
-    type: "single_select",
-    label: "Tienda",
-    bind_expr: `v."tienda"`,
-    value_type: "text",
-    options_sql: `SELECT DISTINCT v."tienda" AS value, v."tienda" AS label
+
+// ---------------------------------------------------------------------------
+// Individual filter definitions
+// ---------------------------------------------------------------------------
+
+const TIENDA: GlobalFilter = {
+  id: "tienda",
+  type: "single_select",
+  label: "Tienda",
+  bind_expr: `v."tienda"`,
+  value_type: "text",
+  options_sql: `SELECT DISTINCT v."tienda" AS value, v."tienda" AS label
 FROM "public"."ps_ventas" v
 WHERE v."entrada" = true
   AND v."tienda" <> '99'
   AND v."fecha_creacion" >= :curr_from
   AND v."fecha_creacion" <= :curr_to
 ORDER BY 1`,
-  },
-  {
-    id: "familia",
-    type: "multi_select",
-    label: "Familia",
-    bind_expr: `fm."fami_grup_marc"`,
-    value_type: "text",
-    options_sql: `SELECT DISTINCT fm."fami_grup_marc" AS value, fm."fami_grup_marc" AS label
+};
+
+const FAMILIA: GlobalFilter = {
+  id: "familia",
+  type: "multi_select",
+  label: "Familia",
+  bind_expr: `fm."fami_grup_marc"`,
+  value_type: "text",
+  options_sql: `SELECT DISTINCT fm."fami_grup_marc" AS value, fm."fami_grup_marc" AS label
 FROM "public"."ps_lineas_ventas" lv
 JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
 JOIN "public"."ps_articulos" p ON lv."codigo" = p."codigo"
@@ -37,5 +61,159 @@ WHERE v."entrada" = true
   AND lv."fecha_creacion" <= :curr_to
   AND __gf_tienda__
 ORDER BY 1`,
-  },
+};
+
+/** Temporada (clave code of the season, e.g. "75" for PV12). Text key stored on ps_articulos.clave_temporada. */
+const TEMPORADA: GlobalFilter = {
+  id: "temporada",
+  type: "multi_select",
+  label: "Temporada",
+  bind_expr: `p."clave_temporada"`,
+  value_type: "text",
+  options_sql: `SELECT DISTINCT t."clave" AS value,
+       COALESCE(NULLIF(t."temporada_tipo", ''), t."clave") AS label
+FROM "public"."ps_temporadas" t
+WHERE t."clave" IS NOT NULL AND t."clave" <> ''
+ORDER BY 1`,
+};
+
+/** Marca (brand). Joined via ps_articulos.num_marca → ps_marcas.reg_marca. */
+const MARCA: GlobalFilter = {
+  id: "marca",
+  type: "multi_select",
+  label: "Marca",
+  bind_expr: `p."num_marca"`,
+  value_type: "numeric",
+  options_sql: `SELECT m."reg_marca" AS value, m."clave" AS label
+FROM "public"."ps_marcas" m
+WHERE m."clave" IS NOT NULL AND m."clave" <> ''
+ORDER BY 2`,
+};
+
+/** Sexo — plain text on ps_articulos.sexo (HOMBRE / MUJER / …). */
+const SEXO: GlobalFilter = {
+  id: "sexo",
+  type: "multi_select",
+  label: "Sexo",
+  bind_expr: `p."sexo"`,
+  value_type: "text",
+  options_sql: `SELECT DISTINCT p."sexo" AS value, p."sexo" AS label
+FROM "public"."ps_articulos" p
+WHERE p."sexo" IS NOT NULL AND p."sexo" <> ''
+ORDER BY 1`,
+};
+
+/** Departamento — FK numeric on ps_articulos.num_departament → ps_departamentos.reg_departament. */
+const DEPARTAMENTO: GlobalFilter = {
+  id: "departamento",
+  type: "multi_select",
+  label: "Departamento",
+  bind_expr: `p."num_departament"`,
+  value_type: "numeric",
+  options_sql: `SELECT d."reg_departament" AS value,
+       COALESCE(NULLIF(d."depa_secc_fabr", ''), d."clave") AS label
+FROM "public"."ps_departamentos" d
+WHERE d."clave" IS NOT NULL AND d."clave" <> ''
+ORDER BY 2`,
+};
+
+/** Proveedor — FK numeric on ps_articulos.num_proveedor / ps_compras.num_proveedor. */
+const PROVEEDOR_ARTICULO: GlobalFilter = {
+  id: "proveedor",
+  type: "multi_select",
+  label: "Proveedor",
+  bind_expr: `p."num_proveedor"`,
+  value_type: "numeric",
+  options_sql: `SELECT pr."reg_proveedor" AS value, pr."nombre" AS label
+FROM "public"."ps_proveedores" pr
+WHERE pr."nombre" IS NOT NULL AND pr."nombre" <> ''
+ORDER BY 2`,
+};
+
+/** Proveedor for purchasing-scope dashboards — binds to ps_compras.num_proveedor via alias `co`. */
+const PROVEEDOR_COMPRAS: GlobalFilter = {
+  ...PROVEEDOR_ARTICULO,
+  id: "proveedor_compras",
+  bind_expr: `co."num_proveedor"`,
+};
+
+/** Cliente mayorista — binds to ps_gc_facturas.num_cliente via alias `f`. */
+const CLIENTE_MAYORISTA: GlobalFilter = {
+  id: "cliente_mayorista",
+  type: "multi_select",
+  label: "Cliente Mayorista",
+  bind_expr: `f."num_cliente"`,
+  value_type: "numeric",
+  options_sql: `SELECT c."reg_cliente" AS value, c."nombre" AS label
+FROM "public"."ps_clientes" c
+JOIN "public"."ps_gc_facturas" gf ON gf."num_cliente" = c."reg_cliente"
+WHERE c."nombre" IS NOT NULL AND c."nombre" <> ''
+  AND gf."abono" = false
+  AND gf."fecha_factura" >= :curr_from
+  AND gf."fecha_factura" <= :curr_to
+GROUP BY c."reg_cliente", c."nombre"
+ORDER BY 2`,
+};
+
+/** Familia for purchasing / stock when there is no ps_ventas scope on the date. */
+const FAMILIA_CATALOG: GlobalFilter = {
+  ...FAMILIA,
+  options_sql: `SELECT fm."fami_grup_marc" AS value, fm."fami_grup_marc" AS label
+FROM "public"."ps_familias" fm
+WHERE fm."fami_grup_marc" IS NOT NULL AND fm."fami_grup_marc" <> ''
+ORDER BY 1`,
+};
+
+/** Tienda for stock — not constrained by ps_ventas date. */
+const TIENDA_STOCK: GlobalFilter = {
+  id: "tienda",
+  type: "single_select",
+  label: "Tienda",
+  bind_expr: `s."tienda"`,
+  value_type: "text",
+  options_sql: `SELECT DISTINCT s."tienda" AS value, s."tienda" AS label
+FROM "public"."ps_stock_tienda" s
+WHERE s."tienda" <> '99'
+ORDER BY 1`,
+};
+
+// ---------------------------------------------------------------------------
+// Template filter sets
+// ---------------------------------------------------------------------------
+
+/**
+ * Retail-scope dashboards (ventas, general). Widgets that join ps_articulos
+ * (alias `p` or `pa`) gain access to temporada / marca / sexo / departamento
+ * filters. Widgets that stay on ps_ventas only use `__gf_tienda__`.
+ */
+export const templateGlobalFiltersRetail: GlobalFilter[] = [
+  TIENDA,
+  FAMILIA,
+  TEMPORADA,
+  MARCA,
+  SEXO,
+  DEPARTAMENTO,
+];
+
+/** Wholesale dashboards: facturas/lineas via `f`/`lf`, articles via `p`. */
+export const templateGlobalFiltersMayorista: GlobalFilter[] = [
+  CLIENTE_MAYORISTA,
+  FAMILIA_CATALOG,
+  TEMPORADA,
+  MARCA,
+];
+
+/** Stock dashboards. Date-free; tienda scopes ps_stock_tienda. */
+export const templateGlobalFiltersStock: GlobalFilter[] = [
+  TIENDA_STOCK,
+  FAMILIA_CATALOG,
+  TEMPORADA,
+  MARCA,
+];
+
+/** Purchasing dashboards. proveedor_compras binds to ps_compras.num_proveedor. */
+export const templateGlobalFiltersCompras: GlobalFilter[] = [
+  PROVEEDOR_COMPRAS,
+  FAMILIA_CATALOG,
+  TEMPORADA,
 ];

--- a/dashboard/lib/template-global-filters.ts
+++ b/dashboard/lib/template-global-filters.ts
@@ -14,7 +14,7 @@ import type { GlobalFilter } from "./schema";
  *
  *   v   — "public"."ps_ventas"
  *   lv  — "public"."ps_lineas_ventas"
- *   p   — "public"."ps_articulos"   (alias `pa` is also tolerated by aliasing bind_expr)
+ *   p   — "public"."ps_articulos"
  *   fm  — "public"."ps_familias"
  *   pr  — "public"."ps_proveedores"
  *   lf  — "public"."ps_gc_lin_facturas"
@@ -211,9 +211,15 @@ export const templateGlobalFiltersStock: GlobalFilter[] = [
   MARCA,
 ];
 
-/** Purchasing dashboards. proveedor_compras binds to ps_compras.num_proveedor. */
+/**
+ * Purchasing dashboards. proveedor_compras binds to ps_compras.num_proveedor.
+ *
+ * NOTE: familia / temporada are intentionally NOT included here. The compras
+ * template widgets do not join ps_lineas_compras → ps_articulos → ps_familias
+ * / ps_temporadas, so declaring those filters would render combobox chrome
+ * that has no effect on any widget. Wire the joins into compras widgets first
+ * before adding those filters back.
+ */
 export const templateGlobalFiltersCompras: GlobalFilter[] = [
   PROVEEDOR_COMPRAS,
-  FAMILIA_CATALOG,
-  TEMPORADA,
 ];

--- a/dashboard/lib/template-global-filters.ts
+++ b/dashboard/lib/template-global-filters.ts
@@ -183,8 +183,9 @@ ORDER BY 1`,
 
 /**
  * Retail-scope dashboards (ventas, general). Widgets that join ps_articulos
- * (alias `p` or `pa`) gain access to temporada / marca / sexo / departamento
- * filters. Widgets that stay on ps_ventas only use `__gf_tienda__`.
+ * as alias `p` gain access to temporada / marca / sexo / departamento
+ * filters (bind_expr above binds to `p."<col>"` exactly). Widgets that stay
+ * on ps_ventas only use `__gf_tienda__`.
  */
 export const templateGlobalFiltersRetail: GlobalFilter[] = [
   TIENDA,

--- a/dashboard/lib/template-global-filters.ts
+++ b/dashboard/lib/template-global-filters.ts
@@ -59,6 +59,8 @@ WHERE v."entrada" = true
   AND lv."tienda" <> '99'
   AND lv."fecha_creacion" >= :curr_from
   AND lv."fecha_creacion" <= :curr_to
+  AND fm."fami_grup_marc" IS NOT NULL
+  AND fm."fami_grup_marc" <> ''
   AND __gf_tienda__
 ORDER BY 1`,
 };

--- a/dashboard/lib/template-global-filters.ts
+++ b/dashboard/lib/template-global-filters.ts
@@ -65,21 +65,39 @@ WHERE v."entrada" = true
 ORDER BY 1`,
 };
 
-/** Temporada (clave code of the season, e.g. "75" for PV12). Text key stored on ps_articulos.clave_temporada. */
+/**
+ * Temporada (season code stored on ps_articulos.clave_temporada as text,
+ * e.g. "PV26" for Primavera-Verano 2026, "OI25" for Otoño-Invierno 2025).
+ *
+ * We source options from ps_articulos.clave_temporada directly (not
+ * ps_temporadas.clave) so that the option values are guaranteed to match
+ * the bind_expr domain — the two "clave" columns can and do diverge, and
+ * only the codes actually assigned to articulos produce filter matches.
+ */
 const TEMPORADA: GlobalFilter = {
   id: "temporada",
   type: "multi_select",
   label: "Temporada",
   bind_expr: `p."clave_temporada"`,
   value_type: "text",
-  options_sql: `SELECT DISTINCT t."clave" AS value,
-       COALESCE(NULLIF(t."temporada_tipo", ''), t."clave") AS label
-FROM "public"."ps_temporadas" t
-WHERE t."clave" IS NOT NULL AND t."clave" <> ''
+  options_sql: `SELECT DISTINCT p."clave_temporada" AS value,
+       COALESCE(NULLIF(t."temporada_tipo", ''), p."clave_temporada") AS label
+FROM "public"."ps_articulos" p
+LEFT JOIN "public"."ps_temporadas" t ON t."clave" = p."clave_temporada"
+WHERE p."clave_temporada" IS NOT NULL
+  AND p."clave_temporada" <> ''
 ORDER BY 1`,
 };
 
-/** Marca (brand). Joined via ps_articulos.num_marca → ps_marcas.reg_marca. */
+/**
+ * Marca (brand). Joined via ps_articulos.num_marca → ps_marcas.reg_marca.
+ *
+ * Label column: ps_marcas has only `clave` and `marca_tratamien` (no
+ * standalone `marca` text column — see etl/schema/init.sql). `clave` is
+ * the short brand code/name that the vendor uses as the primary display
+ * value; knowledge.ts references to `m."marca"` elsewhere in the codebase
+ * are incorrect and should be migrated separately.
+ */
 const MARCA: GlobalFilter = {
   id: "marca",
   type: "multi_select",
@@ -105,7 +123,12 @@ WHERE p."sexo" IS NOT NULL AND p."sexo" <> ''
 ORDER BY 1`,
 };
 
-/** Departamento — FK numeric on ps_articulos.num_departament → ps_departamentos.reg_departament. */
+/**
+ * Departamento — FK numeric on ps_articulos.num_departament →
+ * ps_departamentos.reg_departament. Display column is `depa_secc_fabr`
+ * (the canonical human-readable column used by knowledge.ts sales/margin
+ * SQL pairs); `clave` is an internal code and may be NULL.
+ */
 const DEPARTAMENTO: GlobalFilter = {
   id: "departamento",
   type: "multi_select",
@@ -113,9 +136,9 @@ const DEPARTAMENTO: GlobalFilter = {
   bind_expr: `p."num_departament"`,
   value_type: "numeric",
   options_sql: `SELECT d."reg_departament" AS value,
-       COALESCE(NULLIF(d."depa_secc_fabr", ''), d."clave") AS label
+       d."depa_secc_fabr" AS label
 FROM "public"."ps_departamentos" d
-WHERE d."clave" IS NOT NULL AND d."clave" <> ''
+WHERE d."depa_secc_fabr" IS NOT NULL AND d."depa_secc_fabr" <> ''
 ORDER BY 2`,
 };
 

--- a/dashboard/lib/templates/compras.ts
+++ b/dashboard/lib/templates/compras.ts
@@ -11,6 +11,7 @@
  * - ps_albaranes has fecha_recibido (NOT fecha_creacion)
  */
 import type { DashboardSpec } from "@/lib/schema";
+import { templateGlobalFiltersCompras } from "@/lib/template-global-filters";
 
 export const name = "Responsable de Compras";
 
@@ -20,6 +21,7 @@ export const description =
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Compras",
   description,
+  filters: templateGlobalFiltersCompras,
   widgets: [
     {
       id: "compras-kpis",
@@ -27,35 +29,39 @@ export const spec: DashboardSpec = {
       items: [
         {
           label: "Pedidos de Compra (período seleccionado)",
-          sql: `SELECT COUNT(DISTINCT "reg_pedido") AS value
-FROM "public"."ps_compras"
-WHERE "fecha_pedido" >= :curr_from
-  AND "fecha_pedido" <= :curr_to`,
+          sql: `SELECT COUNT(DISTINCT co."reg_pedido") AS value
+FROM "public"."ps_compras" co
+WHERE co."fecha_pedido" >= :curr_from
+  AND co."fecha_pedido" <= :curr_to
+  AND __gf_proveedor_compras__`,
           format: "number",
         },
         {
           label: "Proveedores Activos (período seleccionado)",
-          sql: `SELECT COUNT(DISTINCT "num_proveedor") AS value
-FROM "public"."ps_compras"
-WHERE "fecha_pedido" >= :curr_from
-  AND "fecha_pedido" <= :curr_to`,
+          sql: `SELECT COUNT(DISTINCT co."num_proveedor") AS value
+FROM "public"."ps_compras" co
+WHERE co."fecha_pedido" >= :curr_from
+  AND co."fecha_pedido" <= :curr_to
+  AND __gf_proveedor_compras__`,
           format: "number",
         },
         {
           label: "Pedidos Recibidos (período seleccionado)",
-          sql: `SELECT COUNT(DISTINCT "reg_pedido") AS value
-FROM "public"."ps_compras"
-WHERE "fecha_recibido" >= :curr_from
-  AND "fecha_recibido" <= :curr_to`,
+          sql: `SELECT COUNT(DISTINCT co."reg_pedido") AS value
+FROM "public"."ps_compras" co
+WHERE co."fecha_recibido" >= :curr_from
+  AND co."fecha_recibido" <= :curr_to
+  AND __gf_proveedor_compras__`,
           format: "number",
         },
         {
           label: "Lineas de Compra (período seleccionado)",
           sql: `SELECT COUNT(*) AS value
 FROM "public"."ps_lineas_compras" lc
-JOIN "public"."ps_compras" c ON lc."num_pedido" = c."reg_pedido"
-WHERE c."fecha_pedido" >= :curr_from
-  AND c."fecha_pedido" <= :curr_to`,
+JOIN "public"."ps_compras" co ON lc."num_pedido" = co."reg_pedido"
+WHERE co."fecha_pedido" >= :curr_from
+  AND co."fecha_pedido" <= :curr_to
+  AND __gf_proveedor_compras__`,
           format: "number",
         },
       ],
@@ -65,11 +71,12 @@ WHERE c."fecha_pedido" >= :curr_from
       type: "bar_chart",
       title: "Pedidos por Proveedor (top 10, período seleccionado)",
       sql: `SELECT pr."nombre" AS label,
-       COUNT(DISTINCT c."reg_pedido") AS value
-FROM "public"."ps_compras" c
-JOIN "public"."ps_proveedores" pr ON c."num_proveedor" = pr."reg_proveedor"
-WHERE c."fecha_pedido" >= :curr_from
-  AND c."fecha_pedido" <= :curr_to
+       COUNT(DISTINCT co."reg_pedido") AS value
+FROM "public"."ps_compras" co
+JOIN "public"."ps_proveedores" pr ON co."num_proveedor" = pr."reg_proveedor"
+WHERE co."fecha_pedido" >= :curr_from
+  AND co."fecha_pedido" <= :curr_to
+  AND __gf_proveedor_compras__
 GROUP BY pr."nombre"
 ORDER BY value DESC
 LIMIT 10`,
@@ -80,16 +87,17 @@ LIMIT 10`,
       id: "compras-ultimos-pedidos",
       type: "table",
       title: "Ultimos Pedidos de Compra",
-      sql: `SELECT c."reg_pedido" AS "Pedido",
+      sql: `SELECT co."reg_pedido" AS "Pedido",
        pr."nombre" AS "Proveedor",
        COUNT(lc."reg_linea_compra") AS "Lineas",
-       c."fecha_pedido" AS "Fecha Pedido",
-       c."fecha_recibido" AS "Fecha Recibido"
-FROM "public"."ps_compras" c
-JOIN "public"."ps_proveedores" pr ON c."num_proveedor" = pr."reg_proveedor"
-LEFT JOIN "public"."ps_lineas_compras" lc ON lc."num_pedido" = c."reg_pedido"
-GROUP BY c."reg_pedido", pr."nombre", c."fecha_pedido", c."fecha_recibido"
-ORDER BY c."fecha_pedido" DESC
+       co."fecha_pedido" AS "Fecha Pedido",
+       co."fecha_recibido" AS "Fecha Recibido"
+FROM "public"."ps_compras" co
+JOIN "public"."ps_proveedores" pr ON co."num_proveedor" = pr."reg_proveedor"
+LEFT JOIN "public"."ps_lineas_compras" lc ON lc."num_pedido" = co."reg_pedido"
+WHERE __gf_proveedor_compras__
+GROUP BY co."reg_pedido", pr."nombre", co."fecha_pedido", co."fecha_recibido"
+ORDER BY co."fecha_pedido" DESC
 LIMIT 20`,
     },
     {
@@ -108,30 +116,32 @@ LIMIT 20`,
       id: "compras-pendientes-recibir",
       type: "table",
       title: "Pedidos Pendientes de Recibir",
-      sql: `SELECT c."reg_pedido" AS "Pedido",
+      sql: `SELECT co."reg_pedido" AS "Pedido",
        pr."nombre" AS "Proveedor",
-       c."fecha_pedido" AS "Fecha Pedido",
+       co."fecha_pedido" AS "Fecha Pedido",
        COUNT(lc."reg_linea_compra") AS "Lineas"
-FROM "public"."ps_compras" c
-JOIN "public"."ps_proveedores" pr ON c."num_proveedor" = pr."reg_proveedor"
-LEFT JOIN "public"."ps_lineas_compras" lc ON lc."num_pedido" = c."reg_pedido"
-WHERE c."fecha_recibido" IS NULL
-  AND c."fecha_pedido" >= :curr_from
-  AND c."fecha_pedido" <= :curr_to
-GROUP BY c."reg_pedido", pr."nombre", c."fecha_pedido"
-ORDER BY c."fecha_pedido" DESC
+FROM "public"."ps_compras" co
+JOIN "public"."ps_proveedores" pr ON co."num_proveedor" = pr."reg_proveedor"
+LEFT JOIN "public"."ps_lineas_compras" lc ON lc."num_pedido" = co."reg_pedido"
+WHERE co."fecha_recibido" IS NULL
+  AND co."fecha_pedido" >= :curr_from
+  AND co."fecha_pedido" <= :curr_to
+  AND __gf_proveedor_compras__
+GROUP BY co."reg_pedido", pr."nombre", co."fecha_pedido"
+ORDER BY co."fecha_pedido" DESC
 LIMIT 20`,
     },
     {
       id: "compras-tendencia-mensual",
       type: "line_chart",
       title: "Pedidos de Compra Mensuales (período seleccionado)",
-      sql: `SELECT DATE_TRUNC('month', c."fecha_pedido") AS x,
-       COUNT(DISTINCT c."reg_pedido") AS y
-FROM "public"."ps_compras" c
-WHERE c."fecha_pedido" >= :curr_from
-  AND c."fecha_pedido" <= :curr_to
-GROUP BY DATE_TRUNC('month', c."fecha_pedido")
+      sql: `SELECT DATE_TRUNC('month', co."fecha_pedido") AS x,
+       COUNT(DISTINCT co."reg_pedido") AS y
+FROM "public"."ps_compras" co
+WHERE co."fecha_pedido" >= :curr_from
+  AND co."fecha_pedido" <= :curr_to
+  AND __gf_proveedor_compras__
+GROUP BY DATE_TRUNC('month', co."fecha_pedido")
 ORDER BY x`,
       x: "x",
       y: "y",

--- a/dashboard/lib/templates/general.ts
+++ b/dashboard/lib/templates/general.ts
@@ -61,7 +61,11 @@ WHERE v."entrada" = true
   AND lv."fecha_creacion" >= :curr_from
   AND lv."fecha_creacion" <= :curr_to
   AND __gf_tienda__
-  AND __gf_familia__`,
+  AND __gf_familia__
+  AND __gf_temporada__
+  AND __gf_marca__
+  AND __gf_sexo__
+  AND __gf_departamento__`,
           format: "percent",
         },
         {
@@ -175,6 +179,10 @@ WHERE v."entrada" = true
   AND lv."fecha_creacion" <= :curr_to
   AND __gf_tienda__
   AND __gf_familia__
+  AND __gf_temporada__
+  AND __gf_marca__
+  AND __gf_sexo__
+  AND __gf_departamento__
 GROUP BY fm."fami_grup_marc"
 ORDER BY "Ventas Netas" DESC
 LIMIT 10`,

--- a/dashboard/lib/templates/mayorista.ts
+++ b/dashboard/lib/templates/mayorista.ts
@@ -6,6 +6,7 @@
  * All date filters use :curr_from / :curr_to tokens set by the date picker.
  */
 import type { DashboardSpec } from "@/lib/schema";
+import { templateGlobalFiltersMayorista } from "@/lib/template-global-filters";
 
 export const name = "Director Mayorista";
 
@@ -15,6 +16,7 @@ export const description =
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Mayorista",
   description,
+  filters: templateGlobalFiltersMayorista,
   widgets: [
     {
       id: "mayorista-kpis",
@@ -22,21 +24,23 @@ export const spec: DashboardSpec = {
       items: [
         {
           label: "Facturacion Neta",
-          sql: `SELECT COALESCE(SUM("base1" + "base2" + "base3"), 0) AS value
-FROM "public"."ps_gc_facturas"
-WHERE "abono" = false
-  AND "fecha_factura" >= :curr_from
-  AND "fecha_factura" <= :curr_to`,
+          sql: `SELECT COALESCE(SUM(f."base1" + f."base2" + f."base3"), 0) AS value
+FROM "public"."ps_gc_facturas" f
+WHERE f."abono" = false
+  AND f."fecha_factura" >= :curr_from
+  AND f."fecha_factura" <= :curr_to
+  AND __gf_cliente_mayorista__`,
           format: "currency",
           prefix: "€",
         },
         {
           label: "Facturas",
-          sql: `SELECT COUNT(DISTINCT "reg_factura") AS value
-FROM "public"."ps_gc_facturas"
-WHERE "abono" = false
-  AND "fecha_factura" >= :curr_from
-  AND "fecha_factura" <= :curr_to`,
+          sql: `SELECT COUNT(DISTINCT f."reg_factura") AS value
+FROM "public"."ps_gc_facturas" f
+WHERE f."abono" = false
+  AND f."fecha_factura" >= :curr_from
+  AND f."fecha_factura" <= :curr_to
+  AND __gf_cliente_mayorista__`,
           format: "number",
         },
         {
@@ -47,19 +51,26 @@ WHERE "abono" = false
 ) AS value
 FROM "public"."ps_gc_lin_facturas" lf
 JOIN "public"."ps_gc_facturas" f ON lf."num_factura" = f."n_factura"
+JOIN "public"."ps_articulos" p ON lf."codigo" = p."codigo"
+JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
 WHERE lf."total" > 0
   AND f."abono" = false
   AND f."fecha_factura" >= :curr_from
-  AND f."fecha_factura" <= :curr_to`,
+  AND f."fecha_factura" <= :curr_to
+  AND __gf_cliente_mayorista__
+  AND __gf_familia__
+  AND __gf_temporada__
+  AND __gf_marca__`,
           format: "percent",
         },
         {
           label: "Clientes Activos (período seleccionado)",
-          sql: `SELECT COUNT(DISTINCT "num_cliente") AS value
-FROM "public"."ps_gc_facturas"
-WHERE "abono" = false
-  AND "fecha_factura" >= :curr_from
-  AND "fecha_factura" <= :curr_to`,
+          sql: `SELECT COUNT(DISTINCT f."num_cliente") AS value
+FROM "public"."ps_gc_facturas" f
+WHERE f."abono" = false
+  AND f."fecha_factura" >= :curr_from
+  AND f."fecha_factura" <= :curr_to
+  AND __gf_cliente_mayorista__`,
           format: "number",
         },
       ],
@@ -75,6 +86,7 @@ JOIN "public"."ps_gc_comerciales" c ON f."num_comercial" = c."reg_comercial"
 WHERE f."abono" = false
   AND f."fecha_factura" >= :curr_from
   AND f."fecha_factura" <= :curr_to
+  AND __gf_cliente_mayorista__
 GROUP BY c."comercial"
 ORDER BY value DESC`,
       x: "label",
@@ -93,6 +105,7 @@ ORDER BY value DESC`,
   WHERE f."abono" = false
     AND f."fecha_factura" >= :curr_from
     AND f."fecha_factura" <= :curr_to
+    AND __gf_cliente_mayorista__
 ), margenes AS (
   SELECT lf."num_factura",
          SUM(lf."total")       AS total_ingreso,
@@ -162,10 +175,15 @@ LIMIT 20`,
 FROM "public"."ps_gc_lin_facturas" lf
 JOIN "public"."ps_gc_facturas" f ON lf."num_factura" = f."n_factura"
 JOIN "public"."ps_articulos" p ON lf."codigo" = p."codigo"
+JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
 WHERE f."abono" = false
   AND lf."unidades" > 0
   AND f."fecha_factura" >= :curr_from
   AND f."fecha_factura" <= :curr_to
+  AND __gf_cliente_mayorista__
+  AND __gf_familia__
+  AND __gf_temporada__
+  AND __gf_marca__
 GROUP BY p."ccrefejofacm", p."descripcion"
 ORDER BY "Importe" DESC
 LIMIT 10`,
@@ -180,6 +198,7 @@ FROM "public"."ps_gc_facturas" f
 WHERE f."abono" = false
   AND f."fecha_factura" >= :curr_from
   AND f."fecha_factura" <= :curr_to
+  AND __gf_cliente_mayorista__
 GROUP BY DATE_TRUNC('month', f."fecha_factura")
 ORDER BY x`,
       x: "x",

--- a/dashboard/lib/templates/stock.ts
+++ b/dashboard/lib/templates/stock.ts
@@ -25,13 +25,19 @@ export const spec: DashboardSpec = {
       items: [
         {
           label: "Unidades en Tiendas",
-          sql: `SELECT COALESCE(SUM("stock"), 0) AS value
-FROM "public"."ps_stock_tienda"
-WHERE "stock" > 0 AND "tienda" <> '99'`,
+          // Alias ps_stock_tienda as `s` so the __gf_tienda__ token (bound
+          // to `s."tienda"` in templateGlobalFiltersStock) resolves cleanly.
+          sql: `SELECT COALESCE(SUM(s."stock"), 0) AS value
+FROM "public"."ps_stock_tienda" s
+WHERE s."stock" > 0 AND s."tienda" <> '99'
+  AND __gf_tienda__`,
           format: "number",
         },
         {
           label: "Unidades en Almacén Central",
+          // Central warehouse (tienda '99') — intentionally ignores the
+          // __gf_tienda__ selection because this KPI measures the almacén
+          // total regardless of which retail tienda the user is focused on.
           sql: `SELECT COALESCE(SUM("stock"), 0) AS value
 FROM "public"."ps_stock_tienda"
 WHERE "stock" > 0 AND "tienda" = '99'`,
@@ -42,7 +48,12 @@ WHERE "stock" > 0 AND "tienda" = '99'`,
           sql: `SELECT COALESCE(ROUND(SUM(s."stock" * p."precio_coste"), 2), 0) AS value
 FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
-WHERE s."stock" > 0 AND p."anulado" = false`,
+LEFT JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
+WHERE s."stock" > 0 AND p."anulado" = false
+  AND __gf_tienda__
+  AND __gf_familia__
+  AND __gf_temporada__
+  AND __gf_marca__`,
           format: "currency",
           prefix: "€",
         },
@@ -51,7 +62,12 @@ WHERE s."stock" > 0 AND p."anulado" = false`,
           sql: `SELECT COUNT(DISTINCT s."codigo") AS value
 FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
-WHERE s."stock" > 0 AND p."anulado" = false`,
+LEFT JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
+WHERE s."stock" > 0 AND p."anulado" = false
+  AND __gf_tienda__
+  AND __gf_familia__
+  AND __gf_temporada__
+  AND __gf_marca__`,
           format: "number",
         },
       ],

--- a/dashboard/lib/templates/stock.ts
+++ b/dashboard/lib/templates/stock.ts
@@ -7,6 +7,7 @@
  * Time-filtered queries (transfers, dead-stock lookback) use :curr_from / :curr_to tokens.
  */
 import type { DashboardSpec } from "@/lib/schema";
+import { templateGlobalFiltersStock } from "@/lib/template-global-filters";
 
 export const name = "Responsable de Stock";
 
@@ -16,6 +17,7 @@ export const description =
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Stock",
   description,
+  filters: templateGlobalFiltersStock,
   widgets: [
     {
       id: "stock-kpis",
@@ -58,10 +60,16 @@ WHERE s."stock" > 0 AND p."anulado" = false`,
       id: "stock-por-tienda",
       type: "bar_chart",
       title: "Stock por Tienda (excluye almacén central)",
-      sql: `SELECT "tienda" AS label, SUM("stock") AS value
-FROM "public"."ps_stock_tienda"
-WHERE "stock" > 0 AND "tienda" <> '99'
-GROUP BY "tienda"
+      sql: `SELECT s."tienda" AS label, SUM(s."stock") AS value
+FROM "public"."ps_stock_tienda" s
+JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
+JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
+WHERE s."stock" > 0 AND s."tienda" <> '99'
+  AND __gf_tienda__
+  AND __gf_familia__
+  AND __gf_temporada__
+  AND __gf_marca__
+GROUP BY s."tienda"
 ORDER BY value DESC`,
       x: "label",
       y: "value",
@@ -76,6 +84,10 @@ FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
 JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
 WHERE s."stock" > 0 AND p."anulado" = false
+  AND __gf_tienda__
+  AND __gf_familia__
+  AND __gf_temporada__
+  AND __gf_marca__
 GROUP BY fm."fami_grup_marc"
 ORDER BY value DESC
 LIMIT 10`,
@@ -92,9 +104,14 @@ LIMIT 10`,
        SUM(s."stock") AS "Stock"
 FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
+JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
 WHERE s."stock" > 0 AND s."stock" < 5
   AND s."tienda" <> '99'
   AND p."anulado" = false
+  AND __gf_tienda__
+  AND __gf_familia__
+  AND __gf_temporada__
+  AND __gf_marca__
 GROUP BY s."tienda", p."ccrefejofacm", p."descripcion"
 ORDER BY "Stock" ASC
 LIMIT 50`,

--- a/dashboard/lib/templates/stock.ts
+++ b/dashboard/lib/templates/stock.ts
@@ -65,6 +65,7 @@ FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
 JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
 WHERE s."stock" > 0 AND s."tienda" <> '99'
+  AND p."anulado" = false
   AND __gf_tienda__
   AND __gf_familia__
   AND __gf_temporada__

--- a/dashboard/lib/templates/ventas.ts
+++ b/dashboard/lib/templates/ventas.ts
@@ -130,8 +130,8 @@ ORDER BY value DESC`,
          / NULLIF(SUM(lv."total_si"), 0) * 100, 1) AS value
 FROM "public"."ps_lineas_ventas" lv
 JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
-JOIN "public"."ps_articulos" pa ON lv."codigo" = pa."codigo"
-JOIN "public"."ps_familias" fm ON pa."num_familia" = fm."reg_familia"
+JOIN "public"."ps_articulos" p ON lv."codigo" = p."codigo"
+JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
 WHERE v."entrada" = true
   AND lv."tienda" <> '99'
   AND lv."total_si" > 0
@@ -139,6 +139,10 @@ WHERE v."entrada" = true
   AND lv."fecha_creacion" <= :curr_to
   AND __gf_tienda__
   AND __gf_familia__
+  AND __gf_temporada__
+  AND __gf_marca__
+  AND __gf_sexo__
+  AND __gf_departamento__
 GROUP BY lv."tienda"
 ORDER BY value DESC`,
       x: "label",
@@ -165,6 +169,10 @@ WHERE v."entrada" = true
   AND lv."fecha_creacion" <= :curr_to
   AND __gf_tienda__
   AND __gf_familia__
+  AND __gf_temporada__
+  AND __gf_marca__
+  AND __gf_sexo__
+  AND __gf_departamento__
 GROUP BY p."ccrefejofacm", p."descripcion"
 ORDER BY "Ventas Netas" DESC
 LIMIT 10`,

--- a/docs/skills/dashboard-app.md
+++ b/docs/skills/dashboard-app.md
@@ -102,7 +102,7 @@ shared sets in `dashboard/lib/template-global-filters.ts`:
 | `templateGlobalFiltersRetail` | ventas, general | tienda, familia, temporada, marca, sexo, departamento |
 | `templateGlobalFiltersMayorista` | mayorista | cliente_mayorista, familia, temporada, marca |
 | `templateGlobalFiltersStock` | stock | tienda (stock-scoped), familia, temporada, marca |
-| `templateGlobalFiltersCompras` | compras | proveedor_compras, familia, temporada |
+| `templateGlobalFiltersCompras` | compras | proveedor_compras |
 
 Rules when writing widget SQL for these templates:
 

--- a/docs/skills/dashboard-app.md
+++ b/docs/skills/dashboard-app.md
@@ -92,6 +92,38 @@ You generate JSON dashboard specifications.
 - Store 99 = almacén central, exclude from retail analytics
 ```
 
+## Global filters (template dashboards)
+
+Pre-built dashboards declare their `spec.filters: GlobalFilter[]` from
+shared sets in `dashboard/lib/template-global-filters.ts`:
+
+| Set | Covers | Filters |
+|-----|--------|---------|
+| `templateGlobalFiltersRetail` | ventas, general | tienda, familia, temporada, marca, sexo, departamento |
+| `templateGlobalFiltersMayorista` | mayorista | cliente_mayorista, familia, temporada, marca |
+| `templateGlobalFiltersStock` | stock | tienda (stock-scoped), familia, temporada, marca |
+| `templateGlobalFiltersCompras` | compras | proveedor_compras, familia, temporada |
+
+Rules when writing widget SQL for these templates:
+
+1. **Stick to the documented alias**: the `bind_expr` of each filter is
+   anchored to an alias (`v`, `lv`, `p`, `fm`, `f`, `lf`, `co`, `s`, …).
+   Widget SQL that wants to apply the filter must use the same alias.
+2. **Only reference filter tokens (`__gf_<id>__`) that the template declares**
+   — the `template-global-filters.test.ts` suite enforces this. Tokens with
+   no active selection compile to `TRUE`; there's no cost to including them
+   in a widget that already joins the right table.
+3. **Inactive filters must produce valid SQL** — our compile step guarantees
+   `TRUE` substitution for unset/empty selections. All tests assert that
+   every template compiles with an empty `GlobalFilterValues`.
+4. **Add new filters via the catalog, not ad-hoc**: edit
+   `template-global-filters.ts`, add/expand a set, wire widgets to use the
+   new token. Re-run `npm run test` — the compilation + orphan-token tests
+   will tell you if a widget references a filter that isn't in the set.
+
+Users interact with these filters through `FilterCombobox` (Headless UI
+Combobox multi/single select with client-side search, chips, and "Limpiar").
+
 ## Testing
 
 - Unit tests: widget components render correct Tremor elements


### PR DESCRIPTION
Closes #401.

## Summary
- Replace the native `<select multiple>` listbox with a Headless UI Combobox-based `FilterCombobox` component: client-side search, chips, "Limpiar" clear-all, keyboard navigation (Esc clears query in both multi- and single-select). Multi- and single-select variants share the same visuals.
- Expand the template filter catalog per scope:
  - retail (ventas, general): tienda, familia, temporada, marca, sexo, departamento
  - mayorista: cliente_mayorista, familia, temporada, marca
  - stock: tienda (stock-scoped), familia, temporada, marca
  - compras: proveedor_compras *(familia/temporada intentionally excluded — compras widgets don't join ps_lineas_compras → ps_articulos → ps_familias/ps_temporadas; a guardrail test prevents silent reintroduction)*
- Wire `__gf_<id>__` tokens into widget SQL wherever the required alias/join exists. Add guardrail tests that enforce every template-declared filter compiles inactive → TRUE, active → parameterized `= ANY($1)`, and that no widget SQL references an undeclared filter id.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run test` — all tests pass, including new `FilterCombobox` (combobox selects, chip removal, clear-all, escape, no-results, disabled/loading guard), new `template-global-filters` tests (catalog shape, pipeline compile, orphan-token guard, compras exclusion guardrail), and updated `DashboardFiltersBar` tests
- [x] `npm run build` — clean Next.js production build
- [ ] Manual: open each template dashboard and verify the filter combobox populates, search narrows results, chips remove individual selections, and "Limpiar" clears all. Confirm widget numbers update when filters change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)