### PR TITLE
fix(dashboard/templates): ventas template review (issue #414)

### DIFF
--- a/dashboard/components/widgets/__tests__/format.test.ts
+++ b/dashboard/components/widgets/__tests__/format.test.ts
@@ -54,4 +54,23 @@ describe("formatValue", () => {
     const result = formatValue(-500.5, "currency", "\u20ac");
     expect(result).toContain("500,50");
   });
+
+  // Regression: format: "number" rounds to integer (1.69 -> "2"). The
+  // "decimal" format preserves fractional precision for ratio KPIs such as
+  // Unidades por Ticket. See PR #424 review.
+  it("formats decimal with two fractional digits (ratios)", () => {
+    expect(formatValue(1.69, "decimal")).toBe("1,69");
+  });
+
+  it("formats decimal large numbers with grouping", () => {
+    expect(formatValue(1234.5, "decimal")).toBe("1.234,50");
+  });
+
+  it("formats decimal integer values with trailing zeros", () => {
+    expect(formatValue(2, "decimal")).toBe("2,00");
+  });
+
+  it("number format still rounds to integer (regression guard)", () => {
+    expect(formatValue(1.69, "number")).toBe("2");
+  });
 });

--- a/dashboard/components/widgets/format.ts
+++ b/dashboard/components/widgets/format.ts
@@ -22,6 +22,15 @@ const percentFormatter = new Intl.NumberFormat("es-ES", {
   maximumFractionDigits: 1,
 });
 
