### PR TITLE
feat(dashboard): stable progress dialog + persistent LLM interaction history

### DIFF
--- a/dashboard/app/admin/interactions/[request_id]/page.tsx
+++ b/dashboard/app/admin/interactions/[request_id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { sql } from "@/lib/db-write";
 import type { InteractionRow } from "@/app/api/dashboard/[id]/interactions/route";
 import type { InteractionLine } from "@/lib/db-write";
+import { interactionLineClass } from "@/lib/interaction-line-class";
 
 export const dynamic = "force-dynamic";
 
@@ -26,22 +27,6 @@ function statusBadge(status: string): string {
   }
 }
 
-function lineClassName(kind: InteractionLine["kind"]): string {
-  switch (kind) {
-    case "tool_call":
-      return "font-mono text-blue-600 dark:text-blue-300";
-    case "tool_result":
-      return "font-mono text-emerald-600 dark:text-emerald-400";
-    case "error":
-      return "font-mono text-red-500 dark:text-red-400";
-    case "assistant_text":
-      return "text-tremor-content dark:text-dark-tremor-content";
-    case "phase":
-    case "meta":
-    default:
-      return "italic text-tremor-content-subtle dark:text-dark-tremor-content-subtle";
-  }
-}
 
 function formatDateEs(iso: string | null): string {
   if (!iso) return "—";
@@ -157,7 +142,7 @@ export default async function InteractionDetailPage({ params }: PageProps) {
             </span>
           ) : (
             lines.map((l, i) => (
-              <div key={i} className={`whitespace-pre-wrap break-words ${lineClassName(l.kind ?? "meta")}`}>
+              <div key={i} className={`whitespace-pre-wrap break-words ${interactionLineClass(l.kind)}`}>
                 {l.ts ? (
                   <span className="mr-2 text-tremor-content-subtle dark:text-dark-tremor-content-subtle select-none">
                     {new Date(l.ts).toLocaleTimeString("es-ES")}

--- a/dashboard/app/admin/interactions/[request_id]/page.tsx
+++ b/dashboard/app/admin/interactions/[request_id]/page.tsx
@@ -75,6 +75,7 @@ export default async function InteractionDetailPage({ params }: PageProps) {
          started_at, finished_at, status
        FROM llm_interactions
        WHERE request_id = $1
+       ORDER BY started_at DESC
        LIMIT 1`,
       [request_id],
     );

--- a/dashboard/app/admin/interactions/[request_id]/page.tsx
+++ b/dashboard/app/admin/interactions/[request_id]/page.tsx
@@ -1,0 +1,187 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { sql } from "@/lib/db-write";
+import type { InteractionRow } from "@/app/api/dashboard/[id]/interactions/route";
+import type { InteractionLine } from "@/lib/db-write";
+
+export const dynamic = "force-dynamic";
+
+type PageProps = { params: Promise<{ request_id: string }> };
+
+export async function generateMetadata({ params }: PageProps) {
+  const { request_id } = await params;
+  return { title: `Interacción ${request_id.slice(0, 16)}… — Admin` };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function statusBadge(status: string): string {
+  switch (status) {
+    case "completed":
+      return "rounded bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-900 dark:bg-emerald-950/60 dark:text-emerald-200";
+    case "error":
+      return "rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-900 dark:bg-red-950/60 dark:text-red-200";
+    default:
+      return "rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-900 dark:bg-amber-950/60 dark:text-amber-200";
+  }
+}
+
+function lineClassName(kind: InteractionLine["kind"]): string {
+  switch (kind) {
+    case "tool_call":
+      return "font-mono text-blue-600 dark:text-blue-300";
+    case "tool_result":
+      return "font-mono text-emerald-600 dark:text-emerald-400";
+    case "error":
+      return "font-mono text-red-500 dark:text-red-400";
+    case "assistant_text":
+      return "text-tremor-content dark:text-dark-tremor-content";
+    case "phase":
+    case "meta":
+    default:
+      return "italic text-tremor-content-subtle dark:text-dark-tremor-content-subtle";
+  }
+}
+
+function formatDateEs(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString("es-ES", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+// ─── Page ────────────────────────────────────────────────────────────────────
+
+export default async function InteractionDetailPage({ params }: PageProps) {
+  const { request_id } = await params;
+
+  // Validate request_id is a non-empty string without path separators
+  if (!request_id || request_id.includes("/") || request_id.length > 256) {
+    notFound();
+  }
+
+  let row: InteractionRow | null = null;
+  try {
+    const rows = await sql<InteractionRow>(
+      `SELECT
+         id, request_id, endpoint, dashboard_id,
+         prompt, final_output, lines,
+         llm_provider, llm_driver,
+         started_at, finished_at, status
+       FROM llm_interactions
+       WHERE request_id = $1
+       LIMIT 1`,
+      [request_id],
+    );
+    row = rows[0] ?? null;
+  } catch (err) {
+    console.error("[admin/interactions/[request_id]]", err);
+    return (
+      <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-900 dark:border-red-900/40 dark:bg-red-950/40 dark:text-red-100">
+        Error al cargar la interacción.
+      </div>
+    );
+  }
+
+  if (!row) {
+    notFound();
+  }
+
+  const lines: InteractionLine[] = Array.isArray(row.lines) ? row.lines : [];
+
+  return (
+    <div className="space-y-6">
+      {/* Breadcrumb */}
+      <nav className="text-sm text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+        <Link href="/admin/interactions" className="hover:underline">
+          Interacciones
+        </Link>
+        {" / "}
+        <span className="font-mono">{row.request_id.slice(0, 20)}…</span>
+      </nav>
+
+      <h1 className="text-xl font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+        Detalle de interacción
+      </h1>
+
+      {/* Metadata grid */}
+      <dl className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+        {(
+          [
+            ["Endpoint", row.endpoint],
+            ["Estado", <span key="status" className={statusBadge(row.status)}>{row.status}</span>],
+            ["Dashboard ID", row.dashboard_id ?? "—"],
+            ["Proveedor", [row.llm_provider, row.llm_driver].filter(Boolean).join(" / ") || "—"],
+            ["Inicio", formatDateEs(row.started_at)],
+            ["Fin", formatDateEs(row.finished_at)],
+            ["Request ID", <span key="rid" className="font-mono text-xs">{row.request_id}</span>],
+            ["UUID", <span key="uuid" className="font-mono text-xs">{row.id}</span>],
+          ] as Array<[string, React.ReactNode]>
+        ).map(([label, value]) => (
+          <div key={label} className="rounded-lg border border-tremor-border dark:border-dark-tremor-border p-3">
+            <dt className="text-xs font-medium text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+              {label}
+            </dt>
+            <dd className="mt-1 text-sm text-tremor-content-strong dark:text-dark-tremor-content-strong">
+              {value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      {/* Prompt */}
+      <section className="space-y-1">
+        <h2 className="text-sm font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+          Prompt
+        </h2>
+        <pre className="whitespace-pre-wrap break-words rounded-lg border border-tremor-border dark:border-dark-tremor-border bg-tremor-background-muted/80 dark:bg-dark-tremor-background-muted/50 p-3 text-xs text-tremor-content dark:text-dark-tremor-content">
+          {row.prompt}
+        </pre>
+      </section>
+
+      {/* Lines */}
+      <section className="space-y-1">
+        <h2 className="text-sm font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+          Log ({lines.length} líneas)
+        </h2>
+        <div className="max-h-[32rem] overflow-y-auto rounded-lg border border-tremor-border dark:border-dark-tremor-border bg-tremor-background-muted/80 dark:bg-dark-tremor-background-muted/50 p-3 text-xs leading-relaxed space-y-0.5">
+          {lines.length === 0 ? (
+            <span className="italic text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+              Sin líneas registradas.
+            </span>
+          ) : (
+            lines.map((l, i) => (
+              <div key={i} className={`whitespace-pre-wrap break-words ${lineClassName(l.kind ?? "meta")}`}>
+                {l.ts ? (
+                  <span className="mr-2 text-tremor-content-subtle dark:text-dark-tremor-content-subtle select-none">
+                    {new Date(l.ts).toLocaleTimeString("es-ES")}
+                  </span>
+                ) : null}
+                {l.text}
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+
+      {/* Final output */}
+      {row.final_output ? (
+        <section className="space-y-1">
+          <h2 className="text-sm font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+            Salida final
+          </h2>
+          <pre className="max-h-64 overflow-y-auto whitespace-pre-wrap break-words rounded-lg border border-tremor-border dark:border-dark-tremor-border bg-tremor-background-muted/80 dark:bg-dark-tremor-background-muted/50 p-3 text-xs text-tremor-content dark:text-dark-tremor-content">
+            {row.final_output.length > 4000
+              ? row.final_output.slice(0, 4000) + "\n… (truncado)"
+              : row.final_output}
+          </pre>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/dashboard/app/admin/interactions/page.tsx
+++ b/dashboard/app/admin/interactions/page.tsx
@@ -1,0 +1,256 @@
+import Link from "next/link";
+import { sql } from "@/lib/db-write";
+import type { InteractionRow } from "@/app/api/dashboard/[id]/interactions/route";
+
+export const metadata = {
+  title: "Interacciones LLM — Admin",
+};
+
+export const dynamic = "force-dynamic";
+
+// ─── Search-param filtering ──────────────────────────────────────────────────
+
+type FilterParams = {
+  endpoint?: string;
+  status?: string;
+  dashboard_id?: string;
+};
+
+function statusBadge(status: string): string {
+  switch (status) {
+    case "completed":
+      return "rounded bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-900 dark:bg-emerald-950/60 dark:text-emerald-200";
+    case "error":
+      return "rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-900 dark:bg-red-950/60 dark:text-red-200";
+    case "running":
+    default:
+      return "rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-900 dark:bg-amber-950/60 dark:text-amber-200";
+  }
+}
+
+function endpointBadge(endpoint: string): string {
+  switch (endpoint) {
+    case "generate":
+      return "rounded bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-900 dark:bg-blue-950/60 dark:text-blue-200";
+    case "modify":
+      return "rounded bg-violet-100 px-2 py-0.5 text-xs font-medium text-violet-900 dark:bg-violet-950/60 dark:text-violet-200";
+    case "analyze":
+    default:
+      return "rounded bg-teal-100 px-2 py-0.5 text-xs font-medium text-teal-900 dark:bg-teal-950/60 dark:text-teal-200";
+  }
+}
+
+async function fetchInteractions(filters: FilterParams): Promise<InteractionRow[]> {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  let idx = 1;
+
+  if (filters.endpoint) {
+    conditions.push(`endpoint = $${idx++}`);
+    params.push(filters.endpoint);
+  }
+  if (filters.status) {
+    conditions.push(`status = $${idx++}`);
+    params.push(filters.status);
+  }
+  if (filters.dashboard_id) {
+    const n = parseInt(filters.dashboard_id, 10);
+    if (!Number.isNaN(n) && n > 0) {
+      conditions.push(`dashboard_id = $${idx++}`);
+      params.push(n);
+    }
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+  return sql<InteractionRow>(
+    `SELECT
+       id, request_id, endpoint, dashboard_id,
+       prompt, final_output, lines,
+       llm_provider, llm_driver,
+       started_at, finished_at, status
+     FROM llm_interactions
+     ${where}
+     ORDER BY started_at DESC
+     LIMIT 50`,
+    params,
+  );
+}
+
+function formatDateEs(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return d.toLocaleString("es-ES", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+// ─── Page ────────────────────────────────────────────────────────────────────
+
+export default async function AdminInteractionsPage({
+  searchParams,
+}: {
+  searchParams: Promise<FilterParams>;
+}) {
+  const filters = await searchParams;
+  let rows: InteractionRow[] = [];
+  let dbError: string | null = null;
+
+  try {
+    rows = await fetchInteractions(filters);
+  } catch (err) {
+    dbError =
+      err instanceof Error ? err.message : "Error desconocido al cargar interacciones";
+    console.error("[admin/interactions]", err);
+  }
+
+  const filterLinks: Array<{ label: string; href: string; active: boolean }> = [
+    { label: "Todos", href: "/admin/interactions", active: !filters.endpoint && !filters.status },
+    {
+      label: "Generate",
+      href: "/admin/interactions?endpoint=generate",
+      active: filters.endpoint === "generate",
+    },
+    {
+      label: "Modify",
+      href: "/admin/interactions?endpoint=modify",
+      active: filters.endpoint === "modify",
+    },
+    {
+      label: "Analyze",
+      href: "/admin/interactions?endpoint=analyze",
+      active: filters.endpoint === "analyze",
+    },
+    {
+      label: "Errores",
+      href: "/admin/interactions?status=error",
+      active: filters.status === "error",
+    },
+    {
+      label: "En curso",
+      href: "/admin/interactions?status=running",
+      active: filters.status === "running",
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+        Interacciones LLM
+      </h1>
+
+      <p className="text-sm text-tremor-content dark:text-dark-tremor-content">
+        Últimas 50 interacciones con el modelo ({rows.length} mostradas). Click en el{" "}
+        <code className="rounded bg-tremor-background-subtle px-1">request_id</code> para ver el
+        log completo.
+      </p>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-2">
+        {filterLinks.map((f) => (
+          <Link
+            key={f.href}
+            href={f.href}
+            className={
+              f.active
+                ? "rounded-full bg-blue-600 px-3 py-1.5 text-xs font-medium text-white"
+                : "rounded-full border border-tremor-border dark:border-dark-tremor-border px-3 py-1.5 text-xs font-medium text-tremor-content dark:text-dark-tremor-content hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle"
+            }
+          >
+            {f.label}
+          </Link>
+        ))}
+      </div>
+
+      {dbError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-900 dark:border-red-900/40 dark:bg-red-950/40 dark:text-red-100">
+          {dbError}
+          <p className="mt-1 text-xs opacity-70">
+            (La tabla <code>llm_interactions</code> puede no existir aún — aplica las migraciones de la
+            base de datos.)
+          </p>
+        </div>
+      ) : (
+        <section className="overflow-x-auto rounded-lg border border-tremor-border dark:border-dark-tremor-border">
+          <table className="min-w-full text-left text-sm">
+            <thead className="bg-tremor-background-muted dark:bg-dark-tremor-background-muted">
+              <tr>
+                <th className="px-3 py-2 font-medium">Request ID</th>
+                <th className="px-3 py-2 font-medium">Endpoint</th>
+                <th className="px-3 py-2 font-medium">Estado</th>
+                <th className="px-3 py-2 font-medium">Dashboard</th>
+                <th className="px-3 py-2 font-medium">Prompt</th>
+                <th className="px-3 py-2 font-medium">Proveedor</th>
+                <th className="px-3 py-2 font-medium">Inicio</th>
+                <th className="px-3 py-2 font-medium">Fin</th>
+                <th className="px-3 py-2 font-medium">Líneas</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={9}
+                    className="px-3 py-6 text-center text-tremor-content-subtle dark:text-dark-tremor-content-subtle"
+                  >
+                    Sin interacciones registradas.
+                  </td>
+                </tr>
+              ) : (
+                rows.map((r) => (
+                  <tr
+                    key={r.id}
+                    className="border-t border-tremor-border dark:border-dark-tremor-border"
+                  >
+                    <td className="px-3 py-2 font-mono text-xs">
+                      <Link
+                        href={`/admin/interactions/${r.request_id}`}
+                        className="text-blue-500 hover:underline"
+                      >
+                        {r.request_id.slice(0, 16)}…
+                      </Link>
+                    </td>
+                    <td className="px-3 py-2">
+                      <span className={endpointBadge(r.endpoint)}>{r.endpoint}</span>
+                    </td>
+                    <td className="px-3 py-2">
+                      <span className={statusBadge(r.status)}>{r.status}</span>
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                      {r.dashboard_id ?? "—"}
+                    </td>
+                    <td
+                      className="max-w-[20rem] overflow-hidden text-ellipsis whitespace-nowrap px-3 py-2 text-xs text-tremor-content dark:text-dark-tremor-content"
+                      title={r.prompt}
+                    >
+                      {r.prompt.slice(0, 80)}
+                      {r.prompt.length > 80 ? "…" : ""}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                      {r.llm_provider ?? "—"}
+                      {r.llm_driver ? ` / ${r.llm_driver}` : ""}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                      {formatDateEs(r.started_at)}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                      {formatDateEs(r.finished_at)}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                      {Array.isArray(r.lines) ? r.lines.length : 0}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/dashboard/app/api/admin/interactions/__tests__/route.test.ts
+++ b/dashboard/app/api/admin/interactions/__tests__/route.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+/**
+ * Unit tests for GET /api/admin/interactions
+ * Mocks @/lib/db-write so no real DB connection is required.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mock DB before importing the route
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/db-write", () => ({
+  sql: vi.fn(),
+}));
+
+import { GET } from "../route";
+import * as dbWrite from "@/lib/db-write";
+
+const mockSql = vi.mocked(dbWrite.sql);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADMIN_KEY = "test-admin-key";
+
+function makeRequest(
+  opts: {
+    adminKey?: string;
+    search?: string;
+  } = {},
+): NextRequest {
+  const url = `http://localhost:4000/api/admin/interactions${opts.search ?? ""}`;
+  const headers: Record<string, string> = {};
+  if (opts.adminKey) {
+    headers["x-admin-key"] = opts.adminKey;
+  }
+  return new NextRequest(url, { headers });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/admin/interactions", () => {
+  beforeEach(() => {
+    vi.stubEnv("ADMIN_API_KEY", ADMIN_KEY);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 401 without a valid admin key", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("unauthorized");
+  });
+
+  it("returns 400 on invalid endpoint filter", async () => {
+    const res = await GET(
+      makeRequest({ adminKey: ADMIN_KEY, search: "?endpoint=badvalue" }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("VALIDATION");
+    expect(body.error).toContain("endpoint");
+  });
+
+  it("returns 200 with interactions array on valid request", async () => {
+    const fakeRows = [
+      {
+        id: "uuid-1",
+        request_id: "req_abc",
+        endpoint: "generate",
+        dashboard_id: 1,
+        prompt: "Crea un dashboard",
+        final_output: null,
+        lines: [],
+        llm_provider: "openrouter",
+        llm_driver: null,
+        started_at: "2026-04-24T10:00:00Z",
+        finished_at: null,
+        status: "completed",
+      },
+    ];
+    mockSql.mockResolvedValue(fakeRows);
+
+    const res = await GET(makeRequest({ adminKey: ADMIN_KEY }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.interactions)).toBe(true);
+    expect(body.interactions).toHaveLength(1);
+    expect(body.returned).toBe(1);
+    // `total` should not be present (renamed to `returned`)
+    expect(body.total).toBeUndefined();
+  });
+});

--- a/dashboard/app/api/admin/interactions/route.ts
+++ b/dashboard/app/api/admin/interactions/route.ts
@@ -17,11 +17,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { adminApiKeyValid, adminUnauthorized } from "@/lib/admin-api-auth";
 import { sql } from "@/lib/db-write";
 import type { InteractionRow } from "@/app/api/dashboard/[id]/interactions/route";
+import { formatApiError, generateRequestId } from "@/lib/errors";
 
 const VALID_ENDPOINTS = ["generate", "modify", "analyze"] as const;
 const VALID_STATUSES = ["running", "completed", "error"] as const;
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
+  const requestId = generateRequestId();
+
   if (!adminApiKeyValid(request)) {
     return adminUnauthorized();
   }
@@ -31,25 +34,49 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const status = searchParams.get("status");
   const dashboardIdParam = searchParams.get("dashboard_id");
 
-  // Validate filters
+  // Validate filters using the standard error shape
   if (
     endpoint !== null &&
     !(VALID_ENDPOINTS as readonly string[]).includes(endpoint)
   ) {
-    return NextResponse.json({ error: "invalid endpoint filter" }, { status: 400 });
+    return NextResponse.json(
+      formatApiError(
+        `El filtro 'endpoint' no es válido. Valores permitidos: ${VALID_ENDPOINTS.join(", ")}.`,
+        "VALIDATION",
+        undefined,
+        requestId,
+      ),
+      { status: 400 },
+    );
   }
   if (
     status !== null &&
     !(VALID_STATUSES as readonly string[]).includes(status)
   ) {
-    return NextResponse.json({ error: "invalid status filter" }, { status: 400 });
+    return NextResponse.json(
+      formatApiError(
+        `El filtro 'status' no es válido. Valores permitidos: ${VALID_STATUSES.join(", ")}.`,
+        "VALIDATION",
+        undefined,
+        requestId,
+      ),
+      { status: 400 },
+    );
   }
 
   let dashboardId: number | null = null;
   if (dashboardIdParam !== null) {
     const n = Number(dashboardIdParam);
     if (!Number.isInteger(n) || n <= 0) {
-      return NextResponse.json({ error: "invalid dashboard_id filter" }, { status: 400 });
+      return NextResponse.json(
+        formatApiError(
+          "El filtro 'dashboard_id' debe ser un entero positivo.",
+          "VALIDATION",
+          undefined,
+          requestId,
+        ),
+        { status: 400 },
+      );
     }
     dashboardId = n;
   }

--- a/dashboard/app/api/admin/interactions/route.ts
+++ b/dashboard/app/api/admin/interactions/route.ts
@@ -74,18 +74,27 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
-  const rows = await sql<InteractionRow>(
-    `SELECT
-       id, request_id, endpoint, dashboard_id,
-       prompt, final_output, lines,
-       llm_provider, llm_driver,
-       started_at, finished_at, status
-     FROM llm_interactions
-     ${where}
-     ORDER BY started_at DESC
-     LIMIT 50`,
-    params,
-  );
+  let rows: InteractionRow[];
+  try {
+    rows = await sql<InteractionRow>(
+      `SELECT
+         id, request_id, endpoint, dashboard_id,
+         prompt, final_output, lines,
+         llm_provider, llm_driver,
+         started_at, finished_at, status
+       FROM llm_interactions
+       ${where}
+       ORDER BY started_at DESC
+       LIMIT 50`,
+      params,
+    );
+  } catch (err) {
+    console.error("[admin/interactions GET]", err);
+    return NextResponse.json(
+      { error: "db_error", message: "No se pudieron cargar las interacciones." },
+      { status: 500 },
+    );
+  }
 
   return NextResponse.json({ interactions: rows, total: rows.length });
 }

--- a/dashboard/app/api/admin/interactions/route.ts
+++ b/dashboard/app/api/admin/interactions/route.ts
@@ -1,0 +1,91 @@
+/**
+ * GET /api/admin/interactions
+ *
+ * Returns up to 50 of the most recent LLM interactions.
+ * Accepts optional query parameters:
+ *   - endpoint: "generate" | "modify" | "analyze"
+ *   - status:   "running"  | "completed" | "error"
+ *   - dashboard_id: number
+ *
+ * Protected by x-admin-key / Bearer token.
+ *
+ * 200 — { interactions: InteractionRow[], total: number }
+ * 401 — unauthorized
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { adminApiKeyValid, adminUnauthorized } from "@/lib/admin-api-auth";
+import { sql } from "@/lib/db-write";
+import type { InteractionRow } from "@/app/api/dashboard/[id]/interactions/route";
+
+const VALID_ENDPOINTS = ["generate", "modify", "analyze"] as const;
+const VALID_STATUSES = ["running", "completed", "error"] as const;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!adminApiKeyValid(request)) {
+    return adminUnauthorized();
+  }
+
+  const { searchParams } = request.nextUrl;
+  const endpoint = searchParams.get("endpoint");
+  const status = searchParams.get("status");
+  const dashboardIdParam = searchParams.get("dashboard_id");
+
+  // Validate filters
+  if (
+    endpoint !== null &&
+    !(VALID_ENDPOINTS as readonly string[]).includes(endpoint)
+  ) {
+    return NextResponse.json({ error: "invalid endpoint filter" }, { status: 400 });
+  }
+  if (
+    status !== null &&
+    !(VALID_STATUSES as readonly string[]).includes(status)
+  ) {
+    return NextResponse.json({ error: "invalid status filter" }, { status: 400 });
+  }
+
+  let dashboardId: number | null = null;
+  if (dashboardIdParam !== null) {
+    const n = Number(dashboardIdParam);
+    if (!Number.isInteger(n) || n <= 0) {
+      return NextResponse.json({ error: "invalid dashboard_id filter" }, { status: 400 });
+    }
+    dashboardId = n;
+  }
+
+  // Build WHERE clauses
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  let paramIdx = 1;
+
+  if (endpoint !== null) {
+    conditions.push(`endpoint = $${paramIdx++}`);
+    params.push(endpoint);
+  }
+  if (status !== null) {
+    conditions.push(`status = $${paramIdx++}`);
+    params.push(status);
+  }
+  if (dashboardId !== null) {
+    conditions.push(`dashboard_id = $${paramIdx++}`);
+    params.push(dashboardId);
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+  const rows = await sql<InteractionRow>(
+    `SELECT
+       id, request_id, endpoint, dashboard_id,
+       prompt, final_output, lines,
+       llm_provider, llm_driver,
+       started_at, finished_at, status
+     FROM llm_interactions
+     ${where}
+     ORDER BY started_at DESC
+     LIMIT 50`,
+    params,
+  );
+
+  return NextResponse.json({ interactions: rows, total: rows.length });
+}

--- a/dashboard/app/api/admin/interactions/route.ts
+++ b/dashboard/app/api/admin/interactions/route.ts
@@ -9,7 +9,7 @@
  *
  * Protected by x-admin-key / Bearer token.
  *
- * 200 — { interactions: InteractionRow[], total: number }
+ * 200 — { interactions: InteractionRow[], returned: number }
  * 401 — unauthorized
  */
 
@@ -123,5 +123,5 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  return NextResponse.json({ interactions: rows, total: rows.length });
+  return NextResponse.json({ interactions: rows, returned: rows.length });
 }

--- a/dashboard/app/api/dashboard/[id]/interactions/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/[id]/interactions/__tests__/route.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment node
+/**
+ * Unit tests for GET /api/dashboard/[id]/interactions
+ * Mocks @/lib/db-write so no real DB connection is required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mock DB before importing the route
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/db-write", () => ({
+  sql: vi.fn(),
+}));
+
+import { GET } from "../route";
+import * as dbWrite from "@/lib/db-write";
+
+const mockSql = vi.mocked(dbWrite.sql);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+function makeRequest(id: string): [NextRequest, RouteContext] {
+  const req = new NextRequest(
+    `http://localhost:4000/api/dashboard/${id}/interactions`,
+  );
+  const ctx: RouteContext = { params: Promise.resolve({ id }) };
+  return [req, ctx];
+}
+
+function makeRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "uuid-1",
+    request_id: "req_abc",
+    endpoint: "generate",
+    dashboard_id: 1,
+    prompt: "Crea un dashboard",
+    final_output: null,
+    lines: [],
+    llm_provider: "openrouter",
+    llm_driver: null,
+    started_at: "2026-04-24T10:00:00Z",
+    finished_at: null,
+    status: "completed",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/dashboard/[id]/interactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 on invalid dashboard id (non-numeric)", async () => {
+    const [req, ctx] = makeRequest("abc");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("VALIDATION");
+  });
+
+  it("returns 400 on invalid dashboard id (zero)", async () => {
+    const [req, ctx] = makeRequest("0");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with interactions ordered by started_at DESC", async () => {
+    const rows = [
+      makeRow({ started_at: "2026-04-24T12:00:00Z", request_id: "req_newer" }),
+      makeRow({ started_at: "2026-04-24T10:00:00Z", request_id: "req_older" }),
+    ];
+    mockSql.mockResolvedValue(rows);
+
+    const [req, ctx] = makeRequest("1");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.interactions)).toBe(true);
+    // First result is newest (DESC order from DB — we trust the DB ordering)
+    expect(body.interactions[0].request_id).toBe("req_newer");
+    expect(typeof body.has_more).toBe("boolean");
+  });
+
+  it("sets has_more=false when fewer than 20 rows returned", async () => {
+    mockSql.mockResolvedValue([makeRow()]);
+
+    const [req, ctx] = makeRequest("1");
+    const res = await GET(req, ctx);
+    const body = await res.json();
+    expect(body.has_more).toBe(false);
+  });
+
+  it("returns 500 structured error response on DB failure", async () => {
+    mockSql.mockRejectedValue(new Error("connection refused"));
+
+    const [req, ctx] = makeRequest("5");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    // Must follow the structured ApiError format
+    expect(body.code).toBeDefined();
+    expect(typeof body.error).toBe("string");
+    expect(typeof body.requestId).toBe("string");
+  });
+});

--- a/dashboard/app/api/dashboard/[id]/interactions/route.ts
+++ b/dashboard/app/api/dashboard/[id]/interactions/route.ts
@@ -1,13 +1,14 @@
 /**
  * GET /api/dashboard/[id]/interactions
  *
- * Returns all LLM interactions for a given dashboard, ordered by started_at DESC.
+ * Returns the 20 most recent LLM interactions for a given dashboard,
+ * ordered by started_at DESC.
  * Each row includes request_id, endpoint, prompt, final_output, lines, status,
  * llm_provider, llm_driver, started_at, finished_at.
  *
  * The `lines` field is a JSONB array of InteractionLine objects.
  *
- * 200 — { interactions: InteractionRow[] }
+ * 200 — { interactions: InteractionRow[], has_more: boolean }
  * 400 — invalid id
  * 500 — unexpected error
  */
@@ -59,6 +60,7 @@ export async function GET(
     );
   }
 
+  const LIMIT = 20;
   try {
     const rows = await sql<InteractionRow>(
       `SELECT
@@ -68,10 +70,12 @@ export async function GET(
          started_at, finished_at, status
        FROM llm_interactions
        WHERE dashboard_id = $1
-       ORDER BY started_at DESC`,
-      [id],
+       ORDER BY started_at DESC
+       LIMIT $2`,
+      [id, LIMIT + 1],
     );
-    return NextResponse.json({ interactions: rows });
+    const has_more = rows.length > LIMIT;
+    return NextResponse.json({ interactions: rows.slice(0, LIMIT), has_more });
   } catch (err) {
     console.error(`[${requestId}] GET /api/dashboard/${id}/interactions failed:`, err);
     return NextResponse.json(

--- a/dashboard/app/api/dashboard/[id]/interactions/route.ts
+++ b/dashboard/app/api/dashboard/[id]/interactions/route.ts
@@ -1,0 +1,87 @@
+/**
+ * GET /api/dashboard/[id]/interactions
+ *
+ * Returns all LLM interactions for a given dashboard, ordered by started_at DESC.
+ * Each row includes request_id, endpoint, prompt, final_output, lines, status,
+ * llm_provider, llm_driver, started_at, finished_at.
+ *
+ * The `lines` field is a JSONB array of InteractionLine objects.
+ *
+ * 200 — { interactions: InteractionRow[] }
+ * 400 — invalid id
+ * 500 — unexpected error
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@/lib/db-write";
+import { formatApiError, generateRequestId } from "@/lib/errors";
+import type { InteractionLine } from "@/lib/db-write";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export interface InteractionRow {
+  id: string;
+  request_id: string;
+  endpoint: "generate" | "modify" | "analyze";
+  dashboard_id: number | null;
+  prompt: string;
+  final_output: string | null;
+  lines: InteractionLine[];
+  llm_provider: string | null;
+  llm_driver: string | null;
+  started_at: string;
+  finished_at: string | null;
+  status: "running" | "completed" | "error";
+}
+
+function parseId(raw: string): number | null {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) return null;
+  return n;
+}
+
+export async function GET(
+  _request: NextRequest,
+  context: RouteContext,
+): Promise<NextResponse> {
+  const requestId = generateRequestId();
+  const { id: rawId } = await context.params;
+  const id = parseId(rawId);
+  if (id === null) {
+    return NextResponse.json(
+      formatApiError(
+        "El identificador del dashboard no es válido (debe ser un entero positivo).",
+        "VALIDATION",
+        undefined,
+        requestId,
+      ),
+      { status: 400 },
+    );
+  }
+
+  try {
+    const rows = await sql<InteractionRow>(
+      `SELECT
+         id, request_id, endpoint, dashboard_id,
+         prompt, final_output, lines,
+         llm_provider, llm_driver,
+         started_at, finished_at, status
+       FROM llm_interactions
+       WHERE dashboard_id = $1
+       ORDER BY started_at DESC`,
+      [id],
+    );
+    return NextResponse.json({ interactions: rows });
+  } catch (err) {
+    console.error(`[${requestId}] GET /api/dashboard/${id}/interactions failed:`, err);
+    return NextResponse.json(
+      formatApiError(
+        "No se pudieron cargar las interacciones del panel.",
+        "DB_QUERY",
+        undefined,
+        requestId,
+      ),
+      { status: 500 },
+    );
+  }
+}

--- a/dashboard/app/api/dashboard/analyze/route.ts
+++ b/dashboard/app/api/dashboard/analyze/route.ts
@@ -27,6 +27,11 @@ import {
   sanitizeErrorMessage,
 } from "@/lib/errors";
 import type { WidgetData } from "@/components/widgets/types";
+import {
+  createInteraction,
+  finishInteraction,
+} from "@/lib/db-write";
+import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -188,6 +193,25 @@ export async function POST(request: Request) {
   // --- Serialize widget data for LLM context --------------------------------
   const serializedData = serializeWidgetData(specParse.data, widgetDataMap);
 
+  // --- Persist interaction start -------------------------------------------
+  const cfg = loadDashboardLlmConfig();
+  const llmProvider = cfg.provider;
+  const llmDriver = cfg.provider === "cli" ? cfg.cliDriver : null;
+
+  let interactionId: string | null = null;
+  try {
+    interactionId = await createInteraction({
+      requestId,
+      endpoint: "analyze",
+      dashboardId: dashboardIdNum ?? null,
+      prompt: prompt.trim(),
+      llmProvider,
+      llmDriver: llmDriver ?? null,
+    });
+  } catch (e) {
+    console.error(`[${requestId}] createInteraction(analyze) failed:`, e);
+  }
+
   // --- Call LLM to analyze dashboard ----------------------------------------
   let analysisResponse: string;
   try {
@@ -202,6 +226,12 @@ export async function POST(request: Request) {
       },
     );
   } catch (err) {
+    if (interactionId) {
+      const errText = err instanceof Error ? err.message : "Error al analizar";
+      void finishInteraction(interactionId, "error", errText).catch((e) =>
+        console.error(`[${requestId}] finishInteraction(analyze,error) failed:`, e),
+      );
+    }
     if (err instanceof AgenticRunnerError) {
       return NextResponse.json(
         formatApiError(
@@ -250,6 +280,12 @@ export async function POST(request: Request) {
   // --- Generate suggestions before returning the response ------------------
   const lastExchange = `Usuario: ${prompt.trim()}\n\nAsistente: ${analysisResponse}`;
   const suggestions = await generateSuggestions(serializedData, lastExchange, { requestId });
+
+  if (interactionId) {
+    void finishInteraction(interactionId, "completed", analysisResponse).catch((e) =>
+      console.error(`[${requestId}] finishInteraction(analyze,completed) failed:`, e),
+    );
+  }
 
   return NextResponse.json({ response: analysisResponse, suggestions });
 }

--- a/dashboard/app/api/dashboard/analyze/route.ts
+++ b/dashboard/app/api/dashboard/analyze/route.ts
@@ -282,7 +282,7 @@ export async function POST(request: Request) {
   const suggestions = await generateSuggestions(serializedData, lastExchange, { requestId });
 
   if (interactionId) {
-    void finishInteraction(interactionId, "completed", analysisResponse).catch((e) =>
+    await finishInteraction(interactionId, "completed", analysisResponse).catch((e) =>
       console.error(`[${requestId}] finishInteraction(analyze,completed) failed:`, e),
     );
   }

--- a/dashboard/app/api/dashboard/analyze/route.ts
+++ b/dashboard/app/api/dashboard/analyze/route.ts
@@ -228,7 +228,7 @@ export async function POST(request: Request) {
   } catch (err) {
     if (interactionId) {
       const errText = err instanceof Error ? err.message : "Error al analizar";
-      void finishInteraction(interactionId, "error", errText).catch((e) =>
+      await finishInteraction(interactionId, "error", errText).catch((e) =>
         console.error(`[${requestId}] finishInteraction(analyze,error) failed:`, e),
       );
     }

--- a/dashboard/app/api/dashboard/generate/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/generate/__tests__/route.test.ts
@@ -17,14 +17,28 @@ vi.mock("@/lib/schema", async () => {
   return { ...actual };
 });
 
+// --- Mock the persistence module ---
+vi.mock("@/lib/db-write", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/db-write")>("@/lib/db-write");
+  return {
+    ...actual,
+    createInteraction: vi.fn().mockResolvedValue("mock-interaction-id"),
+    appendInteractionLines: vi.fn().mockResolvedValue(undefined),
+    finishInteraction: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
 import { POST } from "../route";
 import {
   generateDashboard,
   BudgetExceededError,
   CircuitBreakerOpenError,
 } from "@/lib/llm";
+import * as dbWrite from "@/lib/db-write";
 
 const mockGenerate = vi.mocked(generateDashboard);
+const mockCreateInteraction = vi.mocked(dbWrite.createInteraction);
+const mockFinishInteraction = vi.mocked(dbWrite.finishInteraction);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -62,6 +76,12 @@ const VALID_SPEC = {
 describe("POST /api/dashboard/generate", () => {
   beforeEach(() => {
     mockGenerate.mockReset();
+    mockCreateInteraction.mockReset();
+    mockCreateInteraction.mockResolvedValue("mock-interaction-id");
+    mockFinishInteraction.mockReset();
+    mockFinishInteraction.mockResolvedValue(undefined);
+    vi.mocked(dbWrite.appendInteractionLines).mockReset();
+    vi.mocked(dbWrite.appendInteractionLines).mockResolvedValue(undefined);
   });
 
   // --- Happy path ---
@@ -354,6 +374,54 @@ describe("POST /api/dashboard/generate", () => {
 
       expect(res.status).toBe(400);
       expect(json.code).toBe("LLM_INVALID_RESPONSE");
+    });
+  });
+
+  // --- Persistence (createInteraction / finishInteraction) ---
+
+  describe("interaction persistence (non-stream)", () => {
+    it("creates an interaction and finishes it as completed on success", async () => {
+      mockGenerate.mockResolvedValue(JSON.stringify(VALID_SPEC));
+
+      const res = await POST(makeRequest({ prompt: "Ventas del mes" }));
+      expect(res.status).toBe(200);
+
+      expect(mockCreateInteraction).toHaveBeenCalledWith(
+        expect.objectContaining({ endpoint: "generate", prompt: "Ventas del mes" }),
+      );
+      expect(mockFinishInteraction).toHaveBeenCalledWith(
+        "mock-interaction-id",
+        "completed",
+        expect.any(String),
+      );
+    });
+
+    it("creates an interaction and finishes it as error when LLM throws", async () => {
+      mockGenerate.mockRejectedValue(new Error("LLM down"));
+
+      const res = await POST(makeRequest({ prompt: "Ventas del mes" }));
+      expect(res.status).toBe(500);
+
+      expect(mockCreateInteraction).toHaveBeenCalled();
+      expect(mockFinishInteraction).toHaveBeenCalledWith(
+        "mock-interaction-id",
+        "error",
+        expect.any(String),
+      );
+    });
+
+    it("creates an interaction and finishes it as error when LLM returns invalid spec", async () => {
+      mockGenerate.mockResolvedValue(JSON.stringify({ title: "no widgets" }));
+
+      const res = await POST(makeRequest({ prompt: "Ventas del mes" }));
+      expect(res.status).toBe(400);
+
+      expect(mockCreateInteraction).toHaveBeenCalled();
+      expect(mockFinishInteraction).toHaveBeenCalledWith(
+        "mock-interaction-id",
+        "error",
+        expect.any(String),
+      );
     });
   });
 });

--- a/dashboard/app/api/dashboard/generate/route.ts
+++ b/dashboard/app/api/dashboard/generate/route.ts
@@ -260,7 +260,8 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
           promptPreview: prompt.slice(0, 200),
         });
 
-        // Start persisting the interaction concurrently (non-blocking).
+        // Start persisting the interaction concurrently — the first meta NDJSON line
+        // was already sent above so the DB insert does not block the stream start.
         const interactionLines: InteractionLine[] = [];
         let interactionId: string | null = null;
         const interactionIdPromise = createInteraction({

--- a/dashboard/app/api/dashboard/generate/route.ts
+++ b/dashboard/app/api/dashboard/generate/route.ts
@@ -250,26 +250,38 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
           controller.enqueue(encoder.encode(`${JSON.stringify(obj)}\n`));
         };
 
-        // Start persisting the interaction (fire-and-forget; never blocks stream)
+        const ts = () => new Date().toISOString();
+
+        // Send the first meta line immediately — do NOT await DB before this.
+        send({
+          type: "meta",
+          requestId,
+          message: "Generación con IA iniciada",
+          promptPreview: prompt.slice(0, 200),
+        });
+
+        // Start persisting the interaction concurrently (non-blocking).
         const interactionLines: InteractionLine[] = [];
         let interactionId: string | null = null;
-        try {
-          interactionId = await createInteraction({
-            requestId,
-            endpoint: "generate",
-            prompt,
-            llmProvider,
-            llmDriver: llmDriver ?? null,
-          });
-        } catch (e) {
+        const interactionIdPromise = createInteraction({
+          requestId,
+          endpoint: "generate",
+          prompt,
+          llmProvider,
+          llmDriver: llmDriver ?? null,
+        }).then((id) => {
+          interactionId = id;
+        }).catch((e) => {
           console.error(`[${requestId}] createInteraction failed:`, e);
-        }
+        });
 
         const pushLine = (line: InteractionLine) => {
           interactionLines.push(line);
         };
 
         const flushLines = async () => {
+          // Ensure the insert has resolved before flushing lines
+          await interactionIdPromise;
           if (!interactionId || interactionLines.length === 0) return;
           const toFlush = interactionLines.splice(0);
           try {
@@ -279,14 +291,6 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
           }
         };
 
-        const ts = () => new Date().toISOString();
-
-        send({
-          type: "meta",
-          requestId,
-          message: "Generación con IA iniciada",
-          promptPreview: prompt.slice(0, 200),
-        });
         pushLine({ kind: "meta", text: "Generación con IA iniciada", ts: ts() });
 
         let rawResponse: string;
@@ -301,7 +305,7 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
                 ev.type === "tool_start" || ev.type === "assistant_tools"
                   ? "tool_call"
                   : ev.type === "tool_done"
-                    ? "tool_result"
+                    ? (ev.ok ? "tool_result" : "error")
                     : "meta";
               pushLine({ kind, text, ts: ts() });
             },

--- a/dashboard/app/api/dashboard/generate/route.ts
+++ b/dashboard/app/api/dashboard/generate/route.ts
@@ -319,7 +319,7 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
           pushLine({ kind: "error", text: errText, ts: ts() });
           await flushLines();
           if (interactionId) {
-            void finishInteraction(interactionId, "error", errText).catch((e) =>
+            await finishInteraction(interactionId, "error", errText).catch((e) =>
               console.error(`[${requestId}] finishInteraction(error) failed:`, e),
             );
           }
@@ -345,7 +345,7 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
           pushLine({ kind: "error", text: errText, ts: ts() });
           await flushLines();
           if (interactionId) {
-            void finishInteraction(interactionId, "error", errText).catch((e) =>
+            await finishInteraction(interactionId, "error", errText).catch((e) =>
               console.error(`[${requestId}] finishInteraction(error) failed:`, e),
             );
           }
@@ -362,7 +362,7 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
         pushLine({ kind: "meta", text: "Panel generado correctamente.", ts: ts() });
         await flushLines();
         if (interactionId) {
-          void finishInteraction(
+          await finishInteraction(
             interactionId,
             "completed",
             JSON.stringify(finish.spec),
@@ -413,7 +413,7 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
     if (interactionId) {
       const errText =
         typeof mapped.payload["error"] === "string" ? mapped.payload["error"] : "Error al generar";
-      void finishInteraction(interactionId, "error", errText).catch((e) =>
+      await finishInteraction(interactionId, "error", errText).catch((e) =>
         console.error(`[${requestId}] finishInteraction(error) failed:`, e),
       );
     }
@@ -427,14 +427,14 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
         typeof finish.payload["error"] === "string"
           ? finish.payload["error"]
           : "Validación fallida";
-      void finishInteraction(interactionId, "error", errText).catch((e) =>
+      await finishInteraction(interactionId, "error", errText).catch((e) =>
         console.error(`[${requestId}] finishInteraction(error) failed:`, e),
       );
     }
     return NextResponse.json(finish.payload, { status: finish.status });
   }
   if (interactionId) {
-    void finishInteraction(interactionId, "completed", JSON.stringify(finish.spec)).catch((e) =>
+    await finishInteraction(interactionId, "completed", JSON.stringify(finish.spec)).catch((e) =>
       console.error(`[${requestId}] finishInteraction(completed) failed:`, e),
     );
   }

--- a/dashboard/app/api/dashboard/generate/route.ts
+++ b/dashboard/app/api/dashboard/generate/route.ts
@@ -21,6 +21,15 @@ import {
   generateRequestId,
   sanitizeErrorMessage,
 } from "@/lib/errors";
+import {
+  createInteraction,
+  appendInteractionLines,
+  finishInteraction,
+  type InteractionLine,
+} from "@/lib/db-write";
+import { formatAgenticProgressLineEs } from "@/lib/format-agentic-progress";
+import type { AgenticProgressEvent } from "@/lib/llm-tools/types";
+import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
 
 function extractJson(raw: string): string {
   const trimmed = raw.trim();
@@ -231,11 +240,46 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
 
   if (wantStream) {
     const encoder = new TextEncoder();
+    const cfg = loadDashboardLlmConfig();
+    const llmProvider = cfg.provider;
+    const llmDriver = cfg.provider === "cli" ? cfg.cliDriver : null;
+
     const stream = new ReadableStream<Uint8Array>({
       async start(controller) {
         const send = (obj: Record<string, unknown>) => {
           controller.enqueue(encoder.encode(`${JSON.stringify(obj)}\n`));
         };
+
+        // Start persisting the interaction (fire-and-forget; never blocks stream)
+        const interactionLines: InteractionLine[] = [];
+        let interactionId: string | null = null;
+        try {
+          interactionId = await createInteraction({
+            requestId,
+            endpoint: "generate",
+            prompt,
+            llmProvider,
+            llmDriver: llmDriver ?? null,
+          });
+        } catch (e) {
+          console.error(`[${requestId}] createInteraction failed:`, e);
+        }
+
+        const pushLine = (line: InteractionLine) => {
+          interactionLines.push(line);
+        };
+
+        const flushLines = async () => {
+          if (!interactionId || interactionLines.length === 0) return;
+          const toFlush = interactionLines.splice(0);
+          try {
+            await appendInteractionLines(interactionId, toFlush);
+          } catch (e) {
+            console.error(`[${requestId}] appendInteractionLines failed:`, e);
+          }
+        };
+
+        const ts = () => new Date().toISOString();
 
         send({
           type: "meta",
@@ -243,18 +287,38 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
           message: "Generación con IA iniciada",
           promptPreview: prompt.slice(0, 200),
         });
+        pushLine({ kind: "meta", text: "Generación con IA iniciada", ts: ts() });
 
         let rawResponse: string;
         try {
           rawResponse = await generateDashboard(prompt, {
             requestId,
             endpoint: "generateDashboard",
-            onAgenticProgress: (ev) => {
+            onAgenticProgress: (ev: AgenticProgressEvent) => {
               send({ type: "progress", requestId, event: ev });
+              const text = formatAgenticProgressLineEs(ev);
+              const kind: InteractionLine["kind"] =
+                ev.type === "tool_start" || ev.type === "assistant_tools"
+                  ? "tool_call"
+                  : ev.type === "tool_done"
+                    ? "tool_result"
+                    : "meta";
+              pushLine({ kind, text, ts: ts() });
             },
           });
         } catch (err: unknown) {
           const mapped = mapGenerateLlmError(err, requestId);
+          const errText =
+            typeof mapped.payload["error"] === "string"
+              ? mapped.payload["error"]
+              : "Error al generar";
+          pushLine({ kind: "error", text: errText, ts: ts() });
+          await flushLines();
+          if (interactionId) {
+            void finishInteraction(interactionId, "error", errText).catch((e) =>
+              console.error(`[${requestId}] finishInteraction(error) failed:`, e),
+            );
+          }
           send({
             type: "error",
             requestId,
@@ -266,8 +330,21 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
         }
 
         send({ type: "phase", requestId, message: "Validando JSON del panel…" });
+        pushLine({ kind: "phase", text: "Validando JSON del panel…", ts: ts() });
+
         const finish = finishGenerateFromRawLlm(rawResponse, requestId);
         if (!finish.ok) {
+          const errText =
+            typeof finish.payload["error"] === "string"
+              ? finish.payload["error"]
+              : "Validación fallida";
+          pushLine({ kind: "error", text: errText, ts: ts() });
+          await flushLines();
+          if (interactionId) {
+            void finishInteraction(interactionId, "error", errText).catch((e) =>
+              console.error(`[${requestId}] finishInteraction(error) failed:`, e),
+            );
+          }
           send({
             type: "error",
             requestId,
@@ -276,6 +353,18 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
           });
           controller.close();
           return;
+        }
+
+        pushLine({ kind: "meta", text: "Panel generado correctamente.", ts: ts() });
+        await flushLines();
+        if (interactionId) {
+          void finishInteraction(
+            interactionId,
+            "completed",
+            JSON.stringify(finish.spec),
+          ).catch((e) =>
+            console.error(`[${requestId}] finishInteraction(completed) failed:`, e),
+          );
         }
 
         send({ type: "result", requestId, spec: finish.spec });
@@ -292,6 +381,23 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
     });
   }
 
+  const cfg = loadDashboardLlmConfig();
+  const llmProvider = cfg.provider;
+  const llmDriver = cfg.provider === "cli" ? cfg.cliDriver : null;
+
+  let interactionId: string | null = null;
+  try {
+    interactionId = await createInteraction({
+      requestId,
+      endpoint: "generate",
+      prompt,
+      llmProvider,
+      llmDriver: llmDriver ?? null,
+    });
+  } catch (e) {
+    console.error(`[${requestId}] createInteraction (non-stream) failed:`, e);
+  }
+
   let rawResponse: string;
   try {
     rawResponse = await generateDashboard(prompt, {
@@ -300,12 +406,33 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
     });
   } catch (err: unknown) {
     const mapped = mapGenerateLlmError(err, requestId);
+    if (interactionId) {
+      const errText =
+        typeof mapped.payload["error"] === "string" ? mapped.payload["error"] : "Error al generar";
+      void finishInteraction(interactionId, "error", errText).catch((e) =>
+        console.error(`[${requestId}] finishInteraction(error) failed:`, e),
+      );
+    }
     return NextResponse.json(mapped.payload, { status: mapped.status });
   }
 
   const finish = finishGenerateFromRawLlm(rawResponse, requestId);
   if (!finish.ok) {
+    if (interactionId) {
+      const errText =
+        typeof finish.payload["error"] === "string"
+          ? finish.payload["error"]
+          : "Validación fallida";
+      void finishInteraction(interactionId, "error", errText).catch((e) =>
+        console.error(`[${requestId}] finishInteraction(error) failed:`, e),
+      );
+    }
     return NextResponse.json(finish.payload, { status: finish.status });
+  }
+  if (interactionId) {
+    void finishInteraction(interactionId, "completed", JSON.stringify(finish.spec)).catch((e) =>
+      console.error(`[${requestId}] finishInteraction(completed) failed:`, e),
+    );
   }
   return NextResponse.json(finish.spec, { status: 200 });
 }

--- a/dashboard/app/api/dashboard/modify/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/modify/__tests__/route.test.ts
@@ -14,8 +14,19 @@ vi.mock("@/lib/llm", async () => {
   };
 });
 
+// --- Mock the persistence module ---
+vi.mock("@/lib/db-write", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/db-write")>("@/lib/db-write");
+  return {
+    ...actual,
+    createInteraction: vi.fn().mockResolvedValue("mock-interaction-id"),
+    finishInteraction: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
 import { POST } from "../route";
 import { BudgetExceededError, CircuitBreakerOpenError } from "@/lib/llm";
+import * as dbWrite from "@/lib/db-write";
 
 // --- Helpers ----------------------------------------------------------------
 
@@ -76,11 +87,18 @@ function makeRawRequest(rawBody: string): Request {
   });
 }
 
+const mockCreateInteraction = vi.mocked(dbWrite.createInteraction);
+const mockFinishInteraction = vi.mocked(dbWrite.finishInteraction);
+
 // --- Tests ------------------------------------------------------------------
 
 describe("POST /api/dashboard/modify", () => {
   beforeEach(() => {
     mockModifyDashboard.mockReset();
+    mockCreateInteraction.mockReset();
+    mockCreateInteraction.mockResolvedValue("mock-interaction-id");
+    mockFinishInteraction.mockReset();
+    mockFinishInteraction.mockResolvedValue(undefined);
   });
 
   it("returns updated spec on valid modification", async () => {
@@ -269,5 +287,56 @@ describe("POST /api/dashboard/modify", () => {
     expect(res.status).toBe(400);
     const json = await res.json();
     expect(json.raw).toBeUndefined();
+  });
+
+  // --- Persistence (createInteraction / finishInteraction) ---
+
+  describe("interaction persistence", () => {
+    it("creates an interaction and finishes it as completed on success", async () => {
+      mockModifyDashboard.mockResolvedValue(JSON.stringify(updatedSpec));
+
+      const res = await POST(makeRequest({ spec: validSpec, prompt: "Añade el margen" }));
+      expect(res.status).toBe(200);
+
+      expect(mockCreateInteraction).toHaveBeenCalledWith(
+        expect.objectContaining({ endpoint: "modify", prompt: "Añade el margen" }),
+      );
+      expect(mockFinishInteraction).toHaveBeenCalledWith(
+        "mock-interaction-id",
+        "completed",
+        expect.any(String),
+      );
+    });
+
+    it("creates an interaction and finishes it as error when LLM throws", async () => {
+      mockModifyDashboard.mockRejectedValue(new Error("LLM down"));
+
+      const res = await POST(makeRequest({ spec: validSpec, prompt: "Añade algo" }));
+      expect(res.status).toBe(500);
+
+      expect(mockCreateInteraction).toHaveBeenCalled();
+      expect(mockFinishInteraction).toHaveBeenCalledWith(
+        "mock-interaction-id",
+        "error",
+        expect.any(String),
+      );
+    });
+
+    it("passes dashboardId to createInteraction when provided in request body", async () => {
+      mockModifyDashboard.mockResolvedValue(JSON.stringify(updatedSpec));
+
+      await POST(makeRequest({ spec: validSpec, prompt: "Añade el margen", dashboardId: 42 }));
+
+      expect(mockCreateInteraction).toHaveBeenCalledWith(
+        expect.objectContaining({ endpoint: "modify", dashboardId: 42 }),
+      );
+    });
+
+    it("returns 400 when dashboardId is invalid", async () => {
+      const res = await POST(makeRequest({ spec: validSpec, prompt: "Añade algo", dashboardId: -1 }));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.code).toBe("VALIDATION");
+    });
   });
 });

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -255,7 +255,7 @@ export async function POST(request: Request) {
   }
 
   if (interactionId) {
-    void finishInteraction(interactionId, "completed", JSON.stringify(updatedSpec)).catch((e) =>
+    await finishInteraction(interactionId, "completed", JSON.stringify(updatedSpec)).catch((e) =>
       console.error(`[${requestId}] finishInteraction(modify,completed) failed:`, e),
     );
   }

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -65,7 +65,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const { spec, prompt } = body as Record<string, unknown>;
+  const { spec, prompt, dashboardId } = body as Record<string, unknown>;
 
   // --- Validate required fields ---------------------------------------------
   if (spec === undefined) {
@@ -106,6 +106,28 @@ export async function POST(request: Request) {
     );
   }
 
+  // --- Resolve optional dashboardId -----------------------------------------
+  let dashboardIdNum: number | null = null;
+  if (dashboardId !== undefined && dashboardId !== null) {
+    if (typeof dashboardId === "number" && Number.isInteger(dashboardId) && dashboardId > 0) {
+      dashboardIdNum = dashboardId;
+    } else if (typeof dashboardId === "string" && /^\d+$/.test(dashboardId)) {
+      const n = parseInt(dashboardId, 10);
+      if (n > 0) dashboardIdNum = n;
+    }
+    if (dashboardIdNum === null) {
+      return NextResponse.json(
+        formatApiError(
+          "El campo 'dashboardId' debe ser un entero positivo cuando se envía.",
+          "VALIDATION",
+          undefined,
+          requestId,
+        ),
+        { status: 400 },
+      );
+    }
+  }
+
   // --- Persist interaction start --------------------------------------------
   const cfg = loadDashboardLlmConfig();
   const llmProvider = cfg.provider;
@@ -116,6 +138,7 @@ export async function POST(request: Request) {
     interactionId = await createInteraction({
       requestId,
       endpoint: "modify",
+      dashboardId: dashboardIdNum,
       prompt: prompt.trim(),
       llmProvider,
       llmDriver: llmDriver ?? null,

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -135,7 +135,7 @@ export async function POST(request: Request) {
   } catch (err: unknown) {
     if (interactionId) {
       const errText = err instanceof Error ? err.message : "Error al modificar";
-      void finishInteraction(interactionId, "error", errText).catch((e) =>
+      await finishInteraction(interactionId, "error", errText).catch((e) =>
         console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
       );
     }
@@ -194,7 +194,7 @@ export async function POST(request: Request) {
       `[${requestId}] El LLM devolvió JSON inválido al modificar (${jsonStr.length} chars)`,
     );
     if (interactionId) {
-      void finishInteraction(interactionId, "error", "JSON inválido en respuesta del modelo").catch(
+      await finishInteraction(interactionId, "error", "JSON inválido en respuesta del modelo").catch(
         (e) => console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
       );
     }
@@ -215,7 +215,7 @@ export async function POST(request: Request) {
   } catch {
     console.error(`[${requestId}] El LLM devolvió un spec inválido al modificar.`);
     if (interactionId) {
-      void finishInteraction(interactionId, "error", "Spec inválido").catch((e) =>
+      await finishInteraction(interactionId, "error", "Spec inválido").catch((e) =>
         console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
       );
     }
@@ -237,7 +237,7 @@ export async function POST(request: Request) {
       sqlLint.join(" | "),
     );
     if (interactionId) {
-      void finishInteraction(interactionId, "error", `SQL lint: ${sqlLint.join(" | ")}`).catch(
+      await finishInteraction(interactionId, "error", `SQL lint: ${sqlLint.join(" | ")}`).catch(
         (e) => console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
       );
     }

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -21,6 +21,11 @@ import {
   generateRequestId,
   sanitizeErrorMessage,
 } from "@/lib/errors";
+import {
+  createInteraction,
+  finishInteraction,
+} from "@/lib/db-write";
+import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
 
 /**
  * Extract JSON from a string that may be wrapped in markdown code blocks.
@@ -101,6 +106,24 @@ export async function POST(request: Request) {
     );
   }
 
+  // --- Persist interaction start --------------------------------------------
+  const cfg = loadDashboardLlmConfig();
+  const llmProvider = cfg.provider;
+  const llmDriver = cfg.provider === "cli" ? cfg.cliDriver : null;
+
+  let interactionId: string | null = null;
+  try {
+    interactionId = await createInteraction({
+      requestId,
+      endpoint: "modify",
+      prompt: prompt.trim(),
+      llmProvider,
+      llmDriver: llmDriver ?? null,
+    });
+  } catch (e) {
+    console.error(`[${requestId}] createInteraction(modify) failed:`, e);
+  }
+
   // --- Call LLM to modify the dashboard -------------------------------------
   let rawResponse: string;
   try {
@@ -110,6 +133,12 @@ export async function POST(request: Request) {
       { requestId, endpoint: "modifyDashboard" },
     );
   } catch (err: unknown) {
+    if (interactionId) {
+      const errText = err instanceof Error ? err.message : "Error al modificar";
+      void finishInteraction(interactionId, "error", errText).catch((e) =>
+        console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
+      );
+    }
     if (err instanceof AgenticRunnerError) {
       return NextResponse.json(
         formatApiError(
@@ -164,6 +193,11 @@ export async function POST(request: Request) {
     console.error(
       `[${requestId}] El LLM devolvió JSON inválido al modificar (${jsonStr.length} chars)`,
     );
+    if (interactionId) {
+      void finishInteraction(interactionId, "error", "JSON inválido en respuesta del modelo").catch(
+        (e) => console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
+      );
+    }
     return NextResponse.json(
       formatApiError(
         "El modelo de IA devolvió una respuesta con formato incorrecto.",
@@ -180,6 +214,11 @@ export async function POST(request: Request) {
     updatedSpec = validateSpec(parsed);
   } catch {
     console.error(`[${requestId}] El LLM devolvió un spec inválido al modificar.`);
+    if (interactionId) {
+      void finishInteraction(interactionId, "error", "Spec inválido").catch((e) =>
+        console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
+      );
+    }
     return NextResponse.json(
       formatApiError(
         "El modelo de IA generó un dashboard con estructura incorrecta.",
@@ -197,6 +236,11 @@ export async function POST(request: Request) {
       `[${requestId}] SQL heurístico rechazó el spec modificado por el LLM:`,
       sqlLint.join(" | "),
     );
+    if (interactionId) {
+      void finishInteraction(interactionId, "error", `SQL lint: ${sqlLint.join(" | ")}`).catch(
+        (e) => console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
+      );
+    }
     return NextResponse.json(
       {
         ...formatApiError(
@@ -207,6 +251,12 @@ export async function POST(request: Request) {
         ),
       },
       { status: 400 },
+    );
+  }
+
+  if (interactionId) {
+    void finishInteraction(interactionId, "completed", JSON.stringify(updatedSpec)).catch((e) =>
+      console.error(`[${requestId}] finishInteraction(modify,completed) failed:`, e),
     );
   }
 

--- a/dashboard/app/api/dashboards/route.ts
+++ b/dashboard/app/api/dashboards/route.ts
@@ -49,6 +49,12 @@ interface CreateBody {
   name?: string;
   description?: string;
   spec?: unknown;
+  /**
+   * Optional: request_id from the generate interaction.
+   * When provided, the backend will link the interaction to this dashboard by
+   * setting `llm_interactions.dashboard_id = <new dashboard id>`.
+   */
+  generateRequestId?: string;
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -76,7 +82,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const { name, description, spec } = body;
+  const { name, description, spec, generateRequestId: genReqId } = body;
 
   // Validate name
   if (!name || typeof name !== "string" || !name.trim()) {
@@ -156,7 +162,23 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
        RETURNING id, name, description, spec, created_at, updated_at`,
       [name.trim(), description?.trim() || null, JSON.stringify(validatedSpec)],
     );
-    return NextResponse.json(rows[0], { status: 201 });
+    const newDashboard = rows[0];
+
+    // If a generate request_id was provided, link the interaction to this dashboard.
+    if (newDashboard && genReqId && typeof genReqId === "string" && genReqId.trim()) {
+      void sql(
+        `UPDATE llm_interactions
+            SET dashboard_id = $1
+          WHERE request_id = $2
+            AND endpoint = 'generate'
+            AND dashboard_id IS NULL`,
+        [newDashboard.id, genReqId.trim()],
+      ).catch((e) => {
+        console.error(`[${requestId}] Failed to link interaction to dashboard:`, e);
+      });
+    }
+
+    return NextResponse.json(newDashboard, { status: 201 });
   } catch (err) {
     console.error(`[${requestId}] Error al crear dashboard:`, err);
     return NextResponse.json(

--- a/dashboard/app/api/dashboards/route.ts
+++ b/dashboard/app/api/dashboards/route.ts
@@ -166,7 +166,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     // If a generate request_id was provided, link the interaction to this dashboard.
     if (newDashboard && genReqId && typeof genReqId === "string" && genReqId.trim()) {
-      void sql(
+      await sql(
         `UPDATE llm_interactions
             SET dashboard_id = $1
           WHERE request_id = $2

--- a/dashboard/app/dashboard/new/page.tsx
+++ b/dashboard/app/dashboard/new/page.tsx
@@ -130,11 +130,17 @@ export default function NewDashboard() {
     name: string,
     description: string | null,
     spec: DashboardSpec,
+    genReqId?: string | null,
   ) => {
     const saveRes = await fetch("/api/dashboards", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name, description, spec }),
+      body: JSON.stringify({
+        name,
+        description,
+        spec,
+        ...(genReqId ? { generateRequestId: genReqId } : {}),
+      }),
     });
 
     if (!saveRes.ok) {
@@ -165,9 +171,11 @@ export default function NewDashboard() {
     setAgenticPhase("running");
     setAgenticErrorSummary(null);
 
+    let capturedRequestId: string | null = null;
     try {
       const spec = await runDashboardGenerateStream(trimmed, {
         onMeta: (rid, lines) => {
+          capturedRequestId = rid;
           setAgenticRequestId(rid);
           setAgenticLines((prev) => [...prev, ...lines]);
         },
@@ -178,7 +186,7 @@ export default function NewDashboard() {
 
       const name = spec.title || "Dashboard sin título";
       dismissAgenticDialog();
-      await saveAndRedirect(name, spec.description || null, spec);
+      await saveAndRedirect(name, spec.description || null, spec, capturedRequestId);
     } catch (err) {
       setAgenticPhase("error");
       if (isApiErrorResponse(err)) {

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -60,6 +60,12 @@ function Sidebar() {
             Uso LLM
           </Link>
           <Link
+            href="/admin/interactions"
+            className="flex items-center rounded-md py-2 pl-6 pr-3 text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
+          >
+            Interacciones LLM
+          </Link>
+          <Link
             href="/dashboard/new"
             className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
           >
@@ -120,6 +126,12 @@ function Sidebar() {
             className="text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
           >
             Admin · Uso
+          </Link>
+          <Link
+            href="/admin/interactions"
+            className="text-sm font-medium text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis hover:text-tremor-content-strong dark:hover:text-dark-tremor-content-strong"
+          >
+            Admin · Interacciones
           </Link>
           <Link
             href="/dashboard/new"

--- a/dashboard/components/ChatSidebar.tsx
+++ b/dashboard/components/ChatSidebar.tsx
@@ -9,6 +9,7 @@ import { isApiErrorResponse } from "@/lib/errors";
 import type { ApiErrorResponse } from "@/lib/errors";
 import type { WidgetState } from "@/components/DashboardRenderer";
 import type { InteractionLine } from "@/lib/db-write";
+import { interactionLineClass } from "@/lib/interaction-line-class";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -295,27 +296,6 @@ function MessageBubble({ msg, isMarkdown = false }: { msg: ChatMessage; isMarkdo
 }
 
 // ---------------------------------------------------------------------------
-// Line kind → CSS class (mirrors DashboardGenerateProgressDialog)
-// ---------------------------------------------------------------------------
-
-function logLineClass(kind: InteractionLine["kind"]): string {
-  switch (kind) {
-    case "tool_call":
-      return "font-mono text-blue-400 dark:text-blue-300";
-    case "tool_result":
-      return "font-mono text-emerald-500 dark:text-emerald-400";
-    case "error":
-      return "font-mono text-red-400 dark:text-red-300";
-    case "assistant_text":
-      return "text-tremor-content dark:text-dark-tremor-content";
-    case "phase":
-    case "meta":
-    default:
-      return "italic text-tremor-content-subtle dark:text-dark-tremor-content-subtle";
-  }
-}
-
-// ---------------------------------------------------------------------------
 // CreationLogPanel — collapsible "Log inicial" for the Modificar tab
 // ---------------------------------------------------------------------------
 
@@ -350,7 +330,7 @@ function CreationLogPanel({ lines }: { lines: InteractionLine[] }) {
           {lines.map((l, i) => (
             <div
               key={i}
-              className={`whitespace-pre-wrap break-words ${logLineClass(l.kind ?? "meta")}`}
+              className={`whitespace-pre-wrap break-words ${interactionLineClass(l.kind)}`}
             >
               {l.text}
             </div>

--- a/dashboard/components/ChatSidebar.tsx
+++ b/dashboard/components/ChatSidebar.tsx
@@ -8,6 +8,7 @@ import type { DashboardSpec } from "@/lib/schema";
 import { isApiErrorResponse } from "@/lib/errors";
 import type { ApiErrorResponse } from "@/lib/errors";
 import type { WidgetState } from "@/components/DashboardRenderer";
+import type { InteractionLine } from "@/lib/db-write";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -294,6 +295,115 @@ function MessageBubble({ msg, isMarkdown = false }: { msg: ChatMessage; isMarkdo
 }
 
 // ---------------------------------------------------------------------------
+// Line kind → CSS class (mirrors DashboardGenerateProgressDialog)
+// ---------------------------------------------------------------------------
+
+function logLineClass(kind: InteractionLine["kind"]): string {
+  switch (kind) {
+    case "tool_call":
+      return "font-mono text-blue-400 dark:text-blue-300";
+    case "tool_result":
+      return "font-mono text-emerald-500 dark:text-emerald-400";
+    case "error":
+      return "font-mono text-red-400 dark:text-red-300";
+    case "assistant_text":
+      return "text-tremor-content dark:text-dark-tremor-content";
+    case "phase":
+    case "meta":
+    default:
+      return "italic text-tremor-content-subtle dark:text-dark-tremor-content-subtle";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CreationLogPanel — collapsible "Log inicial" for the Modificar tab
+// ---------------------------------------------------------------------------
+
+function CreationLogPanel({ lines }: { lines: InteractionLine[] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (lines.length === 0) return null;
+
+  return (
+    <div className="mx-4 mt-3 rounded-lg border border-tremor-border dark:border-dark-tremor-border bg-tremor-background-muted/60 dark:bg-dark-tremor-background-muted/40">
+      <button
+        type="button"
+        onClick={() => setExpanded((p) => !p)}
+        className="flex w-full items-center justify-between px-3 py-2 text-xs font-medium text-tremor-content dark:text-dark-tremor-content hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle rounded-lg"
+        aria-expanded={expanded}
+        data-testid="creation-log-toggle"
+      >
+        <span>Log inicial ({lines.length} líneas)</span>
+        <span
+          style={{ transform: expanded ? "rotate(90deg)" : "rotate(0deg)" }}
+          className="inline-block transition-transform text-xs"
+          aria-hidden="true"
+        >
+          &#9656;
+        </span>
+      </button>
+      {expanded && (
+        <div
+          className="max-h-48 overflow-y-auto px-3 pb-3 text-xs leading-relaxed space-y-0.5"
+          data-testid="creation-log-content"
+        >
+          {lines.map((l, i) => (
+            <div
+              key={i}
+              className={`whitespace-pre-wrap break-words ${logLineClass(l.kind ?? "meta")}`}
+            >
+              {l.text}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hook: fetch creation interaction lines for a saved dashboard
+// ---------------------------------------------------------------------------
+
+interface InteractionRowSummary {
+  id: string;
+  request_id: string;
+  endpoint: "generate" | "modify" | "analyze";
+  lines: InteractionLine[];
+  status: "running" | "completed" | "error";
+}
+
+function useCreationLogs(dashboardId?: number): InteractionLine[] {
+  const [lines, setLines] = useState<InteractionLine[]>([]);
+
+  useEffect(() => {
+    if (!dashboardId) return;
+    let cancelled = false;
+    fetch(`/api/dashboard/${dashboardId}/interactions`)
+      .then(async (res) => {
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as { interactions: InteractionRowSummary[] };
+        if (cancelled) return;
+        // Find the most recent completed generate interaction
+        const createInteraction = data.interactions.find(
+          (r) => r.endpoint === "generate" && r.status === "completed",
+        );
+        if (createInteraction) {
+          setLines(Array.isArray(createInteraction.lines) ? createInteraction.lines : []);
+        }
+      })
+      .catch(() => {
+        // Non-critical — silently ignore if the table doesn't exist yet
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [dashboardId]);
+
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
 // ModificarTab — exact current behavior, zero changes
 // ---------------------------------------------------------------------------
 
@@ -305,6 +415,7 @@ function ModificarTab({
   isActive,
   prefillRequest,
   onPrefillApplied,
+  creationLogs,
 }: {
   spec: DashboardSpec;
   onSpecUpdate: (newSpec: DashboardSpec, prompt: string) => void;
@@ -313,6 +424,7 @@ function ModificarTab({
   isActive: boolean;
   prefillRequest?: { text: string; id: number } | null;
   onPrefillApplied?: () => void;
+  creationLogs?: InteractionLine[];
 }) {
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
@@ -458,6 +570,11 @@ function ModificarTab({
 
   return (
     <>
+      {/* Creation log (collapsible, shown when available) */}
+      {creationLogs && creationLogs.length > 0 && (
+        <CreationLogPanel lines={creationLogs} />
+      )}
+
       {/* Messages */}
       <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
         {messages.length === 0 && (
@@ -806,6 +923,9 @@ export default function ChatSidebar({
     initialAnalyzeMessages ?? []
   );
 
+  // Fetch the creation interaction log to show as "Log inicial" in the Modificar tab
+  const creationLogs = useCreationLogs(dashboardId);
+
   // Sync initialAnalyzeMessages on first mount only
   const initializedRef = useRef(false);
   useEffect(() => {
@@ -914,6 +1034,7 @@ export default function ChatSidebar({
                 : null
             }
             onPrefillApplied={onPendingModifyInputConsumed}
+            creationLogs={creationLogs}
           />
         ) : (
           <AnalizarTab

--- a/dashboard/components/ChatSidebar.tsx
+++ b/dashboard/components/ChatSidebar.tsx
@@ -396,6 +396,7 @@ function ModificarTab({
   prefillRequest,
   onPrefillApplied,
   creationLogs,
+  dashboardId,
 }: {
   spec: DashboardSpec;
   onSpecUpdate: (newSpec: DashboardSpec, prompt: string) => void;
@@ -405,6 +406,7 @@ function ModificarTab({
   prefillRequest?: { text: string; id: number } | null;
   onPrefillApplied?: () => void;
   creationLogs?: InteractionLine[];
+  dashboardId?: number;
 }) {
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
@@ -456,7 +458,11 @@ function ModificarTab({
       const res = await fetch("/api/dashboard/modify", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ spec, prompt: trimmed }),
+        body: JSON.stringify({
+          spec,
+          prompt: trimmed,
+          ...(dashboardId !== undefined ? { dashboardId } : {}),
+        }),
       });
 
       if (!res.ok) {
@@ -539,7 +545,7 @@ function ModificarTab({
     } finally {
       setLoading(false);
     }
-  }, [input, loading, spec, onSpecUpdate, setMessages]);
+  }, [input, loading, spec, onSpecUpdate, setMessages, dashboardId]);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -1015,6 +1021,7 @@ export default function ChatSidebar({
             }
             onPrefillApplied={onPendingModifyInputConsumed}
             creationLogs={creationLogs}
+            dashboardId={dashboardId}
           />
         ) : (
           <AnalizarTab

--- a/dashboard/components/DashboardGenerateProgressDialog.tsx
+++ b/dashboard/components/DashboardGenerateProgressDialog.tsx
@@ -3,6 +3,7 @@
 import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from "@headlessui/react";
 import { useEffect, useRef, type ReactNode } from "react";
 import type { InteractionLine } from "@/lib/db-write";
+import { interactionLineClass } from "@/lib/interaction-line-class";
 
 // ─── Line rendering ─────────────────────────────────────────────────────────
 
@@ -22,23 +23,6 @@ function inferKind(text: string): InteractionLine["kind"] {
     return "error";
   }
   return "meta";
-}
-
-function kindClassName(kind: InteractionLine["kind"]): string {
-  switch (kind) {
-    case "tool_call":
-      return "font-mono text-blue-400 dark:text-blue-300";
-    case "tool_result":
-      return "font-mono text-emerald-500 dark:text-emerald-400";
-    case "error":
-      return "font-mono text-red-400 dark:text-red-300";
-    case "assistant_text":
-      return "text-tremor-content dark:text-dark-tremor-content";
-    case "phase":
-    case "meta":
-    default:
-      return "italic text-tremor-content-subtle dark:text-dark-tremor-content-subtle";
-  }
 }
 
 // ─── Component types ─────────────────────────────────────────────────────────
@@ -148,7 +132,7 @@ export function DashboardGenerateProgressDialog({
               normalised.map((line, i) => (
                 <div
                   key={`${i}-${line.text.slice(0, 24)}`}
-                  className={`whitespace-pre-wrap break-words ${kindClassName(line.kind ?? "meta")}`}
+                  className={`whitespace-pre-wrap break-words ${interactionLineClass(line.kind)}`}
                 >
                   {line.text}
                 </div>

--- a/dashboard/components/DashboardGenerateProgressDialog.tsx
+++ b/dashboard/components/DashboardGenerateProgressDialog.tsx
@@ -14,10 +14,11 @@ function inferKind(text: string): InteractionLine["kind"] {
   if (t.startsWith("  →") || t.startsWith("→") || t.includes("Herramientas solicitadas")) {
     return "tool_call";
   }
-  if (t.startsWith("  ✓") || t.startsWith("  ✗") || t.startsWith("✓") || t.startsWith("✗")) {
+  // ✓ = success tool result; ✗ = failed tool result → render as error
+  if (t.startsWith("  ✓") || t.startsWith("✓")) {
     return "tool_result";
   }
-  if (t.toLowerCase().startsWith("error")) {
+  if (t.startsWith("  ✗") || t.startsWith("✗") || t.toLowerCase().startsWith("error")) {
     return "error";
   }
   return "meta";

--- a/dashboard/components/DashboardGenerateProgressDialog.tsx
+++ b/dashboard/components/DashboardGenerateProgressDialog.tsx
@@ -1,17 +1,65 @@
 "use client";
 
 import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from "@headlessui/react";
-import type { ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
+import type { InteractionLine } from "@/lib/db-write";
+
+// ─── Line rendering ─────────────────────────────────────────────────────────
+
+/**
+ * Infer a line `kind` from its raw text when no explicit kind is provided.
+ */
+function inferKind(text: string): InteractionLine["kind"] {
+  const t = text.trim();
+  if (t.startsWith("  →") || t.startsWith("→") || t.includes("Herramientas solicitadas")) {
+    return "tool_call";
+  }
+  if (t.startsWith("  ✓") || t.startsWith("  ✗") || t.startsWith("✓") || t.startsWith("✗")) {
+    return "tool_result";
+  }
+  if (t.toLowerCase().startsWith("error")) {
+    return "error";
+  }
+  return "meta";
+}
+
+function kindClassName(kind: InteractionLine["kind"]): string {
+  switch (kind) {
+    case "tool_call":
+      return "font-mono text-blue-400 dark:text-blue-300";
+    case "tool_result":
+      return "font-mono text-emerald-500 dark:text-emerald-400";
+    case "error":
+      return "font-mono text-red-400 dark:text-red-300";
+    case "assistant_text":
+      return "text-tremor-content dark:text-dark-tremor-content";
+    case "phase":
+    case "meta":
+    default:
+      return "italic text-tremor-content-subtle dark:text-dark-tremor-content-subtle";
+  }
+}
+
+// ─── Component types ─────────────────────────────────────────────────────────
+
+/** A typed line with optional kind + text. Accepts plain string or typed object. */
+export interface ProgressLine {
+  kind?: InteractionLine["kind"];
+  text: string;
+}
 
 export interface DashboardGenerateProgressDialogProps {
   open: boolean;
   title: string;
   requestId: string | null;
-  lines: string[];
+  /** Accept either raw string lines (legacy) or typed ProgressLine objects. */
+  lines: string[] | ProgressLine[];
   phase: "running" | "error" | "success";
   errorSummary?: ReactNode | null;
   onDismiss: () => void;
 }
+
+// ─── Component ───────────────────────────────────────────────────────────────
 
 export function DashboardGenerateProgressDialog({
   open,
@@ -22,6 +70,36 @@ export function DashboardGenerateProgressDialog({
   errorSummary = null,
   onDismiss,
 }: DashboardGenerateProgressDialogProps) {
+  const logRef = useRef<HTMLDivElement>(null);
+  const userScrolledRef = useRef(false);
+
+  // Auto-scroll to bottom on each new line, unless user has scrolled up manually.
+  useEffect(() => {
+    const el = logRef.current;
+    if (!el) return;
+    if (userScrolledRef.current) return;
+    el.scrollTop = el.scrollHeight;
+  }, [lines.length]);
+
+  // Reset userScrolled when dialog opens.
+  useEffect(() => {
+    if (open) {
+      userScrolledRef.current = false;
+    }
+  }, [open]);
+
+  const handleScroll = () => {
+    const el = logRef.current;
+    if (!el) return;
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 8;
+    userScrolledRef.current = !atBottom;
+  };
+
+  // Normalise lines so we always have ProgressLine[]
+  const normalised: ProgressLine[] = (lines as (string | ProgressLine)[]).map((l) =>
+    typeof l === "string" ? { kind: inferKind(l), text: l } : l,
+  );
+
   return (
     <Dialog
       open={open}
@@ -34,57 +112,74 @@ export function DashboardGenerateProgressDialog({
     >
       <DialogBackdrop className="fixed inset-0 bg-black/40 backdrop-blur-[1px]" />
       <div className="fixed inset-0 flex items-center justify-center p-4">
-        <DialogPanel className="w-full max-w-lg rounded-xl border border-tremor-border bg-tremor-background p-5 shadow-xl dark:border-dark-tremor-border dark:bg-dark-tremor-background">
-          <DialogTitle className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-            {title}
-          </DialogTitle>
-          {requestId ? (
-            <p className="mt-1 font-mono text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
-              ID: {requestId}
-            </p>
-          ) : null}
+        <DialogPanel
+          className="flex flex-col rounded-xl border border-tremor-border bg-tremor-background shadow-xl dark:border-dark-tremor-border dark:bg-dark-tremor-background"
+          style={{ width: "min(64rem, 95vw)", height: "min(42rem, 85vh)" }}
+        >
+          {/* Header */}
+          <div className="flex-none px-5 pt-5 pb-2">
+            <DialogTitle className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+              {title}
+            </DialogTitle>
+            {requestId ? (
+              <p className="mt-1 font-mono text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                ID: {requestId}
+              </p>
+            ) : null}
+          </div>
 
+          {/* Log panel — fills remaining space, scrolls independently */}
           <div
-            className="mt-4 max-h-72 overflow-y-auto rounded-lg border border-tremor-border bg-tremor-background-muted/80 p-3 font-mono text-xs leading-relaxed text-tremor-content dark:border-dark-tremor-border dark:bg-dark-tremor-background-muted/50 dark:text-dark-tremor-content"
+            ref={logRef}
+            onScroll={handleScroll}
+            className="flex-1 min-h-0 overflow-y-auto mx-5 rounded-lg border border-tremor-border bg-tremor-background-muted/80 p-3 text-xs leading-relaxed dark:border-dark-tremor-border dark:bg-dark-tremor-background-muted/50"
+            style={{ scrollBehavior: "smooth" }}
             role="log"
             aria-live="polite"
             aria-relevant="additions"
+            data-testid="progress-log"
           >
-            {lines.length === 0 ? (
-              <span className="text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+            {normalised.length === 0 ? (
+              <span className="italic text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
                 Iniciando…
               </span>
             ) : (
-              lines.map((line, i) => (
-                <div key={`${i}-${line.slice(0, 24)}`} className="whitespace-pre-wrap break-words">
-                  {line}
+              normalised.map((line, i) => (
+                <div
+                  key={`${i}-${line.text.slice(0, 24)}`}
+                  className={`whitespace-pre-wrap break-words ${kindClassName(line.kind ?? "meta")}`}
+                >
+                  {line.text}
                 </div>
               ))
             )}
           </div>
 
-          {phase === "error" && errorSummary ? (
-            <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900 dark:border-red-900/40 dark:bg-red-950/40 dark:text-red-100">
-              {errorSummary}
-            </div>
-          ) : null}
+          {/* Footer */}
+          <div className="flex-none px-5 pb-5 pt-3">
+            {phase === "error" && errorSummary ? (
+              <div className="mb-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900 dark:border-red-900/40 dark:bg-red-950/40 dark:text-red-100">
+                {errorSummary}
+              </div>
+            ) : null}
 
-          {phase !== "running" ? (
-            <div className="mt-4 flex justify-end">
-              <button
-                type="button"
-                onClick={onDismiss}
-                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
-              >
-                Cerrar
-              </button>
-            </div>
-          ) : (
-            <p className="mt-3 text-center text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
-              Generando… puedes seguir el progreso arriba. Los mismos pasos se registran en el log
-              del servidor.
-            </p>
-          )}
+            {phase !== "running" ? (
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={onDismiss}
+                  className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  Cerrar
+                </button>
+              </div>
+            ) : (
+              <p className="text-center text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
+                Generando… puedes seguir el progreso arriba. Los mismos pasos se registran en el log
+                del servidor.
+              </p>
+            )}
+          </div>
         </DialogPanel>
       </div>
     </Dialog>

--- a/dashboard/lib/db-write.ts
+++ b/dashboard/lib/db-write.ts
@@ -8,6 +8,23 @@
 
 import { Pool, type PoolConfig, type QueryResultRow } from "pg";
 
+// ─── llm_interactions types ─────────────────────────────────────────────────
+
+/**
+ * A structured progress line stored in `llm_interactions.lines`.
+ * Uses `kind` so callers can format them by type in the UI.
+ */
+export interface InteractionLine {
+  /** Logical line type for UI formatting. */
+  kind: "meta" | "tool_call" | "tool_result" | "assistant_text" | "error" | "phase";
+  /** Human-readable text (Spanish). */
+  text: string;
+  /** ISO timestamp when the line was emitted. */
+  ts: string;
+}
+
+export type InteractionEndpoint = "generate" | "modify" | "analyze";
+
 // ─── Pool configuration ─────────────────────────────────────────────────────
 
 const STATEMENT_TIMEOUT_MS = 30_000;
@@ -65,4 +82,74 @@ export async function sql<T extends QueryResultRow = QueryResultRow>(
   const pool = getPool();
   const result = await pool.query<T>(text, params);
   return result.rows;
+}
+
+// ─── llm_interactions helpers ────────────────────────────────────────────────
+
+/**
+ * Insert a new `llm_interactions` row with status='running' and return its UUID.
+ *
+ * Fire-and-forget safe: callers should not await this in the hot path if they
+ * want to avoid blocking the stream; however the returned promise can be awaited
+ * to get the row id for subsequent updates.
+ */
+export async function createInteraction(opts: {
+  requestId: string;
+  endpoint: InteractionEndpoint;
+  dashboardId?: number | null;
+  prompt: string;
+  llmProvider?: string | null;
+  llmDriver?: string | null;
+}): Promise<string> {
+  const rows = await sql<{ id: string }>(
+    `INSERT INTO llm_interactions
+       (request_id, endpoint, dashboard_id, prompt, llm_provider, llm_driver, started_at, status)
+     VALUES ($1, $2, $3, $4, $5, $6, NOW(), 'running')
+     RETURNING id`,
+    [
+      opts.requestId,
+      opts.endpoint,
+      opts.dashboardId ?? null,
+      opts.prompt,
+      opts.llmProvider ?? null,
+      opts.llmDriver ?? null,
+    ],
+  );
+  if (!rows[0]) throw new Error("createInteraction: no row returned");
+  return rows[0].id;
+}
+
+/**
+ * Append a batch of lines to `llm_interactions.lines` (JSONB concatenation).
+ * Non-blocking in production — errors are logged but not re-thrown.
+ */
+export async function appendInteractionLines(
+  id: string,
+  lines: InteractionLine[],
+): Promise<void> {
+  if (lines.length === 0) return;
+  await sql(
+    `UPDATE llm_interactions
+        SET lines = lines || $2::jsonb
+      WHERE id = $1`,
+    [id, JSON.stringify(lines)],
+  );
+}
+
+/**
+ * Mark an interaction as completed or error.
+ */
+export async function finishInteraction(
+  id: string,
+  status: "completed" | "error",
+  finalOutput?: string | null,
+): Promise<void> {
+  await sql(
+    `UPDATE llm_interactions
+        SET status = $2,
+            finished_at = NOW(),
+            final_output = $3
+      WHERE id = $1`,
+    [id, status, finalOutput ?? null],
+  );
 }

--- a/dashboard/lib/db-write.ts
+++ b/dashboard/lib/db-write.ts
@@ -139,6 +139,10 @@ export async function appendInteractionLines(
 
 /**
  * Mark an interaction as completed or error.
+ *
+ * Throws on DB errors — callers should `.catch()` and log if they want
+ * best-effort behavior (success-path callers should `await` this before
+ * returning the HTTP response so status never stays 'running').
  */
 export async function finishInteraction(
   id: string,

--- a/dashboard/lib/db-write.ts
+++ b/dashboard/lib/db-write.ts
@@ -121,8 +121,8 @@ export async function createInteraction(opts: {
 
 /**
  * Append a batch of lines to `llm_interactions.lines` (JSONB concatenation).
- * Throws on DB errors — callers should catch and log if they want best-effort
- * behavior (the generate route wraps this in try/catch).
+ * Throws on DB errors — callers should wrap in try/catch if they want
+ * best-effort behavior (the generate route does this already).
  */
 export async function appendInteractionLines(
   id: string,

--- a/dashboard/lib/db-write.ts
+++ b/dashboard/lib/db-write.ts
@@ -121,7 +121,8 @@ export async function createInteraction(opts: {
 
 /**
  * Append a batch of lines to `llm_interactions.lines` (JSONB concatenation).
- * Non-blocking in production — errors are logged but not re-thrown.
+ * Throws on DB errors — callers should catch and log if they want best-effort
+ * behavior (the generate route wraps this in try/catch).
  */
 export async function appendInteractionLines(
   id: string,

--- a/dashboard/lib/interaction-line-class.ts
+++ b/dashboard/lib/interaction-line-class.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared CSS class helper for rendering InteractionLine entries consistently
+ * across DashboardGenerateProgressDialog, ChatSidebar, and admin detail pages.
+ */
+import type { InteractionLine } from "@/lib/db-write";
+
+export function interactionLineClass(kind: InteractionLine["kind"] | undefined): string {
+  switch (kind) {
+    case "tool_call":
+      return "font-mono text-blue-400 dark:text-blue-300";
+    case "tool_result":
+      return "font-mono text-emerald-500 dark:text-emerald-400";
+    case "error":
+      return "font-mono text-red-400 dark:text-red-300";
+    case "assistant_text":
+      return "text-tremor-content dark:text-dark-tremor-content";
+    case "phase":
+    case "meta":
+    default:
+      return "italic text-tremor-content-subtle dark:text-dark-tremor-content-subtle";
+  }
+}

--- a/etl/schema/init.sql
+++ b/etl/schema/init.sql
@@ -6,6 +6,11 @@ EXCEPTION WHEN OTHERS THEN
 END
 $$;
 
+-- pgcrypto provides gen_random_uuid() used by llm_interactions.id.
+-- PostgreSQL 13+ ships this in core (pgcrypto is a no-op), but older
+-- installations need it explicitly.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 -- PostgreSQL DDL for the PowerShop Analytics mirror schema.
 -- All tables use the ps_ prefix.
 -- Run once to create tables; safe to re-run (IF NOT EXISTS).
@@ -645,6 +650,21 @@ CREATE TABLE IF NOT EXISTS llm_interactions (
 CREATE INDEX IF NOT EXISTS idx_llm_interactions_dashboard ON llm_interactions(dashboard_id);
 CREATE INDEX IF NOT EXISTS idx_llm_interactions_request   ON llm_interactions(request_id);
 CREATE INDEX IF NOT EXISTS idx_llm_interactions_started   ON llm_interactions(started_at DESC);
+-- Support common admin filter patterns without sequential scans
+CREATE INDEX IF NOT EXISTS idx_llm_interactions_endpoint_started
+    ON llm_interactions(endpoint, started_at DESC);
+-- request_id must be unique: the admin detail page and client fetch use it as a stable key
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'llm_interactions'::regclass AND contype = 'u'
+      AND conname = 'llm_interactions_request_id_key'
+  ) THEN
+    ALTER TABLE llm_interactions ADD CONSTRAINT llm_interactions_request_id_key UNIQUE (request_id);
+  END IF;
+END
+$$;
 
 -- ============================================================
 -- Unique constraints required by wholesale FK targets

--- a/etl/schema/init.sql
+++ b/etl/schema/init.sql
@@ -7,9 +7,16 @@ END
 $$;
 
 -- pgcrypto provides gen_random_uuid() used by llm_interactions.id.
--- PostgreSQL 13+ ships this in core (pgcrypto is a no-op), but older
--- installations need it explicitly.
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
+-- Wrapped in a DO/EXCEPTION block so that installations where the role
+-- lacks CREATE EXTENSION privilege (or the extension is unavailable)
+-- fall back gracefully with a notice rather than aborting init.sql.
+DO $$
+BEGIN
+  CREATE EXTENSION IF NOT EXISTS pgcrypto;
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'pgcrypto not available — gen_random_uuid() may require PostgreSQL 13+ core support';
+END
+$$;
 
 -- PostgreSQL DDL for the PowerShop Analytics mirror schema.
 -- All tables use the ps_ prefix.

--- a/etl/schema/init.sql
+++ b/etl/schema/init.sql
@@ -635,9 +635,9 @@ ALTER TABLE llm_tool_calls ADD COLUMN IF NOT EXISTS llm_driver TEXT;
 -- LLM interaction history (Dashboard App — full run audit trail)
 -- ============================================================
 
--- One row per generate/modify/analyze call.  Lines are the NDJSON progress
--- events exactly as streamed to the client (stored as JSONB array so they can
--- be replayed in the admin UI without string parsing).
+-- One row per generate/modify/analyze call.  The `lines` column stores
+-- InteractionLine objects (kind, text, optional ts) as a JSONB array so they
+-- can be replayed in the admin UI without string parsing.
 CREATE TABLE IF NOT EXISTS llm_interactions (
     id           UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
     request_id   TEXT         NOT NULL,
@@ -655,7 +655,8 @@ CREATE TABLE IF NOT EXISTS llm_interactions (
 );
 
 CREATE INDEX IF NOT EXISTS idx_llm_interactions_dashboard ON llm_interactions(dashboard_id);
-CREATE INDEX IF NOT EXISTS idx_llm_interactions_request   ON llm_interactions(request_id);
+-- idx_llm_interactions_request intentionally omitted: the UNIQUE (request_id)
+-- constraint added below creates an equivalent unique index automatically.
 CREATE INDEX IF NOT EXISTS idx_llm_interactions_started   ON llm_interactions(started_at DESC);
 -- Support common admin filter patterns without sequential scans
 CREATE INDEX IF NOT EXISTS idx_llm_interactions_endpoint_started

--- a/etl/schema/init.sql
+++ b/etl/schema/init.sql
@@ -620,6 +620,33 @@ ALTER TABLE llm_tool_calls ADD COLUMN IF NOT EXISTS llm_provider TEXT NOT NULL D
 ALTER TABLE llm_tool_calls ADD COLUMN IF NOT EXISTS llm_driver TEXT;
 
 -- ============================================================
+-- LLM interaction history (Dashboard App — full run audit trail)
+-- ============================================================
+
+-- One row per generate/modify/analyze call.  Lines are the NDJSON progress
+-- events exactly as streamed to the client (stored as JSONB array so they can
+-- be replayed in the admin UI without string parsing).
+CREATE TABLE IF NOT EXISTS llm_interactions (
+    id           UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    request_id   TEXT         NOT NULL,
+    endpoint     TEXT         NOT NULL CHECK (endpoint IN ('generate','modify','analyze')),
+    dashboard_id INTEGER      REFERENCES dashboards(id) ON DELETE SET NULL,
+    prompt       TEXT         NOT NULL,
+    final_output TEXT,
+    lines        JSONB        NOT NULL DEFAULT '[]'::jsonb,
+    llm_provider TEXT,
+    llm_driver   TEXT,
+    started_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    finished_at  TIMESTAMPTZ,
+    status       TEXT         NOT NULL DEFAULT 'running'
+                              CHECK (status IN ('running','completed','error'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_interactions_dashboard ON llm_interactions(dashboard_id);
+CREATE INDEX IF NOT EXISTS idx_llm_interactions_request   ON llm_interactions(request_id);
+CREATE INDEX IF NOT EXISTS idx_llm_interactions_started   ON llm_interactions(started_at DESC);
+
+-- ============================================================
 -- Unique constraints required by wholesale FK targets
 -- (n_albaran and n_factura are not PKs but are used as FK targets)
 -- ============================================================


### PR DESCRIPTION
Closes #400. Depends on #403 (admin-redesign).

## Summary
- **Progress dialog enlarged and stabilised**: `min(64rem, 95vw) × min(42rem, 85vh)`, flex layout with auto-scroll to bottom on each new line (pauses when user scrolls up, resumes on dialog reopen). Lines colour-coded by kind: `tool_call`=blue, `tool_result`=green, `error`=red, `meta`/`phase`=italic muted.
- **New `llm_interactions` table**: persists all generate/modify/analyze runs with `lines JSONB`, `request_id`, `endpoint`, `dashboard_id FK`, `llm_provider/driver`, `started_at/finished_at`, `status`. Added to `etl/schema/init.sql`.
- **Backend persistence**: generate (streaming + non-streaming), modify, and analyze routes now create a row on start, accumulate typed progress lines in streaming path, and mark completed/error on finish.
- **Chat sidebar `Log inicial`**: when opening a saved dashboard, `useCreationLogs()` fetches the most recent completed generate interaction and shows its lines as a collapsible panel at the top of the Modificar tab.
- **Admin pages**: `/admin/interactions` (filterable list, last 50) + `/admin/interactions/[request_id]` (detail with typed lines, metadata, prompt, final output). Protected GET `/api/admin/interactions` (admin-key). Added to sidebar nav.

## Test plan
- [x] `vitest run` — 1151/1151 pass
- [x] `next build` — compiles without errors
- [x] `next lint` — no warnings or errors
- [ ] Manual: generate a dashboard → dialog shows formatted lines, auto-scrolls → close → reopen dashboard → "Log inicial" visible in Modificar tab
- [ ] Manual: open `/admin/interactions` → interactions visible; click request_id → detail shows typed log
- [ ] Manual: filter by endpoint=generate → only generate rows shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)