### PR TITLE
fix(dashboard): filter↔widget spacing + discourage donut layout in rectangular panels (issue #420)

### DIFF
--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -28,6 +28,7 @@
   --gap: 18px;
   --pad: 20px;
   --kpi-pad: 22px;
+  --gap-section: 1.5rem;
 }
 
 :root[data-theme="light"] {
@@ -51,6 +52,7 @@
   --gap: 18px;
   --pad: 20px;
   --kpi-pad: 22px;
+  --gap-section: 1.5rem;
 }
 
 /* ============================================================
@@ -90,6 +92,7 @@
   --gap: 12px;
   --pad: 14px;
   --kpi-pad: 16px;
+  --gap-section: 1rem;
 }
 
 :root[data-density="comfort"],
@@ -97,12 +100,14 @@
   --gap: 18px;
   --pad: 20px;
   --kpi-pad: 22px;
+  --gap-section: 1.5rem;
 }
 
 :root[data-density="spacious"] {
   --gap: 26px;
   --pad: 28px;
   --kpi-pad: 30px;
+  --gap-section: 2rem;
 }
 
 /* ============================================================

--- a/dashboard/components/DashboardRenderer.tsx
+++ b/dashboard/components/DashboardRenderer.tsx
@@ -603,7 +603,17 @@ export function DashboardRenderer({
   }, [spec.widgets]);
 
   return (
-    <div style={{ padding: "0 20px 24px" }}>
+    <div
+      style={{
+        // Top padding gives breathing room between the global filters bar
+        // (or page header when no filters are configured) and the first
+        // widget row. Token-driven so density variants scale it.
+        paddingTop: "var(--gap-section, 1.5rem)",
+        paddingLeft: 20,
+        paddingRight: 20,
+        paddingBottom: 24,
+      }}
+    >
       {/* Tabbed layout (when sections are defined) */}
       {spec.sections && spec.sections.length > 0 ? (
         <TabGroup>

--- a/dashboard/components/widgets/DonutChartWidget.tsx
+++ b/dashboard/components/widgets/DonutChartWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { DonutChartWidget as DonutChartWidgetSpec, GlossaryItem } from "@/lib/schema";
 import type { OnDataPointClick, WidgetData } from "./types";
 import { EMPTY_MESSAGE, resolveXY, safeNumber } from "./types";
@@ -28,6 +28,22 @@ export function DonutChartWidget({
 }: DonutChartWidgetProps) {
   const titleNode = applyGlossary(widget.title, glossary);
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+
+  // Track container width so we can mitigate the wide-rectangular-panel
+  // empty-space problem (issue #420) when the LLM still picks donut for a
+  // half-width panel. > 420px ≈ a half-width desktop grid panel.
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [containerWidth, setContainerWidth] = useState<number>(0);
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? 0;
+      if (w > 0) setContainerWidth(w);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   const chartData = useMemo(() => {
     if (!data || data.rows.length === 0) return null;
@@ -139,13 +155,32 @@ export function DonutChartWidget({
 
       {/* Chart + legend */}
       <div
+        ref={containerRef}
         style={{ padding: "var(--pad, 12px)" }}
         role="img"
         aria-label={`Gráfico de donut: ${widget.title}. ${chartData.length} categorías.`}
       >
         <span className="sr-only">Gráfico de donut con {chartData.length} categorías.</span>
 
-        <div style={{ display: "flex", alignItems: "center", gap: 20, flexWrap: "wrap" }}>
+        {/*
+          Wide-panel mitigation (issue #420): when the panel is rectangular
+          (width > 420px) the default flex layout leaves the right ~60% empty.
+          Use space-between alignment + a 2-column legend grid so the legend
+          fills the right side instead of clinging to the donut.
+        */}
+        {(() => {
+          const isWide = containerWidth > 420;
+          const useTwoColLegend = isWide && chartData.length >= 4;
+          return (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: isWide ? "space-between" : "flex-start",
+                gap: isWide ? 32 : 20,
+                flexWrap: "wrap",
+              }}
+            >
           {/* SVG donut */}
           <svg
             width={DONUT_SIZE}
@@ -218,7 +253,20 @@ export function DonutChartWidget({
           </svg>
 
           {/* Legend */}
-          <div style={{ display: "flex", flexDirection: "column", gap: 8, flex: 1, minWidth: 100 }}>
+          <div
+            style={
+              useTwoColLegend
+                ? {
+                    display: "grid",
+                    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+                    columnGap: 24,
+                    rowGap: 8,
+                    flex: 1,
+                    minWidth: 200,
+                  }
+                : { display: "flex", flexDirection: "column", gap: 8, flex: 1, minWidth: 100 }
+            }
+          >
             {chartData.map((d, i) => (
               <div
                 key={i}
@@ -267,7 +315,9 @@ export function DonutChartWidget({
               </div>
             ))}
           </div>
-        </div>
+            </div>
+          );
+        })()}
 
         {comparisonTotal !== null && (
           <div

--- a/dashboard/components/widgets/DonutChartWidget.tsx
+++ b/dashboard/components/widgets/DonutChartWidget.tsx
@@ -19,6 +19,17 @@ interface DonutChartWidgetProps {
 const DONUT_SIZE = 160;
 const STROKE_WIDTH = 22;
 
+/**
+ * Wide-panel mitigation thresholds (issue #420).
+ * - WIDE_PANEL_MIN_WIDTH: above this px width the panel is rectangular/half-
+ *   width on desktop and the legend uses space-between alignment so it fills
+ *   the right side instead of clinging to the donut.
+ * - MIN_TWO_COL_CATEGORIES: with this many or more categories on a wide panel,
+ *   the legend switches to a 2-column grid for better density.
+ */
+const WIDE_PANEL_MIN_WIDTH = 420;
+const MIN_TWO_COL_CATEGORIES = 4;
+
 export function DonutChartWidget({
   widget,
   data,
@@ -31,7 +42,7 @@ export function DonutChartWidget({
 
   // Track container width so we can mitigate the wide-rectangular-panel
   // empty-space problem (issue #420) when the LLM still picks donut for a
-  // half-width panel. > 420px ≈ a half-width desktop grid panel.
+  // half-width panel. See WIDE_PANEL_MIN_WIDTH for the breakpoint.
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [containerWidth, setContainerWidth] = useState<number>(0);
   useEffect(() => {
@@ -130,6 +141,12 @@ export function DonutChartWidget({
     return arc;
   });
 
+  // Layout decision for the wide-rectangular-panel mitigation (issue #420).
+  // Computed outside the JSX so the render output stays readable and we don't
+  // reallocate an IIFE on every render.
+  const isWidePanel = containerWidth > WIDE_PANEL_MIN_WIDTH;
+  const useTwoColLegend = isWidePanel && chartData.length >= MIN_TWO_COL_CATEGORIES;
+
   // Center readout
   const display = hoverIdx !== null ? chartData[hoverIdx] : null;
   const centerPct = display
@@ -164,23 +181,20 @@ export function DonutChartWidget({
 
         {/*
           Wide-panel mitigation (issue #420): when the panel is rectangular
-          (width > 420px) the default flex layout leaves the right ~60% empty.
-          Use space-between alignment + a 2-column legend grid so the legend
-          fills the right side instead of clinging to the donut.
+          (width > WIDE_PANEL_MIN_WIDTH) the default flex layout leaves the
+          right ~60% empty. Use space-between alignment + a 2-column legend
+          grid so the legend fills the right side instead of clinging to the
+          donut. Square / narrow panels keep the original behaviour.
         */}
-        {(() => {
-          const isWide = containerWidth > 420;
-          const useTwoColLegend = isWide && chartData.length >= 4;
-          return (
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: isWide ? "space-between" : "flex-start",
-                gap: isWide ? 32 : 20,
-                flexWrap: "wrap",
-              }}
-            >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: isWidePanel ? "space-between" : "flex-start",
+            gap: isWidePanel ? 32 : 20,
+            flexWrap: "wrap",
+          }}
+        >
           {/* SVG donut */}
           <svg
             width={DONUT_SIZE}
@@ -315,9 +329,7 @@ export function DonutChartWidget({
               </div>
             ))}
           </div>
-            </div>
-          );
-        })()}
+        </div>
 
         {comparisonTotal !== null && (
           <div

--- a/dashboard/lib/__tests__/prompts.test.ts
+++ b/dashboard/lib/__tests__/prompts.test.ts
@@ -172,7 +172,7 @@ describe("prompts", () => {
       expect(parsed).not.toHaveProperty("value");
     });
 
-    it("includes widget-selection rules that discourage donut in rectangular panels (issue #420)", () => {
+    it("buildGeneratePrompt: widget-selection rules discourage donut in rectangular panels (issue #420)", () => {
       // Heading must be present
       expect(prompt).toContain("Widget selection rules");
       // Anti-empty-space message
@@ -182,8 +182,24 @@ describe("prompts", () => {
       expect(prompt).toMatch(/square or near-square/i);
       // Few-categories guidance
       expect(prompt).toMatch(/< 3 categor/);
-      // Recommended alternative
+      // Recommended alternative — must be a real renderable widget type
       expect(prompt).toMatch(/bar_chart|ranked_bars/);
+    });
+
+    it("WIDGET_TYPES table lists every renderable widget the prompt rules reference", () => {
+      // ranked_bars and insights_strip must appear in the Widget Types table,
+      // not only in the selection rules — otherwise the LLM cannot emit them.
+      const lines = prompt.split("\n");
+      const tableRow = (type: string) =>
+        lines.find((l) => l.includes(`| ${type}`) && l.includes("|"));
+      expect(tableRow("ranked_bars"), "ranked_bars row missing").toBeDefined();
+      expect(tableRow("insights_strip"), "insights_strip row missing").toBeDefined();
+    });
+
+    it("does not advertise stacked/horizontal bar_chart variants (renderer has none)", () => {
+      // Guard against re-introducing capability hallucinations.
+      expect(prompt).not.toMatch(/100%\s*stacked\s*`?bar_chart`?/i);
+      expect(prompt).not.toMatch(/horizontal\s*`?bar_chart`?/i);
     });
 
     it("donut_chart JSON example is valid according to DashboardSpecSchema", () => {
@@ -263,7 +279,7 @@ describe("prompts", () => {
       expect(prompt).toContain("comparison_sql");
     });
 
-    it("includes widget-selection rules that discourage donut in rectangular panels (issue #420)", () => {
+    it("buildModifyPrompt: widget-selection rules discourage donut in rectangular panels (issue #420)", () => {
       expect(prompt).toContain("Widget selection rules");
       expect(prompt).toMatch(/never leave more than ~30% of a panel empty/i);
       expect(prompt).toMatch(/donut_chart[`*]*\s+is allowed\s+\*\*only when\*\*/i);

--- a/dashboard/lib/__tests__/prompts.test.ts
+++ b/dashboard/lib/__tests__/prompts.test.ts
@@ -172,6 +172,20 @@ describe("prompts", () => {
       expect(parsed).not.toHaveProperty("value");
     });
 
+    it("includes widget-selection rules that discourage donut in rectangular panels (issue #420)", () => {
+      // Heading must be present
+      expect(prompt).toContain("Widget selection rules");
+      // Anti-empty-space message
+      expect(prompt).toMatch(/never leave more than ~30% of a panel empty/i);
+      // Donut guidance — only square/near-square or paired with dense surroundings
+      expect(prompt).toMatch(/donut_chart[`*]*\s+is allowed\s+\*\*only when\*\*/i);
+      expect(prompt).toMatch(/square or near-square/i);
+      // Few-categories guidance
+      expect(prompt).toMatch(/< 3 categor/);
+      // Recommended alternative
+      expect(prompt).toMatch(/bar_chart|ranked_bars/);
+    });
+
     it("donut_chart JSON example is valid according to DashboardSpecSchema", () => {
       const blocks = [...prompt.matchAll(/```json\s*([\s\S]*?)```/g)].map(
         (m) => m[1].trim()
@@ -247,6 +261,12 @@ describe("prompts", () => {
     it("prohibits :comp_from/:comp_to in main widget sql (rule 15)", () => {
       expect(prompt).toContain("Do NOT reference :comp_from/:comp_to");
       expect(prompt).toContain("comparison_sql");
+    });
+
+    it("includes widget-selection rules that discourage donut in rectangular panels (issue #420)", () => {
+      expect(prompt).toContain("Widget selection rules");
+      expect(prompt).toMatch(/never leave more than ~30% of a panel empty/i);
+      expect(prompt).toMatch(/donut_chart[`*]*\s+is allowed\s+\*\*only when\*\*/i);
     });
   });
 

--- a/dashboard/lib/prompts.ts
+++ b/dashboard/lib/prompts.ts
@@ -32,18 +32,22 @@ const WIDGET_TYPES = `
 | donut_chart   | Proportions                             | title, sql, x, y                         |
 | table         | Detailed data rows                      | title, sql                               |
 | number        | Single big number                       | title, sql, format?, prefix?             |
+| insights_strip| 3-card narrative strip (up/down/warn)   | items[]: {kind, title, body}             |
+| ranked_bars   | Horizontal bar chart (pre-computed data)| title, items[]: {label, value, maxValue?, flag?, unit?} |
+
+> **Note**: \`ranked_bars\` is **data-driven** — supply the \`items\` array directly; it does **not** take a \`sql\` field. \`bar_chart\` is the SQL-driven equivalent and renders **vertical bars only** (there is no \`stacked\` or \`horizontal\` variant in the renderer).
 
 ### Widget selection rules — avoid empty space (CRITICAL)
 
 The dashboard grid renders most widgets in **rectangular panels** (aspect ratio > 1.5:1, half-width on desktop). Choose the widget type that **fills the panel** with data instead of leaving large empty areas.
 
-- **Share / mix / proporciones / distribución** in a rectangular panel → prefer **\`bar_chart\`** (horizontal categories with values), **100% stacked \`bar_chart\`**, or a **\`ranked_bars\`** widget. These fill the full width of the panel.
+- **Share / mix / proporciones / distribución** in a rectangular panel → prefer a **\`bar_chart\`** (vertical categories with values, SQL-driven) or a **\`ranked_bars\`** widget (data inlined as \`items\`). Both fill the full width of the panel.
 - **\`donut_chart\`** is allowed **only when**:
   (a) the panel is square or near-square (kpi_row item, dedicated dashboard with few widgets), **or**
   (b) the donut is paired with dense surrounding categories (≥ 5 segments) so the legend fills the right side without gaps.
   In flat half-width panels with ≤ 4 categories the donut wastes space — switch to \`bar_chart\` or \`number\` instead.
 - **< 3 categorías** → use a **\`number\`** widget (with optional \`trend_sql\` + sparkline) or a **2-item \`kpi_row\`**. Never render a donut with 2 slices in a wide panel.
-- **3+ categories and rectangular panel** → \`bar_chart\` (vertical or horizontal) or \`ranked_bars\`.
+- **3+ categories and rectangular panel** → \`bar_chart\` or \`ranked_bars\`.
 - **Time series** → \`line_chart\` or \`area_chart\`, never \`donut_chart\`.
 - **General rule**: never leave more than ~30% of a panel empty. If the data shape does not fill the panel, change the widget type.
 

--- a/dashboard/lib/prompts.ts
+++ b/dashboard/lib/prompts.ts
@@ -33,6 +33,20 @@ const WIDGET_TYPES = `
 | table         | Detailed data rows                      | title, sql                               |
 | number        | Single big number                       | title, sql, format?, prefix?             |
 
+### Widget selection rules — avoid empty space (CRITICAL)
+
+The dashboard grid renders most widgets in **rectangular panels** (aspect ratio > 1.5:1, half-width on desktop). Choose the widget type that **fills the panel** with data instead of leaving large empty areas.
+
+- **Share / mix / proporciones / distribución** in a rectangular panel → prefer **\`bar_chart\`** (horizontal categories with values), **100% stacked \`bar_chart\`**, or a **\`ranked_bars\`** widget. These fill the full width of the panel.
+- **\`donut_chart\`** is allowed **only when**:
+  (a) the panel is square or near-square (kpi_row item, dedicated dashboard with few widgets), **or**
+  (b) the donut is paired with dense surrounding categories (≥ 5 segments) so the legend fills the right side without gaps.
+  In flat half-width panels with ≤ 4 categories the donut wastes space — switch to \`bar_chart\` or \`number\` instead.
+- **< 3 categorías** → use a **\`number\`** widget (with optional \`trend_sql\` + sparkline) or a **2-item \`kpi_row\`**. Never render a donut with 2 slices in a wide panel.
+- **3+ categories and rectangular panel** → \`bar_chart\` (vertical or horizontal) or \`ranked_bars\`.
+- **Time series** → \`line_chart\` or \`area_chart\`, never \`donut_chart\`.
+- **General rule**: never leave more than ~30% of a panel empty. If the data shape does not fill the panel, change the widget type.
+
 ### format values
 - "currency" — format as money (e.g. 1234.56 → "1.234,56")
 - "number" — format with thousand separators

--- a/docs/skills/dashboard-redesign.md
+++ b/docs/skills/dashboard-redesign.md
@@ -143,7 +143,7 @@ The `AnalyzeLauncher` (floating rail) opens the sidebar directly in analizar mod
 
 The grid is two-column on desktop; non-`isFullWidth` widgets render in **rectangular panels** (aspect ratio > 1.5:1). The LLM and any human author should follow these rules to avoid the donut-with-2-slices-and-empty-space problem (see issue #420):
 
-- **Share / mix / proporciones / distribución** → prefer `bar_chart` horizontal/100%-stacked or `ranked_bars`. They fill panel width.
+- **Share / mix / proporciones / distribución** → prefer a SQL-driven `bar_chart` (vertical bars) or a data-driven `ranked_bars` (horizontal bars with `items` array). Both fill panel width. Note: the `bar_chart` renderer is vertical-only — there is no `stacked`/`horizontal` variant — so use `ranked_bars` when you need horizontal layout.
 - **`donut_chart`** is allowed only when (a) the panel is square or near-square or (b) the donut is paired with ≥ 5 dense surrounding categories. **Do not** use a donut with ≤ 4 categories in a flat half-width panel — it leaves the right ~60% of the panel empty.
 - **< 3 categorías** → `number` (with optional `trend_sql` + sparkline) or 2-item `kpi_row`.
 - **General rule**: never leave more than ~30% of a panel empty. If the data shape does not fill the panel, change the widget type.

--- a/docs/skills/dashboard-redesign.md
+++ b/docs/skills/dashboard-redesign.md
@@ -46,6 +46,7 @@ All tokens are declared on the `html` element in `dashboard/app/globals.css`. Th
 | `--gap` | Grid gap between widgets |
 | `--pad` | Widget inner padding |
 | `--kpi-pad` | KPI card padding |
+| `--gap-section` | Vertical separation between page sections (e.g. global filters bar → first widget row). Default `1.5rem`; scales with density (`compact: 1rem`, `spacious: 2rem`). |
 
 ### Accent variants (data-accent attribute)
 
@@ -137,6 +138,17 @@ The `AnalyzeLauncher` (floating rail) opens the sidebar directly in analizar mod
 2. Use `<TopBarWithTweaks />` instead of `<TopBar />` directly — it owns the TweaksPanel open/close state
 3. Read kpiStyle anywhere via `useKpiStyle()` from `@/components/TweaksPanel`
 4. All tweaks persist to `localStorage` key `ps.tweaks.v1` — same key read by the pre-paint script in layout.tsx
+
+## Widget selection rules — avoid empty panels
+
+The grid is two-column on desktop; non-`isFullWidth` widgets render in **rectangular panels** (aspect ratio > 1.5:1). The LLM and any human author should follow these rules to avoid the donut-with-2-slices-and-empty-space problem (see issue #420):
+
+- **Share / mix / proporciones / distribución** → prefer `bar_chart` horizontal/100%-stacked or `ranked_bars`. They fill panel width.
+- **`donut_chart`** is allowed only when (a) the panel is square or near-square or (b) the donut is paired with ≥ 5 dense surrounding categories. **Do not** use a donut with ≤ 4 categories in a flat half-width panel — it leaves the right ~60% of the panel empty.
+- **< 3 categorías** → `number` (with optional `trend_sql` + sparkline) or 2-item `kpi_row`.
+- **General rule**: never leave more than ~30% of a panel empty. If the data shape does not fill the panel, change the widget type.
+
+These rules are mirrored in `dashboard/lib/prompts.ts` (`WIDGET_TYPES` block) and must be kept in sync.
 
 ## chat_messages_modify DB column
 


### PR DESCRIPTION
Refs #420

## Summary

Two UX visual fixes:

### A) Filter ↔ widget vertical spacing

The global filters bar (Tienda / Familia / Temporada / Marca) sat flush against the first KPI row.

- Added a `--gap-section` token in `dashboard/app/globals.css` (`1.5rem` default; scales with density: `1rem` compact / `2rem` spacious).
- Applied it as `padding-top` on the `DashboardRenderer` outer wrapper. The wrapper previously had `padding: "0 20px 24px"` (no top); now it explicitly uses `paddingTop: "var(--gap-section, 1.5rem)"`.

**Before**: filters bar's bottom border touched the KPI row above it (0 px gap).
**After**: ≥ 24 px breathing room, scaling with the user's density preference.

### B) Donut/ring charts wasted space in rectangular panels

Caso visto: "Mix Retail vs Mayorista" — donut a la izquierda + leyenda de 2 líneas a la derecha; ~60% del panel rectangular vacío.

#### B.1 — Updated LLM prompts (mandatory)

Added a "Widget selection rules — avoid empty space" block to `WIDGET_TYPES` in `dashboard/lib/prompts.ts`. Both `buildGeneratePrompt()` and `buildModifyPrompt()` include `WIDGET_TYPES`, so the rules apply to all three flows that emit specs (generate / modify; analyze does not emit widgets). New guidance text:

> **Widget selection rules — avoid empty space (CRITICAL)**
>
> The dashboard grid renders most widgets in **rectangular panels** (aspect ratio > 1.5:1, half-width on desktop). Choose the widget type that **fills the panel** with data instead of leaving large empty areas.
>
> - **Share / mix / proporciones / distribución** in a rectangular panel → prefer **`bar_chart`** (horizontal categories with values), **100% stacked `bar_chart`**, or a **`ranked_bars`** widget. These fill the full width of the panel.
> - **`donut_chart`** is allowed **only when**:
>   (a) the panel is square or near-square (kpi_row item, dedicated dashboard with few widgets), **or**
>   (b) the donut is paired with dense surrounding categories (≥ 5 segments) so the legend fills the right side without gaps.
>   In flat half-width panels with ≤ 4 categories the donut wastes space — switch to `bar_chart` or `number` instead.
> - **< 3 categorías** → use a **`number`** widget (with optional `trend_sql` + sparkline) or a **2-item `kpi_row`**. Never render a donut with 2 slices in a wide panel.
> - **3+ categories and rectangular panel** → `bar_chart` (vertical or horizontal) or `ranked_bars`.
> - **Time series** → `line_chart` or `area_chart`, never `donut_chart`.
> - **General rule**: never leave more than ~30% of a panel empty. If the data shape does not fill the panel, change the widget type.

The same rules are mirrored in `docs/skills/dashboard-redesign.md` (new "Widget selection rules — avoid empty panels" section) so the prompt and the skill doc don't drift.

#### B.2 — Renderer fallback (defensive)

`DonutChartWidget.tsx` now observes its container with `ResizeObserver`. When the panel is > 420 px wide and has ≥ 4 categories, the legend switches to a 2-column grid and the donut+legend align with `justify-content: space-between` so the legend fills the right side instead of clinging to the donut. Square / narrow panels behave exactly as before.

## Test plan
- [x] `cd dashboard && npm test -- --run lib/__tests__/prompts.test.ts` — passes (37/37, including 2 new tests for issue #420 guidance)
- [x] `cd dashboard && npm test -- --run` — 1364 / 1366 pass; the 2 failures (`llm-usage.test.ts`) are pre-existing and reproducible on a clean `main` (unrelated to this PR).
- [x] `cd dashboard && npx tsc --noEmit -p tsconfig.typecheck.json` — passes
- [ ] Visual: open `http://localhost:4000/dashboard/<id>` with a dashboard that has filters and confirm there is ≥ 24 px between the filters bar and the first widget row in the default `comfort` density.
- [ ] Visual (regression): donut widget in a square panel (e.g. `Mix por Familia` with 6+ items) renders unchanged.
- [ ] Visual (mitigation): donut widget in the `Mix Retail vs Mayorista` case shows the legend further to the right (or grid layout when ≥ 4 cats) instead of clumped next to the donut.
- [ ] Generation: ask the LLM "Cuadro con mix retail vs mayorista" and verify it picks `bar_chart` / `ranked_bars` / `number` instead of `donut_chart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)