+// Decimal formatter for ratios / non-integer indicators such as
+// "Unidades por Ticket" (1,69). Distinct from `number` (integer) so the
+// caller can opt in to preserve fractional precision.
+const decimalFormatter = new Intl.NumberFormat("es-ES", {
+  useGrouping: true,
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
 /**
  * Format a numeric value according to the given KPI format.
  * Returns a string like "€1.234,56", "1.234", or "12,3%".
@@ -45,6 +54,10 @@ export function formatValue(
       return `${percentFormatter.format(num)}%`;
     case "number":
       return integerFormatter.format(num);
+    case "decimal": {
+      const formatted = decimalFormatter.format(num);
+      return prefix ? `${prefix}${formatted}` : formatted;
+    }
     default:
       return String(num);
   }

--- a/dashboard/lib/schema.ts
+++ b/dashboard/lib/schema.ts
@@ -10,9 +10,13 @@ import { z } from "zod";
 // Zod schemas
 // ---------------------------------------------------------------------------
 
-const KPI_FORMAT_ALIASES: Record<string, "currency" | "number" | "percent"> = {
+const KPI_FORMAT_ALIASES: Record<string, "currency" | "number" | "percent" | "decimal"> = {
   euro: "currency", euros: "currency", money: "currency", importe: "currency",
-  cantidad: "number", integer: "number", float: "number", count: "number", entero: "number",
+  cantidad: "number", integer: "number", count: "number", entero: "number",
+  // "decimal" / "float" are routed to the new decimal format (up to 2 decimals).
+  // This preserves precision for ratios such as Unidades por Ticket (1,69),
+  // which "number" would round to 2.
+  decimales: "decimal", float: "decimal",
   percentage: "percent", pct: "percent", porcentaje: "percent", ratio: "percent",
 };
 
@@ -22,7 +26,7 @@ const KpiFormatSchema = z.preprocess(
     const lv = v.toLowerCase().trim();
     return KPI_FORMAT_ALIASES[lv] ?? lv;
   },
-  z.enum(["currency", "number", "percent"]),
+  z.enum(["currency", "number", "percent", "decimal"]),
 );
 
 /** Optional string that must be non-empty when provided. */

--- a/dashboard/lib/templates/ventas.ts
+++ b/dashboard/lib/templates/ventas.ts
@@ -1,9 +1,34 @@
 /**
- * Template: Responsable de Ventas
+ * Template: Responsable de Ventas (retail)
  *
- * KPIs de ventas retail, devoluciones, desglose por tienda, tendencia semanal,
- * formas de pago, margen por tienda, top articulos con margen.
- * All date filters use :curr_from / :curr_to tokens set by the date picker.
+ * Panel diario para el responsable de tienda / ventas retail. Cubre la pregunta
+ * de la mañana — "¿cómo vamos hoy?" — y el cierre de día/semana/mes:
+ *   - KPIs de actividad (ventas netas, tickets, ticket medio, unidades/ticket)
+ *   - Comparativas (% devoluciones, YoY)
+ *   - Desglose por tienda (volumen + margen)
+ *   - Tendencia diaria
+ *   - Mix de formas de pago
+ *   - Top artículos con margen
+ *
+ * Decisiones de negocio (mantener consistentes en todos los widgets):
+ *   - Tienda 99 excluida en todas las queries de retail (es la "tienda fantasma"
+ *     usada para movimientos internos / no comerciales).
+ *   - "Ventas Netas" = SUM(total_si) sobre tickets con entrada=true (importe sin
+ *     impuestos). Las devoluciones (entrada=false) se muestran aparte y NO se
+ *     restan del KPI principal — coherente con el desglose por tienda.
+ *   - Margen: solo líneas con total_si > 0 (excluye líneas regalo / coste cero).
+ *   - Marketplace / web: actualmente todo retail está consolidado (campo
+ *     `pedido_web` está casi vacío, ver `ps_ventas`). Si se quiere desglose
+ *     online vs físico habrá que segmentar por `pedido_web IS NOT NULL`.
+ *   - IVA: `total_si` excluye impuestos (sufijo `_si` = sin impuestos).
+ *
+ * Tokens:
+ *   - `:curr_from` / `:curr_to`  — rango temporal (todos los widgets reaccionan).
+ *   - `__gf_tienda__`            — filtro tienda (todos los widgets reaccionan).
+ *   - `__gf_familia__` / `__gf_temporada__` / `__gf_marca__` /
+ *     `__gf_sexo__` / `__gf_departamento__` — solo widgets que se unen a
+ *     `ps_articulos` (margen y top artículos). Los KPIs sobre `ps_ventas` no
+ *     se filtran por estos campos (no hay join), expandiéndose a TRUE.
  */
 import type { DashboardSpec } from "@/lib/schema";
 import { templateGlobalFiltersRetail } from "@/lib/template-global-filters";
@@ -11,7 +36,7 @@ import { templateGlobalFiltersRetail } from "@/lib/template-global-filters";
 export const name = "Responsable de Ventas";
 
 export const description =
-  "Panel para el responsable de ventas retail: KPIs y devoluciones, desglose por tienda, tendencia semanal, formas de pago, margen por tienda y top articulos.";
+  "Panel para el responsable de ventas retail: KPIs (ventas netas, tickets, ticket medio, unidades por ticket), % devoluciones y YoY, desglose por tienda, tendencia diaria, formas de pago, margen por tienda y top artículos.";
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Ventas Retail",
@@ -24,6 +49,7 @@ export const spec: DashboardSpec = {
       items: [
         {
           label: "Ventas Netas",
+          // SUM(total_si) sobre tickets de venta (entrada=true). No incluye IVA.
           sql: `SELECT COALESCE(SUM(v."total_si"), 0) AS value
 FROM "public"."ps_ventas" v
 WHERE v."entrada" = true
@@ -36,6 +62,7 @@ WHERE v."entrada" = true
         },
         {
           label: "Tickets",
+          // COUNT(DISTINCT reg_ventas) — un ticket puede tener varias líneas.
           sql: `SELECT COUNT(DISTINCT v."reg_ventas") AS value
 FROM "public"."ps_ventas" v
 WHERE v."entrada" = true
@@ -47,6 +74,8 @@ WHERE v."entrada" = true
         },
         {
           label: "Ticket Medio",
+          // Importe medio por ticket = SUM(total_si) / COUNT(DISTINCT reg_ventas).
+          // NULLIF protege contra rango sin tickets (división por cero).
           sql: `SELECT ROUND(SUM(v."total_si") / NULLIF(COUNT(DISTINCT v."reg_ventas"), 0), 2) AS value
 FROM "public"."ps_ventas" v
 WHERE v."entrada" = true
@@ -58,7 +87,25 @@ WHERE v."entrada" = true
           prefix: "€",
         },
         {
+          label: "Unidades por Ticket",
+          // Unidades vendidas / tickets. Indicador de "cesta media".
+          // El denominador cuenta tickets con al menos una línea — si ningún
+          // ticket tiene líneas, NULLIF evita la división por cero.
+          sql: `SELECT ROUND(SUM(lv."unidades")::numeric / NULLIF(COUNT(DISTINCT v."reg_ventas"), 0), 2) AS value
+FROM "public"."ps_lineas_ventas" lv
+JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
+WHERE v."entrada" = true
+  AND lv."tienda" <> '99'
+  AND lv."fecha_creacion" >= :curr_from
+  AND lv."fecha_creacion" <= :curr_to
+  AND __gf_tienda__`,
+          format: "number",
+        },
+        {
           label: "Devoluciones",
+          // ABS(SUM(total_si)) sobre tickets de devolución (entrada=false).
+          // ABS porque los importes vienen negativos.
+          // `inverted: true` indica al renderer que un valor que sube es malo.
           sql: `SELECT COALESCE(ABS(SUM(v."total_si")), 0) AS value
 FROM "public"."ps_ventas" v
 WHERE v."entrada" = false
@@ -68,13 +115,67 @@ WHERE v."entrada" = false
   AND __gf_tienda__`,
           format: "currency",
           prefix: "€",
+          inverted: true,
+        },
+        {
+          label: "% Devoluciones",
+          // Devoluciones como % del flujo bruto (ventas + devoluciones absolutas).
+          // Denominador NULLIF para rangos vacíos.
+          sql: `SELECT ROUND(
+  COALESCE(devo.imp, 0) / NULLIF(ven.imp + COALESCE(devo.imp, 0), 0) * 100, 1
+) AS value
+FROM (
+  SELECT COALESCE(SUM(v."total_si"), 0) AS imp
+  FROM "public"."ps_ventas" v
+  WHERE v."entrada" = true AND v."tienda" <> '99'
+    AND v."fecha_creacion" >= :curr_from
+    AND v."fecha_creacion" <= :curr_to
+    AND __gf_tienda__
+) ven,
+(
+  SELECT COALESCE(ABS(SUM(v."total_si")), 0) AS imp
+  FROM "public"."ps_ventas" v
+  WHERE v."entrada" = false AND v."tienda" <> '99'
+    AND v."fecha_creacion" >= :curr_from
+    AND v."fecha_creacion" <= :curr_to
+    AND __gf_tienda__
+) devo`,
+          format: "percent",
+          inverted: true,
+        },
+        {
+          label: "Ventas YoY %",
+          // Comparativa con el mismo período un año antes.
+          // `:curr_from::date - INTERVAL '1 year'` — el cast a ::date es necesario
+          // para que PostgreSQL interprete el token como fecha (ver test
+          // "YoY-style SQL uses :curr_*::date before INTERVAL" en templates.test.ts).
+          sql: `SELECT ROUND(
+  (curr.ventas - prev.ventas) / NULLIF(ABS(prev.ventas), 0) * 100, 1
+) AS value
+FROM (
+  SELECT COALESCE(SUM(v."total_si"), 0) AS ventas
+  FROM "public"."ps_ventas" v
+  WHERE v."entrada" = true AND v."tienda" <> '99'
+    AND v."fecha_creacion" >= :curr_from
+    AND v."fecha_creacion" <= :curr_to
+    AND __gf_tienda__
+) curr,
+(
+  SELECT COALESCE(SUM(v."total_si"), 0) AS ventas
+  FROM "public"."ps_ventas" v
+  WHERE v."entrada" = true AND v."tienda" <> '99'
+    AND v."fecha_creacion" >= :curr_from::date - INTERVAL '1 year'
+    AND v."fecha_creacion" <= :curr_to::date - INTERVAL '1 year'
+    AND __gf_tienda__
+) prev`,
+          format: "percent",
         },
       ],
     },
     {
       id: "ventas-por-tienda",
       type: "bar_chart",
-      title: "Ventas por Tienda (período seleccionado)",
+      title: "Ventas Netas por Tienda (período seleccionado)",
       sql: `SELECT v."tienda" AS label, SUM(v."total_si") AS value
 FROM "public"."ps_ventas" v
 WHERE v."entrada" = true
@@ -88,17 +189,20 @@ ORDER BY value DESC`,
       y: "value",
     },
     {
-      id: "ventas-tendencia-semanal",
+      id: "ventas-tendencia-diaria",
       type: "line_chart",
-      title: "Tendencia Semanal (período seleccionado)",
-      sql: `SELECT DATE_TRUNC('week', v."fecha_creacion") AS x, SUM(v."total_si") AS y
+      title: "Tendencia Diaria de Ventas (período seleccionado)",
+      // Bucketización diaria: para 30 días produce 30 puntos (más útil que
+      // 4-5 puntos semanales en el rango por defecto). Para rangos largos
+      // (>1 año) considerar cambiar a 'week' o 'month' en una versión futura.
+      sql: `SELECT v."fecha_creacion" AS x, SUM(v."total_si") AS y
 FROM "public"."ps_ventas" v
 WHERE v."entrada" = true
   AND v."tienda" <> '99'
   AND v."fecha_creacion" >= :curr_from
   AND v."fecha_creacion" <= :curr_to
   AND __gf_tienda__
-GROUP BY DATE_TRUNC('week', v."fecha_creacion")
+GROUP BY v."fecha_creacion"
 ORDER BY x`,
       x: "x",
       y: "y",
@@ -107,11 +211,16 @@ ORDER BY x`,
       id: "ventas-formas-pago",
       type: "donut_chart",
       title: "Mix de Formas de Pago (período seleccionado)",
+      // p.entrada = true filtra los pagos que son cobros (no devoluciones de pago).
+      // Sin este filtro aparecerían formas como "Devolución Vale" / "Devolución
+      // Metálico" mezcladas con los cobros normales y distorsionarían el mix.
+      // El filtro v.entrada = true asegura que solo miramos tickets de venta.
       sql: `SELECT p."forma" AS label,
        SUM(p."importe_cob") AS value
 FROM "public"."ps_pagos_ventas" p
 JOIN "public"."ps_ventas" v ON p."num_ventas" = v."reg_ventas"
 WHERE v."entrada" = true
+  AND p."entrada" = true
   AND p."tienda" <> '99'
   AND p."fecha_creacion" >= :curr_from
   AND p."fecha_creacion" <= :curr_to
@@ -125,6 +234,10 @@ ORDER BY value DESC`,
       id: "ventas-margen-tienda",
       type: "bar_chart",
       title: "Margen Bruto % por Tienda (período seleccionado)",
+      // Margen = (ventas - coste) / ventas * 100.
+      // total_si > 0 excluye líneas regalo / promocionales con importe 0
+      // que distorsionan el margen calculado.
+      // NULLIF evita división por cero cuando todas las líneas son 0.
       sql: `SELECT lv."tienda" AS label,
        ROUND((SUM(lv."total_si") - SUM(lv."total_coste_si"))
          / NULLIF(SUM(lv."total_si"), 0) * 100, 1) AS value
@@ -151,11 +264,15 @@ ORDER BY value DESC`,
     {
       id: "ventas-top-articulos",
       type: "table",
-      title: "Top 10 Artículos (período seleccionado)",
+      title: "Top 10 Artículos por Ventas (período seleccionado)",
+      // Columna "Ventas Netas (€)" — incluye sufijo de unidad para que el
+      // usuario sepa que es importe (TableWidget no aplica símbolo €
+      // automáticamente). "Margen %" se renderiza con formato de porcentaje
+      // (detectado por el sufijo "%").
       sql: `SELECT p."ccrefejofacm" AS "Referencia",
        p."descripcion" AS "Descripción",
        SUM(lv."unidades") AS "Unidades",
-       SUM(lv."total_si") AS "Ventas Netas",
+       ROUND(SUM(lv."total_si")::numeric, 2) AS "Ventas Netas (€)",
        ROUND((SUM(lv."total_si") - SUM(lv."total_coste_si"))
          / NULLIF(SUM(lv."total_si"), 0) * 100, 1) AS "Margen %"
 FROM "public"."ps_lineas_ventas" lv
@@ -174,7 +291,7 @@ WHERE v."entrada" = true
   AND __gf_sexo__
   AND __gf_departamento__
 GROUP BY p."ccrefejofacm", p."descripcion"
-ORDER BY "Ventas Netas" DESC
+ORDER BY "Ventas Netas (€)" DESC
 LIMIT 10`,
     },
   ],

--- a/dashboard/lib/templates/ventas.ts
+++ b/dashboard/lib/templates/ventas.ts
@@ -91,7 +91,10 @@ WHERE v."entrada" = true
           // Unidades vendidas / tickets. Indicador de "cesta media".
           // El denominador cuenta tickets con al menos una línea — si ningún
           // ticket tiene líneas, NULLIF evita la división por cero.
-          sql: `SELECT ROUND(SUM(lv."unidades")::numeric / NULLIF(COUNT(DISTINCT v."reg_ventas"), 0), 2) AS value
+          // COALESCE evita "—" cuando el rango no tiene líneas.
+          // Usa format: "decimal" porque es un ratio fraccional (p.ej. 1,69):
+          // "number" lo redondearía a entero (→ 2) y perdería precisión.
+          sql: `SELECT COALESCE(ROUND(SUM(lv."unidades")::numeric / NULLIF(COUNT(DISTINCT v."reg_ventas"), 0), 2), 0) AS value
 FROM "public"."ps_lineas_ventas" lv
 JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
 WHERE v."entrada" = true
@@ -99,7 +102,7 @@ WHERE v."entrada" = true
   AND lv."fecha_creacion" >= :curr_from
   AND lv."fecha_creacion" <= :curr_to
   AND __gf_tienda__`,
-          format: "number",
+          format: "decimal",
         },
         {
           label: "Devoluciones",


### PR DESCRIPTION
## Summary

Review and improvement of the **Responsable de Ventas** dashboard template (`dashboard/lib/templates/ventas.ts`) per issue #414. Changes are validated against the live Postgres mirror over `2026-03-25..2026-04-24` (last 30 days).

### Key fixes
- **New KPIs** specific to the retail-sales-manager role (B-Ventas):
  - **Unidades por Ticket** — `SUM(unidades) / COUNT(DISTINCT reg_ventas)` with `NULLIF` div-by-zero guard.
  - **% Devoluciones** — devoluciones / (ventas + |devoluciones|) * 100. `inverted: true` so the renderer flags rising values as bad.
  - **Ventas YoY %** — same period one year prior, using the `:curr_*::date - INTERVAL '1 year'` pattern that templates.test.ts already enforces in general.ts.
  - **Devoluciones** flagged with `inverted: true` (rising = bad) per the D-022 / dashboard-redesign skill.
- **Formas de Pago donut**: added `p."entrada" = true` (matches knowledge.ts line 615) so refund pseudo-formas (`"Devolución Vale"`, `"Devolución Metálico"`) don't pollute the cobro mix. Verified two flows pre/post fix.
- **Tendencia Semanal → Tendencia Diaria**: weekly trunc produces 4-5 points in the default 30-day range; daily produces ~30 useful datapoints. `:curr_from`/`:curr_to` already keep the time picker driving it.
- **Top Artículos table**: column renamed `Ventas Netas` → `Ventas Netas (€)` so the user knows the unit (TableWidget doesn't auto-format currency, only `%`).
- **Header docstring** rewrites the business decisions explicitly: tienda 99 exclusion, entrada=true definition of ventas netas, `total_si > 0` margin filter, marketplace/web consolidation note (`pedido_web` is essentially empty in current data — see verification below), IVA exclusion via `_si` suffix.
- **Inline comments** on every non-obvious decision (NULLIF, ABS, inverted, `total_si > 0` exclusion, daily bucketing, etc.).

## Verified (SQL evidence against Postgres mirror, range 2026-03-25..2026-04-24)

| KPI | Result |
|-----|--------|
| Ventas Netas | 255.686,81 € |
| Tickets | 9.835 |
| Ticket Medio | 26,00 € |
| Unidades por Ticket | 1,69 |
| Devoluciones | 22.606,17 € |
| % Devoluciones | 8,1 % |
| Ventas YoY % | +11,2 % (curr 255k vs prev 230k) |

- **Token consistency** — every widget that should react to the time picker carries `:curr_from`/`:curr_to`; `__gf_tienda__` is on every widget; `__gf_familia__/temporada/marca/sexo/departamento` only on widgets that join `ps_articulos` (margen and top artículos), as designed in `template-global-filters.ts`.
- **Donut** sanity-checked — pre-fix included `"Devolución Vale"` + `"Devolución Metálico"`, post-fix returns the 9 actual cobro formas only.
- **Tienda mismatch** between `ps_pagos_ventas.tienda` and `ps_ventas.tienda` (joined via reg_ventas) is **0 rows** in the current 30-day window — keeping both filters as defense-in-depth.
- **Filter coverage**: `templateGlobalFiltersRetail` already exports `tienda, familia, temporada, marca, sexo, departamento` — no missing tokens. `proveedor` is intentionally excluded from the retail set (purchasing-only).
- **SQL heuristics + Zod** — `lintDashboardSpec` clean; `templates.test.ts` (139 tests) all pass.

## Needs human / browser verification

These items in the B-extended checklist (B1–B20) and the 8-point checklist need a human or a Playwright run because they exercise UI behaviour, not SQL:

- **B1** Empty-state, error fallback, skeleton — render-time only.
- **B5** Tooltips per KPI — the schema doesn't yet support `tooltip` on KPI items; would be a separate spec extension.
- **B6** Per-widget < 3 s budget — measure in browser Network tab.
- **B8** ETL freshness banner — D-020 surface, not template-level.
- **B9 / B10 / B16 / B17** Visual / responsive / accessibility checks.
- **B12** Click-through drill-down (chart/table → filtered view).
- **B13** CSV export, URL state preservation, PNG capture.
- **B14** E2E (Playwright) load-the-template-and-assert-each-widget-renders test.
- **B-Ventas: ranking individual de vendedor/a** — `cajero_nombre` is a single value (`Cajero 01`) for ~99,3 % of tickets in the current 30-day window; not useful as a breakdown right now. Will track as a separate issue if real cashier data lands.
- **B-Ventas: comparativa vs objetivo** — no `objetivos` table in the mirror. Out of scope until ETL exposes it.
- **B-Ventas: heat map hora / día** — `ps_ventas.fecha_creacion` is `date` (no time), so hour-of-day breakdown isn't possible until we mirror a timestamp column.

Issue #420 (filter↔widget spacing, donut layout, LLM widget-selection prompt) and #419 (CLI agentic exit-code-1) are explicitly out of scope and tracked separately.

## Test plan

- [x] `npx vitest run lib/__tests__/templates.test.ts lib/__tests__/template-global-filters.test.ts lib/__tests__/schema.test.ts` → 139/139 pass.
- [x] `npx tsc --noEmit -p tsconfig.typecheck.json` → clean.
- [x] Full `npm test` baseline: 1362/1364 pass; the 2 failures are in `lib/__tests__/llm-usage.test.ts` (`checkDailyBudget`) and exist on `main` before this change (verified by stashing).
- [ ] Browser smoke: load the template at `localhost:4000`, run the time-picker presets (today / 7d / 30d / month / YTD), apply filter combos, confirm every widget responds.
- [ ] Drill-down "Analizar con IA" payload check (Network tab) per B-checklist item 8.

Refs #414, #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)