### PR TITLE
docs: cap PR reviews at one Copilot + one Opus (clean context) round

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,10 +365,16 @@ All GitHub issues in this project follow a single standard format. When creating
   - **Acceptance**: `docker compose run --rm etl python -m pytest && python -m ruff check etl/ && python -m mypy etl/`
   - **Spec update**: mark done
 
-- [ ] N-1b) Review cycle (owner: agent)
-  - **Change**: Request Copilot review, address all feedback, re-request until no new feedback
-  - **How**: `gh pr create` then request Copilot review via REST API: `gh api repos/{owner}/{repo}/pulls/{PR#}/requested_reviewers --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'`. Poll for review: `gh api repos/{owner}/{repo}/pulls/{PR#}/reviews --jq '[.[] | {state, user: .user.login, body}]'`. Address all comments with inline replies. Re-request after each round.
-  - **Acceptance**: Copilot review shows no unresolved comments
+- [ ] N-1b) Copilot review (owner: agent, **one round only**)
+  - **Change**: Request a Copilot review, address all feedback, then stop. Do **not** re-request Copilot.
+  - **How**: `gh pr create`, then request Copilot review via REST API: `gh api repos/{owner}/{repo}/pulls/{PR#}/requested_reviewers --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'`. Poll for review: `gh api repos/{owner}/{repo}/pulls/{PR#}/reviews --jq '[.[] | {state, user: .user.login, body}]'`. Address all comments with inline replies.
+  - **Acceptance**: Copilot review arrived, every comment has either a code change or a reply explaining why it does not apply. No second Copilot round.
+  - **Spec update**: mark done
+
+- [ ] N-1c) Opus review (owner: agent, **one round only, clean context**)
+  - **Change**: Run a single Opus review of the PR **from a fresh context** (new session, no implementation history), address all feedback, then stop.
+  - **How**: Start a new Claude Code session with no prior conversation about this PR and invoke the PR review flow on this PR number. Reply inline to every comment; apply the fixes that are correct.
+  - **Acceptance**: Opus review completed; every comment has either a code change or a reply. No second Opus round.
   - **Spec update**: mark done
 
 - [ ] N) Create commit (owner: agent)
@@ -395,22 +401,31 @@ git worktree remove ../<repo>-<worktree-name>
 
 ### PR and review policy
 
+Every PR gets **exactly two review rounds, in order, each run only once**:
+
+1. **One Copilot review** (bot).
+2. **One Opus review**, started from a **clean context** (fresh Claude Code session with no prior history about this PR or its implementation).
+
+After each round: address every comment with either a code change or an inline reply, then move on. **Do not re-request the same reviewer.** Iterating "until there are no comments" is no longer the policy — it was too much. If a later round surfaces a genuinely blocking issue, use judgement and escalate to the human owner rather than looping.
+
+Rules:
 - Every piece of work goes through a PR, even solo work.
-- **Always request a Copilot review** on every PR using the REST API:
+- **Round 1 — Copilot.** Request via the REST API:
   ```bash
   gh api repos/{owner}/{repo}/pulls/{PR#}/requested_reviewers \
     --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
   ```
   Do NOT use `gh pr review --request copilot` (doesn't work) or `gh pr edit --add-reviewer copilot` (can't resolve bot users). The REST API with `copilot-pull-request-reviewer[bot]` is the only working CLI method.
