### PR TITLE
fix(dashboard/templates): general template review (issue #417)

### DIFF
--- a/dashboard/lib/templates/general.ts
+++ b/dashboard/lib/templates/general.ts
@@ -2,9 +2,58 @@
  * Template: Director General
  *
  * Executive overview: retail + wholesale revenue, channel mix, margin,
- * 12-month trend (retail + wholesale), and top product families.
- * All date filters use :curr_from / :curr_to tokens set by the date picker.
- * YoY KPI compares selected period vs same period one year prior.
+ * 12-month rolling trend, top product families, and stock value.
+ *
+ * ## Cross-source discipline (retail + mayorista)
+ *
+ * This is the only template that mixes two source families:
+ *   - Retail: `ps_ventas` / `ps_lineas_ventas` (POS sales, store-scoped, IVA-incluido in `total_si`).
+ *   - Mayorista: `ps_gc_facturas` / `ps_gc_lin_facturas` (B2B invoices, NOT store-scoped,
+ *     net base in `base1+base2+base3`, costs in `ps_gc_lin_facturas.total_coste`).
+ *
+ * Rules every future agent MUST preserve:
+ *   1. NEVER add the two sums into a single "ventas totales" KPI without making the
+ *      double-counting decision explicit. A retail sale of stock that originated from a
+ *      wholesale invoice does NOT cross between tables — `ps_ventas` is recorded at the
+ *      POS and `ps_gc_facturas` at B2B billing. They are independent revenue streams,
+ *      so summing them is safe at the channel level. The mix donut + the 12-month
+ *      trend already do this correctly.
+ *   2. The retail half is filtered by `__gf_tienda__`; the wholesale half is NOT
+ *      (no store column on `ps_gc_facturas`). This is intentional — a global "Tienda"
+ *      pick must scope retail only.
+ *   3. Selected-period boundary: retail uses `v.fecha_creacion`, wholesale uses
+ *      `f.fecha_factura`. Treat them as comparable revenue accruals (both are issuance
+ *      dates of the underlying transaction).
+ *   4. Devoluciones: retail abonos = `v.entrada = false`; wholesale abonos =
+ *      `f.abono = true` (excluded from facturación). The retail "Devoluciones %" KPI
+ *      below uses retail-only data — wholesale credit notes are tracked separately.
+ *
+ * ## YoY definition
+ *
+ * Comparativa YoY uses the **same exact day-count window shifted one year**:
+ *   prev_from = curr_from - INTERVAL '1 year'
+ *   prev_to   = curr_to   - INTERVAL '1 year'
+ *
+ * Side effect: when the current period spans a leap day (Feb 29), the prior period
+ * may include / exclude one extra day. We accept this trade-off because it preserves
+ * the exact day-count and makes the % comparable for any custom range.
+ *
+ * ## Tendencia 12 meses
+ *
+ * The trend chart is **rolling 12 calendar months anchored to `:curr_to`**, not the
+ * selected period. This is intentional: an executive scanning the dashboard wants
+ * the long arc regardless of the picker. The selected period is reflected by the
+ * other widgets (KPIs, mix, top families). Title makes the rolling behavior explicit.
+ *
+ * ## Filters
+ *
+ * `templateGlobalFiltersRetail` is reused so the chrome stays consistent with the
+ * Ventas template. Wholesale widgets do not consume any of these filters (no
+ * `__gf_*__` tokens are referenced in mayorista SQL). A future iteration can add a
+ * dedicated `templateGlobalFiltersGeneral` with a `canal` (retail/mayorista) toggle
+ * — tracked as a follow-up to issue #417.
+ *
+ * All date filters use `:curr_from` / `:curr_to` tokens set by the date picker.
  */
 import type { DashboardSpec } from "@/lib/schema";
 import { templateGlobalFiltersRetail } from "@/lib/template-global-filters";
@@ -24,6 +73,7 @@ export const spec: DashboardSpec = {
       type: "kpi_row",
       items: [
         {
+          // Retail: POS sales with IVA included; tienda 99 = ghost/no-store excluded.
           label: "Ventas Retail Netas (período seleccionado)",
           sql: `SELECT COALESCE(SUM(v."total_si"), 0) AS value
 FROM "public"."ps_ventas" v
@@ -36,6 +86,8 @@ WHERE v."entrada" = true
           prefix: "€",
         },
         {
+          // Mayorista: B2B invoice net (base1+base2+base3 = three IVA bases summed).
+          // Not store-scoped; __gf_tienda__ intentionally absent.
           label: "Facturacion Mayorista (período seleccionado)",
           sql: `SELECT COALESCE(SUM("base1" + "base2" + "base3"), 0) AS value
 FROM "public"."ps_gc_facturas"
@@ -69,6 +121,9 @@ WHERE v."entrada" = true
           format: "percent",
         },
         {
+          // YoY: same day-count window shifted one year (see header note).
+          // ::date casts are required before INTERVAL to avoid PG
+          // 'invalid input syntax for type interval' on parameter substitution.
           label: "Retail YoY %",
           sql: `SELECT ROUND(
   (curr.ventas - prev.ventas) / NULLIF(ABS(prev.ventas), 0) * 100, 1
@@ -94,6 +149,72 @@ FROM (
       ],
     },
     {
+      id: "general-kpis-secondary",
+      type: "kpi_row",
+      items: [
+        {
+          // Mayorista YoY symmetric to retail YoY (same day-count window).
+          label: "Mayorista YoY %",
+          sql: `SELECT ROUND(
+  (curr.facturacion - prev.facturacion) / NULLIF(ABS(prev.facturacion), 0) * 100, 1
+) AS value
+FROM (
+  SELECT COALESCE(SUM("base1" + "base2" + "base3"), 0) AS facturacion
+  FROM "public"."ps_gc_facturas"
+  WHERE "abono" = false
+    AND "fecha_factura" >= :curr_from
+    AND "fecha_factura" <= :curr_to
+) curr,
+(
+  SELECT COALESCE(SUM("base1" + "base2" + "base3"), 0) AS facturacion
+  FROM "public"."ps_gc_facturas"
+  WHERE "abono" = false
+    AND "fecha_factura" >= :curr_from::date - INTERVAL '1 year'
+    AND "fecha_factura" <= :curr_to::date - INTERVAL '1 year'
+) prev`,
+          format: "percent",
+        },
+        {
+          // Mayorista margin via GC invoice lines. Wholesale margin is structurally
+          // lower than retail (no end-customer markup); show separately so the exec
+          // does not blend the two.
+          label: "Margen Global Mayorista",
+          sql: `SELECT ROUND(
+  (SUM(lf."total") - SUM(lf."total_coste"))
+  / NULLIF(SUM(lf."total"), 0) * 100, 1
+) AS value
+FROM "public"."ps_gc_lin_facturas" lf
+JOIN "public"."ps_gc_facturas" f ON lf."num_factura" = f."reg_factura"
+WHERE f."abono" = false
+  AND lf."total" > 0
+  AND f."fecha_factura" >= :curr_from
+  AND f."fecha_factura" <= :curr_to`,
+          format: "percent",
+        },
+        {
+          // Devoluciones retail (entrada=false) as % of bruto retail (entrada=true).
+          // Wholesale credit notes (f.abono=true) are excluded from this metric
+          // because the executive view treats devoluciones as a retail-quality signal.
+          label: "Devoluciones Retail %",
+          sql: `SELECT ROUND(
+  COALESCE(SUM(CASE WHEN v."entrada" = false THEN ABS(v."total_si") ELSE 0 END), 0)
+  / NULLIF(
+      COALESCE(SUM(CASE WHEN v."entrada" = true THEN v."total_si" ELSE 0 END), 0),
+    0) * 100, 1
+) AS value
+FROM "public"."ps_ventas" v
+WHERE v."tienda" <> '99'
+  AND v."fecha_creacion" >= :curr_from
+  AND v."fecha_creacion" <= :curr_to
+  AND __gf_tienda__`,
+          format: "percent",
+        },
+      ],
+    },
+    {
+      // Mix Retail vs Mayorista. Both halves are mutually exclusive revenue streams
+      // (independent tables), so the donut totals to the sum of the two channel KPIs.
+      // Validated 2026-04-26 against `general-kpis` for the same period.
       id: "general-mix-canales",
       type: "donut_chart",
       title: "Mix Retail vs Mayorista (período seleccionado)",
@@ -119,7 +240,7 @@ WHERE "abono" = false
       id: "general-ventas-por-tienda",
       type: "bar_chart",
       title: "Ventas Retail por Tienda (período seleccionado)",
-      sql: `SELECT v."tienda" AS label, SUM(v."total_si") AS value
+      sql: `SELECT v."tienda" AS label, COALESCE(SUM(v."total_si"), 0) AS value
 FROM "public"."ps_ventas" v
 WHERE v."entrada" = true
   AND v."tienda" <> '99'
@@ -132,16 +253,26 @@ ORDER BY value DESC`,
       y: "value",
     },
     {
+      // Tendencia mensual: lower bound = LEAST(:curr_from, :curr_to − 11 months).
+      // This guarantees AT LEAST a rolling 12-month arc when the picker is short
+      // (executive wants the long view) while still respecting longer ranges
+      // (e.g. YTD with 14 months → shows full 14-month range).
+      // Upper bound is :curr_to. Retail and mayorista are independent revenue
+      // streams (different tables, different transactions) so the UNION does NOT
+      // double-count. See header for the cross-source discipline rules.
       id: "general-tendencia-12m",
       type: "line_chart",
-      title: "Tendencia Mensual Retail + Mayorista (período seleccionado)",
-      sql: `SELECT mes, SUM(importe) AS y, mes AS x FROM (
+      title: "Tendencia Mensual Retail + Mayorista (mín. 12 meses móviles)",
+      sql: `SELECT mes AS x, SUM(importe) AS y FROM (
   SELECT DATE_TRUNC('month', v."fecha_creacion") AS mes,
          SUM(v."total_si") AS importe
   FROM "public"."ps_ventas" v
   WHERE v."entrada" = true
     AND v."tienda" <> '99'
-    AND v."fecha_creacion" >= :curr_from
+    AND v."fecha_creacion" >= LEAST(
+      :curr_from::date,
+      (DATE_TRUNC('month', :curr_to::date) - INTERVAL '11 months')::date
+    )
     AND v."fecha_creacion" <= :curr_to
     AND __gf_tienda__
   GROUP BY DATE_TRUNC('month', v."fecha_creacion")
@@ -150,7 +281,10 @@ ORDER BY value DESC`,
          SUM("base1" + "base2" + "base3") AS importe
   FROM "public"."ps_gc_facturas"
   WHERE "abono" = false
-    AND "fecha_factura" >= :curr_from
+    AND "fecha_factura" >= LEAST(
+      :curr_from::date,
+      (DATE_TRUNC('month', :curr_to::date) - INTERVAL '11 months')::date
+    )
     AND "fecha_factura" <= :curr_to
   GROUP BY DATE_TRUNC('month', "fecha_factura")
 ) combined
@@ -164,8 +298,8 @@ ORDER BY mes`,
       type: "table",
       title: "Top 10 Familias por Ventas (período seleccionado)",
       sql: `SELECT fm."fami_grup_marc" AS "Familia",
-       SUM(lv."total_si") AS "Ventas Netas",
-       SUM(lv."unidades") AS "Unidades",
+       COALESCE(SUM(lv."total_si"), 0) AS "Ventas Netas",
+       COALESCE(SUM(lv."unidades"), 0) AS "Unidades",
        ROUND((SUM(lv."total_si") - SUM(lv."total_coste_si"))
          / NULLIF(SUM(lv."total_si"), 0) * 100, 1) AS "Margen %"
 FROM "public"."ps_lineas_ventas" lv
@@ -192,6 +326,8 @@ LIMIT 10`,
       type: "kpi_row",
       items: [
         {
+          // Working-capital approximation: stock units × precio_coste at item level.
+          // Excludes anulado articles. Stock is point-in-time (not period-bound).
           label: "Valor Stock Total al Coste",
           sql: `SELECT COALESCE(ROUND(SUM(s."stock" * p."precio_coste"), 2), 0) AS value
 FROM "public"."ps_stock_tienda" s

--- a/dashboard/lib/templates/general.ts
+++ b/dashboard/lib/templates/general.ts
@@ -30,20 +30,24 @@
  *
  * ## YoY definition
  *
- * Comparativa YoY uses the **same exact day-count window shifted one year**:
+ * Comparativa YoY uses the **same dates shifted one year back**:
  *   prev_from = curr_from - INTERVAL '1 year'
  *   prev_to   = curr_to   - INTERVAL '1 year'
  *
- * Side effect: when the current period spans a leap day (Feb 29), the prior period
- * may include / exclude one extra day. We accept this trade-off because it preserves
- * the exact day-count and makes the % comparable for any custom range.
+ * Side effect: for ranges that cross a leap year / Feb 29, the prior period's
+ * day-count may differ by ±1 day. We accept this trade-off because it preserves
+ * date alignment year over year and keeps the % comparable for any custom range.
  *
  * ## Tendencia 12 meses
  *
- * The trend chart is **rolling 12 calendar months anchored to `:curr_to`**, not the
- * selected period. This is intentional: an executive scanning the dashboard wants
- * the long arc regardless of the picker. The selected period is reflected by the
- * other widgets (KPIs, mix, top families). Title makes the rolling behavior explicit.
+ * The trend chart is anchored to `:curr_to` and covers **at least 12 calendar
+ * months**. If the selected period starts earlier than `:curr_to - INTERVAL '11
+ * months'`, the chart expands to respect that longer picker range; otherwise it
+ * shows the standard rolling 12-month window. This is intentional: an executive
+ * scanning the dashboard wants the long arc while still preserving longer
+ * user-selected ranges. The selected period remains directly reflected by the
+ * other widgets (KPIs, mix, top families). Title makes the minimum rolling window
+ * explicit.
  *
  * ## Filters
  *


### PR DESCRIPTION
Refs #417, #413

## Summary

Review and harden the **Director General** template — the only template that crosses retail (`ps_ventas`) + mayorista (`ps_gc_facturas`) sources. Every widget validated against PostgreSQL with real data; cross-source discipline now codified in the file header so future agents cannot silently re-introduce double-counting.

## Changes

- **Header docstring**: cross-source discipline rules, YoY definition (same day-count window shifted -1y), 12-month trend rolling-anchor behavior, filter scope (`templateGlobalFiltersRetail` applies only to retail half — wholesale intentionally unfiltered, follow-up tracked).
- **New KPI row (`general-kpis-secondary`)**: Mayorista YoY %, Margen Global Mayorista, Devoluciones Retail % — answers B-General checklist gaps.
- **NULL safety**: COALESCE / NULLIF added to top-familias, ventas-por-tienda, devoluciones pct, mayorista YoY. No NaN / divide-by-zero on empty periods.
- **12-month trend**: lower bound is now `LEAST(:curr_from, :curr_to − 11 months)`. Short picker → at least 12 rolling months; long picker (e.g. YTD with 14 months) → respects picker. Title updated to reflect the behavior.
- **Inline SQL comments** at every cross-source boundary explaining the discipline (mayorista not store-scoped, donut totals = sum of channel KPIs, `::date` casts required before INTERVAL).

## Verified (against local Postgres, period 2026-03-26 → 2026-04-24)

- Ventas Retail Netas: **€246,020.88**
- Facturación Mayorista: **€795,299.84**
- Margen Retail / Mayorista: **60.3 % / 24.6 %**
- Retail YoY: **+10.3 %** (curr 246,020.88 vs prev 223,115.20 — independently cross-checked)
- Devoluciones Retail %: **8.8 %**
- Mix donut totals = sum of channel KPIs exactly (no double-counting)
- 12-month trend returns 12 monthly points (May-2025 → Apr-2026)
- Valor Stock al Coste: **€697,623.32**, Pedidos Mayorista pendientes: **38**

All SQL produced expected non-NaN, non-NULL results.

## Needs browser verification

- Visual rendering of the new `general-kpis-secondary` row (4-KPI → 3-KPI rows side by side).
- Behavior of the trend chart under different picker ranges (1-day, current month, YTD, custom 18 months).
- Drilldown via `/api/dashboard/analyze` — LLM should now have wholesale margin + devoluciones context.

## Out of scope

- `templateGlobalFiltersGeneral` (mixed retail + mayorista filters with `canal` toggle): documented as a follow-up, not implemented in this PR.
- Issues #420 (spacing/donut UX) and #419 (CLI bug) explicitly excluded.
- The duplicate `fami_grup_marc = 'PANTALON'` in `ps_familias` (two distinct `reg_familia` values) is a data-quality issue inherited from 4D — not changed here, matches sibling templates.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.typecheck.json` — clean
- [x] `npm test` — all template + date-params tests pass; only pre-existing `llm-usage.test.ts` failures (verified on main) remain
- [ ] Manual: load the dashboard in Docker (`http://localhost:4000` → "Crear desde plantilla" → Director General) and verify each widget renders, time picker propagates, drilldown produces sensible Spanish narrative
- [ ] Manual: pick a future date range (no data) and confirm widgets show 0 / empty without NaN