-- **From GitHub Actions**, the default `GITHUB_TOKEN` **cannot** assign `copilot-pull-request-reviewer[bot]` — the API returns 200 but with an empty `requested_reviewers` array. Workflows must use a PAT stored in the repo secret `COPILOT_PAT` (fine-grained PAT, scope `Pull requests: Read and write`). Pattern:
-  ```bash
-  GH_TOKEN="$COPILOT_PAT" gh api repos/{owner}/{repo}/pulls/{PR#}/requested_reviewers \
-    --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
-  ```
-  Always verify the response contains `Copilot` in `requested_reviewers` before claiming the review was requested.
-- Poll for the review result: `gh api repos/{owner}/{repo}/pulls/{PR#}/reviews --jq '[.[] | {state, user: .user.login, body}]'`
-- Address all feedback, reply to each comment, then re-request review.
-- Only merge after Copilot has reviewed and there is no unresolved feedback.
+  - **From GitHub Actions**, the default `GITHUB_TOKEN` **cannot** assign `copilot-pull-request-reviewer[bot]` — the API returns 200 but with an empty `requested_reviewers` array. Workflows must use a PAT stored in the repo secret `COPILOT_PAT` (fine-grained PAT, scope `Pull requests: Read and write`). Pattern:
+    ```bash
+    GH_TOKEN="$COPILOT_PAT" gh api repos/{owner}/{repo}/pulls/{PR#}/requested_reviewers \
+      --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
+    ```
+    Always verify the response contains `Copilot` in `requested_reviewers` before claiming the review was requested.
+  - Poll for the review: `gh api repos/{owner}/{repo}/pulls/{PR#}/reviews --jq '[.[] | {state, user: .user.login, body}]'`.
+  - Address every comment with a code change or inline reply. **One round only — do not re-request Copilot.**
+- **Round 2 — Opus, clean context.** Start a new Claude Code session (no prior conversation about this PR or the branch) and run the PR review flow on this PR number. Reply inline to every comment; apply the correct fixes. **One round only — do not re-request Opus.**
+- **Merge** after both rounds are done and every comment has a change or a reply. Unresolved disagreement → flag to the human owner; don't start a third round to paper over it.
 
 ### Phase labels and execution order
 

--- a/DECISIONS-AND-CHANGES.md
+++ b/DECISIONS-AND-CHANGES.md
@@ -4,6 +4,16 @@
 
 ## Decision Log
 
+### D-021: PR review policy capped at two fixed rounds (Copilot → Opus clean-context) — 2026-04-24
+**Context**: The prior policy (AGENTS.md) required re-requesting Copilot "until no new feedback". In practice this produced long loops where late nit-pick rounds blocked merges without meaningfully improving the code. The human owner called it "too much".
+**Decision**: Every PR gets **exactly two review rounds, each run once**:
+1. **Copilot** (bot) — request via the REST API pattern already documented. Address each comment with a code change or inline reply, then stop. No re-request.
+2. **Opus** — run the PR review flow **from a clean Claude Code context** (fresh session, no prior conversation about the PR or branch) so Opus reviews the diff without being anchored to the implementation history. Address each comment with a change or reply, then stop. No re-request.
+Merge after both rounds; if a comment is genuinely blocking and disputed, escalate to the human owner instead of opening a third round.
+**Alternatives rejected**: Keeping the "until no feedback" loop (current pain point). Opus-only or Copilot-only (loses the cross-check). Running Opus in the implementation session (context bias defeats the purpose of a second opinion).
+**Rationale**: Two independent reviewers, each exactly once, bounds the review cost while preserving a cross-check from a different vantage point. The clean-context requirement for Opus is the core of why round 2 is useful — without it, the review is correlated with the implementation.
+**See**: `AGENTS.md` "PR and review policy" and issue-template tasks `N-1b` (Copilot) + `N-1c` (Opus).
+
 ### D-020: Force-resync trigger channel for ETL Monitor — 2026-04-23
 **Context**: Issue #398. After D-017's signed-int16 fix the nightly ETL only rewrites rows with a fresh `Exportaciones.FechaModifica`, so historical negative-stock rows already stored as 65535 persist until origin changes. Also, `etl_sync_runs.total_rows_synced` was hard-coded to zero because `finish_run` was never called with the accumulator.
 **Decision**:
@@ -155,6 +165,9 @@ The button needs to signal the ETL container (a pure Python scheduler with no HT
 ---
 
 ## Changelog
+
+### 2026-04-24
+- PR review policy capped at two fixed rounds — D-021: one Copilot round, then one Opus round from a clean Claude Code context. Old "re-request until no feedback" loop removed. `AGENTS.md` updated (policy section + issue-template tasks `N-1b` Copilot / `N-1c` Opus).
 
 ### 2026-04-23
 - Dashboard LLM: OpenRouter vs Claude Code CLI provider abstraction (issue #394, D-019); `llm_usage` / `llm_tool_calls` provider columns; admin usage aggregates by provider.


### PR DESCRIPTION
Replace the "re-request until no feedback" loop with a fixed two-round
policy: one Copilot review, then one Opus review started from a clean
Claude Code context. Each reviewer runs exactly once; address each
comment with a code change or inline reply, then merge. Escalate
blocking disagreements to the human owner instead of opening a third
round.

Updates AGENTS.md "PR and review policy" and splits the issue-template
task N-1b into N-1b (Copilot) + N-1c (Opus). Logs the change as D-021
in DECISIONS-AND-CHANGES.md.