### PR TITLE
fix(dashboard/templates): mayorista template review (issue #416)

### DIFF
--- a/dashboard/lib/__tests__/templates.test.ts
+++ b/dashboard/lib/__tests__/templates.test.ts
@@ -164,3 +164,47 @@ describe("SQL rule compliance across all templates", () => {
     expect(sql).toMatch(/:curr_to::date\s*-\s*INTERVAL\s+'1 year'/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Mayorista-specific invariants (issue #416)
+// ---------------------------------------------------------------------------
+
+describe("template 'mayorista' wholesale-channel invariants", () => {
+  const mayorista = TEMPLATES.find((t) => t.slug === "mayorista");
+  if (!mayorista) {
+    throw new Error("mayorista template not registered in TEMPLATES");
+  }
+  const allSql = collectWidgetSqlStrings(mayorista.spec);
+
+  it("never joins ps_gc_lin_facturas to ps_gc_facturas on n_factura (must use reg_factura)", () => {
+    // Regression guard: the line.num_<parent> column matches the header's
+    // record id (reg_*), not the human number n_*. Joining on n_factura is
+    // a silent zero-row bug — see mayorista.ts header comment.
+    for (const sql of allSql) {
+      expect(
+        sql,
+        "join key for ps_gc_lin_facturas must be num_factura = reg_factura, never n_factura",
+      ).not.toMatch(/lf\."?num_factura"?\s*=\s*f\."?n_factura"?/);
+    }
+  });
+
+  it("does not filter GC widgets by ccrefejofacm M-prefix (channel is table-defined)", () => {
+    // Wholesale data lives in ps_gc_* by definition; adding `ccrefejofacm
+    // LIKE 'M%'` here would drop ~96% of legitimate wholesale invoice
+    // lines, since most reference retail-coded articles. See header
+    // comment in mayorista.ts.
+    for (const sql of allSql) {
+      expect(sql).not.toMatch(/ccrefejofacm.+LIKE\s+'M%'/i);
+      expect(sql).not.toMatch(/codigo\s+LIKE\s+'M%'/i);
+    }
+  });
+
+  it("never invokes the int16 stock decoder on GC quantity columns (D-017)", () => {
+    // The signed-int16 word decode applies only to Exportaciones.Stock1..34;
+    // GC line quantities (unidades / total / total_coste) are 4D Reals and
+    // can exceed 32767 legitimately.
+    for (const sql of allSql) {
+      expect(sql).not.toMatch(/decode_signed_int16_word/i);
+    }
+  });
+});

--- a/dashboard/lib/__tests__/templates.test.ts
+++ b/dashboard/lib/__tests__/templates.test.ts
@@ -176,15 +176,61 @@ describe("template 'mayorista' wholesale-channel invariants", () => {
   }
   const allSql = collectWidgetSqlStrings(mayorista.spec);
 
-  it("never joins ps_gc_lin_facturas to ps_gc_facturas on n_factura (must use reg_factura)", () => {
+  it("never joins line.num_<parent> against header.n_<parent> for any GC alias/order", () => {
     // Regression guard: the line.num_<parent> column matches the header's
-    // record id (reg_*), not the human number n_*. Joining on n_factura is
-    // a silent zero-row bug — see mayorista.ts header comment.
+    // record id (reg_*), not the human number n_*. Joining on n_<parent>
+    // is a silent zero-row bug — see mayorista.ts header comment.
+    //
+    // We test BOTH orderings (line.num=header.n AND header.n=line.num)
+    // and accept ANY alias (one or more letters), so a future widget
+    // that aliases ps_gc_facturas as `g`, `gf`, `hdr`, etc. is still
+    // covered. We also accept arbitrary whitespace and the optional
+    // double-quoted variant for each identifier.
+    const FORBIDDEN_PARENTS = ["factura", "albaran", "pedido"];
     for (const sql of allSql) {
-      expect(
-        sql,
-        "join key for ps_gc_lin_facturas must be num_factura = reg_factura, never n_factura",
-      ).not.toMatch(/lf\."?num_factura"?\s*=\s*f\."?n_factura"?/);
+      for (const parent of FORBIDDEN_PARENTS) {
+        // Order A: <alias>.num_<parent> = <alias>.n_<parent>
+        const re1 = new RegExp(
+          String.raw`\b[A-Za-z_][A-Za-z0-9_]*\."?num_${parent}"?\s*=\s*[A-Za-z_][A-Za-z0-9_]*\."?n_${parent}"?\b`,
+          "i",
+        );
+        // Order B: <alias>.n_<parent> = <alias>.num_<parent>
+        const re2 = new RegExp(
+          String.raw`\b[A-Za-z_][A-Za-z0-9_]*\."?n_${parent}"?\s*=\s*[A-Za-z_][A-Za-z0-9_]*\."?num_${parent}"?\b`,
+          "i",
+        );
+        expect(
+          sql,
+          `join key for ps_gc_lin_${parent}s must be num_${parent} = reg_${parent}, never n_${parent} (any alias/order)`,
+        ).not.toMatch(re1);
+        expect(
+          sql,
+          `join key for ps_gc_lin_${parent}s must be num_${parent} = reg_${parent}, never n_${parent} (any alias/order)`,
+        ).not.toMatch(re2);
+      }
+    }
+  });
+
+  it("aggregates base1+base2+base3 NULL-safely (COALESCE-wrapped inside SUM)", () => {
+    // Regression guard: ps_gc_facturas.base1/2/3 are nullable in the
+    // schema (numeric(15,2), no NOT NULL). A bare `SUM(base1+base2+base3)`
+    // drops the entire row from the aggregate when ANY of the three is
+    // NULL (PG's + propagates NULL → SUM ignores NULL row contributions).
+    // Every base-arithmetic SUM in the mayorista template must wrap each
+    // base in COALESCE(..., 0). See Opus review #425.
+    for (const sql of allSql) {
+      const sumMatches = sql.match(
+        /SUM\s*\([^()]*(?:\([^()]*\)[^()]*)*base1[^()]*(?:\([^()]*\)[^()]*)*base2[^()]*(?:\([^()]*\)[^()]*)*base3[^()]*\)/gi,
+      );
+      if (!sumMatches) continue;
+      for (const m of sumMatches) {
+        for (const col of ["base1", "base2", "base3"]) {
+          expect(
+            m,
+            `SUM expression must COALESCE ${col} to 0 (NULL-safe): "${m.trim()}"`,
+          ).toMatch(new RegExp(String.raw`COALESCE\s*\([^)]*${col}[^)]*\)`, "i"));
+        }
+      }
     }
   });
 

--- a/dashboard/lib/template-global-filters.ts
+++ b/dashboard/lib/template-global-filters.ts
@@ -162,21 +162,35 @@ const PROVEEDOR_COMPRAS: GlobalFilter = {
   bind_expr: `co."num_proveedor"`,
 };
 
-/** Cliente mayorista — binds to ps_gc_facturas.num_cliente via alias `f`. */
+/**
+ * Cliente mayorista — binds to ps_gc_facturas.num_cliente via alias `f`.
+ *
+ * NOTE: ps_clientes.nombre is sourced from 4D's NombreComercial (commercial
+ * name) which is empty for ~98% of customers in the wholesale book. We
+ * therefore COALESCE down to nif (tax ID) and then to a synthetic
+ * "Cliente <num>" label so the filter dropdown actually contains every
+ * customer that has invoices in the picker range, not just the ~1-2 that
+ * happen to have NombreComercial populated.
+ *
+ * Widgets that want to use this filter MUST alias ps_gc_facturas (or any
+ * GC table that exposes `num_cliente`) as `f` so that `bind_expr` matches.
+ */
 const CLIENTE_MAYORISTA: GlobalFilter = {
   id: "cliente_mayorista",
   type: "multi_select",
   label: "Cliente Mayorista",
   bind_expr: `f."num_cliente"`,
   value_type: "numeric",
-  options_sql: `SELECT c."reg_cliente" AS value, c."nombre" AS label
+  options_sql: `SELECT c."reg_cliente" AS value,
+       COALESCE(NULLIF(TRIM(c."nombre"), ''),
+                NULLIF(TRIM(c."nif"), ''),
+                'Cliente ' || (c."num_cliente")::text) AS label
 FROM "public"."ps_clientes" c
 JOIN "public"."ps_gc_facturas" gf ON gf."num_cliente" = c."reg_cliente"
-WHERE c."nombre" IS NOT NULL AND c."nombre" <> ''
-  AND gf."abono" = false
+WHERE gf."abono" = false
   AND gf."fecha_factura" >= :curr_from
   AND gf."fecha_factura" <= :curr_to
-GROUP BY c."reg_cliente", c."nombre"
+GROUP BY c."reg_cliente", c."nombre", c."nif", c."num_cliente"
 ORDER BY 2`,
 };
 

--- a/dashboard/lib/templates/mayorista.ts
+++ b/dashboard/lib/templates/mayorista.ts
@@ -2,7 +2,45 @@
  * Template: Director Mayorista
  *
  * Wholesale channel: invoicing KPIs, breakdown by sales rep, top clients,
- * recent delivery notes, and period comparison.
+ * pending orders (with aging), recent delivery notes, top products and
+ * monthly trend.
+ *
+ * ## Channel discipline (read before changing the SQL)
+ *
+ * The retail vs wholesale separation in PowerShop is enforced AT THE TABLE
+ * LEVEL: every `ps_gc_*` table holds wholesale data only and `ps_ventas` /
+ * `ps_lineas_ventas` hold retail data only. The often-cited
+ * `ccrefejofacm LIKE 'M%'` rule is a *retail-side* filter to drop wholesale
+ * articles that drift into ps_articulos — it is **not** a primary key for
+ * channel selection, and applying it to GC lines drops ~96% of legitimate
+ * wholesale invoice rows. So: do **not** add `ccrefejofacm LIKE 'M%'` (or
+ * any equivalent codigo prefix predicate) to the GC widgets below.
+ *
+ * ## Quantity decoder reminder (D-017)
+ *
+ * `GCLin*` line quantities (e.g. ps_gc_lin_facturas.unidades, .total,
+ * .total_coste) come from 4D Real columns and can legitimately exceed
+ * 32767. The signed-int16 decoder applies *only* to
+ * Exportaciones.Stock1..Stock34 and must NOT be invoked here.
+ *
+ * ## Foreign-key gotcha
+ *
+ * The line-to-header join in the GC tables is
+ *   `ps_gc_lin_facturas.num_factura  = ps_gc_facturas.reg_factura`
+ *   `ps_gc_lin_albarane.num_albaran  = ps_gc_albaranes.reg_albaran`
+ *   `ps_gc_lin_pedidos.num_pedido    = ps_gc_pedidos.reg_pedido`
+ * i.e. the line `num_<parent>` matches the header's record id (`reg_*`),
+ * NOT the human-friendly `n_<parent>` number. Joining on `n_*` returns
+ * zero rows and silently produces NULL margins.
+ *
+ * ## Customer name fallback
+ *
+ * `ps_clientes.nombre` mirrors 4D's NombreComercial column, which is empty
+ * for the majority of wholesale customers (only ~2% populated). We
+ * COALESCE down to nif and then to a synthetic "Cliente <num>" label so
+ * the user sees stable, distinct rows in tables and the global filter
+ * dropdown.
+ *
  * All date filters use :curr_from / :curr_to tokens set by the date picker.
  */
 import type { DashboardSpec } from "@/lib/schema";
@@ -12,6 +50,15 @@ export const name = "Director Mayorista";
 
 export const description =
   "Panel para el director del canal mayorista: facturacion neta, margen, desglose por comercial, top clientes, pedidos pendientes, albaranes recientes, top productos y comparativa mensual.";
+
+/**
+ * Reusable SQL fragment: customer label with NombreComercial → NIF →
+ * synthetic fallback. Inline as a SELECT expression where `c` is aliased
+ * to ps_clientes.
+ */
+const CLIENTE_LABEL = `COALESCE(NULLIF(TRIM(c."nombre"), ''),
+                NULLIF(TRIM(c."nif"), ''),
+                'Cliente ' || (c."num_cliente")::text)`;
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Mayorista",
@@ -44,15 +91,26 @@ WHERE f."abono" = false
           format: "number",
         },
         {
+          // Margen % at the line level. We LEFT JOIN ps_articulos / ps_familias
+          // so that lines whose codigo does not resolve to a current article
+          // (~4% in production) still contribute to the aggregate. The filter
+          // joins are only INNER-effective when the user picks a value, since
+          // an unmatched LEFT JOIN row has NULL on the bind_expr column and
+          // `__gf_*__ = ANY(:gf_*)` evaluates to NULL → filtered out only
+          // when the filter is active. Result: TRUE-token (no selection)
+          // keeps all lines; selecting a familia/marca/temporada filters as
+          // expected.
+          //
+          // Join key: lf.num_factura = f.reg_factura (NOT f.n_factura).
           label: "Margen Mayorista",
           sql: `SELECT ROUND(
   (SUM(lf."total") - SUM(lf."total_coste"))
   / NULLIF(SUM(lf."total"), 0) * 100, 1
 ) AS value
 FROM "public"."ps_gc_lin_facturas" lf
-JOIN "public"."ps_gc_facturas" f ON lf."num_factura" = f."n_factura"
-JOIN "public"."ps_articulos" p ON lf."codigo" = p."codigo"
-JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
+JOIN "public"."ps_gc_facturas" f ON lf."num_factura" = f."reg_factura"
+LEFT JOIN "public"."ps_articulos" p ON lf."codigo" = p."codigo"
+LEFT JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
 WHERE lf."total" > 0
   AND f."abono" = false
   AND f."fecha_factura" >= :curr_from
@@ -64,7 +122,7 @@ WHERE lf."total" > 0
           format: "percent",
         },
         {
-          label: "Clientes Activos (período seleccionado)",
+          label: "Clientes Activos",
           sql: `SELECT COUNT(DISTINCT f."num_cliente") AS value
 FROM "public"."ps_gc_facturas" f
 WHERE f."abono" = false
@@ -76,29 +134,34 @@ WHERE f."abono" = false
       ],
     },
     {
+      // LEFT JOIN ps_gc_comerciales so invoices with num_comercial = 0 (the
+      // unassigned default in this dataset) still surface, labelled
+      // "(Sin comercial asignado)", instead of vanishing from the chart.
       id: "mayorista-por-comercial",
       type: "bar_chart",
-      title: "Facturacion por Comercial (período seleccionado)",
-      sql: `SELECT c."comercial" AS label,
+      title: "Facturacion por Comercial",
+      sql: `SELECT COALESCE(NULLIF(TRIM(c."comercial"), ''),
+                '(Sin comercial asignado)') AS label,
        SUM(f."base1" + f."base2" + f."base3") AS value
 FROM "public"."ps_gc_facturas" f
-JOIN "public"."ps_gc_comerciales" c ON f."num_comercial" = c."reg_comercial"
+LEFT JOIN "public"."ps_gc_comerciales" c ON f."num_comercial" = c."reg_comercial"
 WHERE f."abono" = false
   AND f."fecha_factura" >= :curr_from
   AND f."fecha_factura" <= :curr_to
   AND __gf_cliente_mayorista__
-GROUP BY c."comercial"
+GROUP BY 1
 ORDER BY value DESC`,
       x: "label",
       y: "value",
     },
     {
+      // Top 10 clientes — facturacion neta + margen.
+      // Using the corrected line-to-header join lf.num_factura = f.reg_factura.
       id: "mayorista-top-clientes",
       type: "table",
-      title: "Top 10 Clientes Mayorista (período seleccionado)",
+      title: "Top 10 Clientes Mayorista",
       sql: `WITH facturas_periodo AS (
   SELECT f."reg_factura",
-         f."n_factura",
          f."num_cliente",
          (f."base1" + f."base2" + f."base3") AS neto
   FROM "public"."ps_gc_facturas" f
@@ -111,71 +174,96 @@ ORDER BY value DESC`,
          SUM(lf."total")       AS total_ingreso,
          SUM(lf."total_coste") AS total_coste
   FROM "public"."ps_gc_lin_facturas" lf
-  WHERE lf."num_factura" IN (SELECT "n_factura" FROM facturas_periodo)
+  WHERE lf."num_factura" IN (SELECT "reg_factura" FROM facturas_periodo)
   GROUP BY lf."num_factura"
 )
-SELECT c."nombre" AS "Cliente",
+SELECT ${CLIENTE_LABEL} AS "Cliente",
        COUNT(DISTINCT fy."reg_factura") AS "Facturas",
        SUM(fy.neto) AS "Facturacion Neta",
        ROUND((SUM(m.total_ingreso) - SUM(m.total_coste))
-         / NULLIF(SUM(m.total_ingreso), 0) * 100, 1) AS "Margen %"
+         / NULLIF(SUM(m.total_ingreso), 0) * 100, 1) AS "Margen %",
+       MAX(c."ultima_compra_f") AS "Última Compra"
 FROM facturas_periodo fy
 JOIN "public"."ps_clientes" c ON fy."num_cliente" = c."reg_cliente"
-LEFT JOIN margenes m ON m."num_factura" = fy."n_factura"
-GROUP BY c."nombre"
+LEFT JOIN margenes m ON m."num_factura" = fy."reg_factura"
+GROUP BY c."reg_cliente", c."nombre", c."nif", c."num_cliente"
 ORDER BY "Facturacion Neta" DESC
 LIMIT 10`,
     },
     {
+      // Pedidos pendientes con AGING (días desde emisión).
+      //
+      // This widget intentionally does NOT filter by :curr_from/:curr_to —
+      // a wholesale director needs to see the full pending backlog,
+      // independent of the time-picker. It DOES still react to
+      // __gf_cliente_mayorista__ (we alias ps_gc_pedidos as `f` so the
+      // filter's `bind_expr = f."num_cliente"` resolves).
       id: "mayorista-pedidos-pendientes",
       type: "table",
-      title: "Pedidos Pendientes de Entregar",
-      sql: `SELECT c."nombre" AS "Cliente",
-       gp."n_pedido" AS "Pedido",
-       gp."fecha_pedido" AS "Fecha",
-       gp."unidades" AS "Pedidas",
-       gp."entregadas" AS "Entregadas",
-       gp."pendientes" AS "Pendientes",
-       gp."temporada" AS "Temporada"
-FROM "public"."ps_gc_pedidos" gp
-JOIN "public"."ps_clientes" c ON gp."num_cliente" = c."reg_cliente"
-WHERE gp."pedido_cerrado" = false
-  AND gp."abono" = false
-  AND gp."pendientes" > 0
-ORDER BY gp."fecha_pedido" DESC
+      title: "Pedidos Pendientes (con aging)",
+      sql: `SELECT ${CLIENTE_LABEL} AS "Cliente",
+       (f."n_pedido")::bigint AS "Pedido",
+       f."fecha_pedido" AS "Fecha",
+       (CURRENT_DATE - f."fecha_pedido")::int AS "Días",
+       f."unidades" AS "Pedidas",
+       f."entregadas" AS "Entregadas",
+       f."pendientes" AS "Pendientes",
+       ROUND(COALESCE(f."entregadas", 0)
+             / NULLIF(f."unidades", 0) * 100, 1) AS "% Cumplimiento",
+       f."temporada" AS "Temporada"
+FROM "public"."ps_gc_pedidos" f
+JOIN "public"."ps_clientes" c ON f."num_cliente" = c."reg_cliente"
+WHERE f."pedido_cerrado" = false
+  AND f."abono" = false
+  AND COALESCE(f."pendientes", 0) > 0
+  AND __gf_cliente_mayorista__
+ORDER BY (CURRENT_DATE - f."fecha_pedido") DESC,
+         f."pendientes" DESC
 LIMIT 20`,
     },
     {
+      // Recent albaranes. ps_gc_albaranes is aliased as `f` so the cliente
+      // filter (bind_expr = f."num_cliente") applies.
       id: "mayorista-albaranes-recientes",
       type: "table",
-      title: "Albaranes Recientes (período seleccionado)",
-      sql: `SELECT a."n_albaran" AS "Albaran",
-       c."nombre" AS "Cliente",
-       a."entregadas" AS "Unidades",
-       (a."base1" + a."base2" + a."base3") AS "Importe Neto",
-       a."fecha_envio" AS "Fecha"
-FROM "public"."ps_gc_albaranes" a
-JOIN "public"."ps_clientes" c ON a."num_cliente" = c."reg_cliente"
-WHERE a."abono" = false
-  AND a."fecha_envio" >= :curr_from
-  AND a."fecha_envio" <= :curr_to
-ORDER BY a."fecha_envio" DESC
+      title: "Albaranes Recientes",
+      sql: `SELECT (f."n_albaran")::bigint AS "Albarán",
+       ${CLIENTE_LABEL} AS "Cliente",
+       f."fecha_envio" AS "Fecha",
+       f."entregadas" AS "Unidades",
+       (COALESCE(f."base1",0) + COALESCE(f."base2",0)
+        + COALESCE(f."base3",0)) AS "Importe Neto"
+FROM "public"."ps_gc_albaranes" f
+JOIN "public"."ps_clientes" c ON f."num_cliente" = c."reg_cliente"
+WHERE f."abono" = false
+  AND f."fecha_envio" >= :curr_from
+  AND f."fecha_envio" <= :curr_to
+  AND __gf_cliente_mayorista__
+ORDER BY f."fecha_envio" DESC, f."reg_albaran" DESC
 LIMIT 20`,
     },
     {
+      // Top 10 productos vendidos en el canal mayorista.
+      // LEFT JOIN ps_articulos / ps_familias (see KPI Margen comment for
+      // rationale on why this is LEFT, not INNER).
+      // Join key: lf.num_factura = f.reg_factura.
       id: "mayorista-top-productos",
       type: "table",
-      title: "Top 10 Productos Mayorista (período seleccionado)",
-      sql: `SELECT p."ccrefejofacm" AS "Referencia",
-       p."descripcion" AS "Descripción",
+      title: "Top 10 Productos Mayorista",
+      sql: `SELECT COALESCE(NULLIF(TRIM(p."ccrefejofacm"), ''),
+                NULLIF(TRIM(lf."codigo"), ''),
+                '—') AS "Referencia",
+       COALESCE(NULLIF(TRIM(p."descripcion"), ''),
+                NULLIF(TRIM(lf."descripcion"), ''),
+                '—') AS "Descripción",
        SUM(lf."unidades") AS "Unidades",
        SUM(lf."total") AS "Importe",
        ROUND((SUM(lf."total") - SUM(lf."total_coste"))
          / NULLIF(SUM(lf."total"), 0) * 100, 1) AS "Margen %"
 FROM "public"."ps_gc_lin_facturas" lf
-JOIN "public"."ps_gc_facturas" f ON lf."num_factura" = f."n_factura"
-JOIN "public"."ps_articulos" p ON lf."codigo" = p."codigo"
-JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
+JOIN "public"."ps_gc_facturas" f ON lf."num_factura" = f."reg_factura"
+LEFT JOIN "public"."ps_articulos" p ON lf."codigo" = p."codigo"
+LEFT JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
 WHERE f."abono" = false
   AND lf."unidades" > 0
   AND f."fecha_factura" >= :curr_from
@@ -184,23 +272,37 @@ WHERE f."abono" = false
   AND __gf_familia__
   AND __gf_temporada__
   AND __gf_marca__
-GROUP BY p."ccrefejofacm", p."descripcion"
+GROUP BY 1, 2
 ORDER BY "Importe" DESC
 LIMIT 10`,
     },
     {
+      // Tendencia mensual con un mínimo de 12 meses de contexto.
+      //
+      // The chart anchors to :curr_to and shows AT LEAST the last 12 months
+      // ending there. If the user picks a wider time-picker range than 12
+      // months, the chart expands to cover :curr_from..:curr_to instead —
+      // we accomplish that with `LEAST(:curr_from::date, anchor_12m_back)`.
+      // A narrow time-picker (e.g. 7 days) therefore still produces a
+      // legible 13-point monthly trend, while a 24-month picker shows the
+      // full 24 months.
+      //
+      // Both :curr_from and :curr_to are referenced so the widget honours
+      // the time-picker invariant enforced by templates.test.ts.
       id: "mayorista-comparativa-mensual",
       type: "line_chart",
-      title: "Facturacion Mensual (período seleccionado)",
-      sql: `SELECT DATE_TRUNC('month', f."fecha_factura") AS x,
+      title: "Facturación Mensual (últimos 12 meses o más)",
+      sql: `SELECT DATE_TRUNC('month', f."fecha_factura")::date AS x,
        SUM(f."base1" + f."base2" + f."base3") AS y
 FROM "public"."ps_gc_facturas" f
 WHERE f."abono" = false
-  AND f."fecha_factura" >= :curr_from
+  AND f."fecha_factura" >= LEAST(
+        :curr_from::date,
+        (DATE_TRUNC('month', :curr_to::date) - INTERVAL '12 months')::date)
   AND f."fecha_factura" <= :curr_to
   AND __gf_cliente_mayorista__
-GROUP BY DATE_TRUNC('month', f."fecha_factura")
-ORDER BY x`,
+GROUP BY 1
+ORDER BY 1`,
       x: "x",
       y: "y",
     },

--- a/dashboard/lib/templates/mayorista.ts
+++ b/dashboard/lib/templates/mayorista.ts
@@ -53,12 +53,17 @@ export const description =
 
 /**
  * Reusable SQL fragment: customer label with NombreComercial → NIF →
- * synthetic fallback. Inline as a SELECT expression where `c` is aliased
- * to ps_clientes.
+ * synthetic-num → static fallback. Inline as a SELECT expression where
+ * `c` is aliased to ps_clientes.
+ *
+ * The final 'Cliente desconocido' fallback guarantees the expression is
+ * NEVER NULL even if num_cliente is itself NULL (which would make the
+ * `'Cliente ' || num_cliente::text` arm collapse to NULL).
  */
 const CLIENTE_LABEL = `COALESCE(NULLIF(TRIM(c."nombre"), ''),
                 NULLIF(TRIM(c."nif"), ''),
-                'Cliente ' || (c."num_cliente")::text)`;
+                NULLIF('Cliente ' || COALESCE(c."num_cliente"::text, ''), 'Cliente '),
+                'Cliente desconocido')`;
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Mayorista",
@@ -71,7 +76,14 @@ export const spec: DashboardSpec = {
       items: [
         {
           label: "Facturacion Neta",
-          sql: `SELECT COALESCE(SUM(f."base1" + f."base2" + f."base3"), 0) AS value
+          // NULL-safe per-base COALESCE inside SUM so that if a single
+          // base column is NULL (schema allows it; current data has none)
+          // the row still contributes its non-null bases instead of being
+          // silently dropped from the aggregate. Outer COALESCE handles
+          // the empty-result case.
+          sql: `SELECT COALESCE(SUM(COALESCE(f."base1", 0)
+                  + COALESCE(f."base2", 0)
+                  + COALESCE(f."base3", 0)), 0) AS value
 FROM "public"."ps_gc_facturas" f
 WHERE f."abono" = false
   AND f."fecha_factura" >= :curr_from
@@ -142,7 +154,9 @@ WHERE f."abono" = false
       title: "Facturacion por Comercial",
       sql: `SELECT COALESCE(NULLIF(TRIM(c."comercial"), ''),
                 '(Sin comercial asignado)') AS label,
-       SUM(f."base1" + f."base2" + f."base3") AS value
+       SUM(COALESCE(f."base1", 0)
+           + COALESCE(f."base2", 0)
+           + COALESCE(f."base3", 0)) AS value
 FROM "public"."ps_gc_facturas" f
 LEFT JOIN "public"."ps_gc_comerciales" c ON f."num_comercial" = c."reg_comercial"
 WHERE f."abono" = false
@@ -163,7 +177,9 @@ ORDER BY value DESC`,
       sql: `WITH facturas_periodo AS (
   SELECT f."reg_factura",
          f."num_cliente",
-         (f."base1" + f."base2" + f."base3") AS neto
+         (COALESCE(f."base1", 0)
+          + COALESCE(f."base2", 0)
+          + COALESCE(f."base3", 0)) AS neto
   FROM "public"."ps_gc_facturas" f
   WHERE f."abono" = false
     AND f."fecha_factura" >= :curr_from
@@ -293,7 +309,9 @@ LIMIT 10`,
       type: "line_chart",
       title: "Facturación Mensual (últimos 12 meses o más)",
       sql: `SELECT DATE_TRUNC('month', f."fecha_factura")::date AS x,
-       SUM(f."base1" + f."base2" + f."base3") AS y
+       SUM(COALESCE(f."base1", 0)
+           + COALESCE(f."base2", 0)
+           + COALESCE(f."base3", 0)) AS y
 FROM "public"."ps_gc_facturas" f
 WHERE f."abono" = false
   AND f."fecha_factura" >= LEAST(


### PR DESCRIPTION
Refs #416, #413

## Summary

Reviewed the Director Mayorista template by substituting `:curr_from`/`:curr_to` (last 30 days) and global-filter tokens (TRUE) into every widget and running the resulting SQL against the production-mirror Postgres. Several real bugs surfaced and are fixed in this PR.

### Critical fixes (Verified)

- **Wrong join key on every line→header GC join.** `ps_gc_lin_facturas.num_factura` matches `ps_gc_facturas.reg_factura`, **not** `n_factura`. The previous code joined on `n_factura` and silently returned zero rows: KPI Margen and the Margen % column in Top Clientes were always NULL, and Top Productos was effectively unable to compute margin.
- **INNER JOIN to `ps_articulos`/`ps_familias` skewed margen from 24.7 % to 1.6 %** — ~263 of 6 700 recent lines have no matching `ps_familias.reg_familia`, and those drop ~62 % of revenue when the join is INNER. Switched to LEFT JOIN; the global filters keep working because `__gf_familia__` evaluates to NULL on unmatched rows when the filter is active and to TRUE (no-op) when it is not.
- **Cliente filter dropdown showed ~1 customer.** `ps_clientes.nombre` (mirrors 4D `NombreComercial`) is empty for ~98 % of wholesale customers, but the filter required `nombre <> ''`. Switched the options query to `COALESCE(nombre → nif → "Cliente <num>")` and applied the same fallback in every customer-facing widget. The filter dropdown now contains every customer with invoices in the picker range (40 customers in the 30-day test slice).

### Coverage and UX fixes (Verified)

- **Pedidos Pendientes** gains an aging column (`CURRENT_DATE - fecha_pedido`) and a `% Cumplimiento` column. Sorted oldest-first. Respects `__gf_cliente_mayorista__`. Time-picker is intentionally not applied — the wholesale director needs the full pending backlog regardless of range. (Documented inline.)
- **Albaranes Recientes** and **Comparativa Mensual** now apply `__gf_cliente_mayorista__` (previously ignored).
- **Comparativa Mensual** was capped at the rest-of-dashboard window, so a 30-day picker reduced the chart to 1–2 points. Now anchored to the last 12 months ending at `:curr_to` (auto-expanding if the picker covers more than 12 months). Both `:curr_from` and `:curr_to` are referenced via `LEAST(...)` so the time-picker invariant in `templates.test.ts` is honoured.
- **"Por Comercial" bar chart** used INNER JOIN to `ps_gc_comerciales`, and 99.99 % of facturas in this dataset have `num_comercial = 0`, so the chart was empty. Switched to LEFT JOIN with a labelled fallback `(Sin comercial asignado)` so channel volume remains visible. Logging the actual data gap as a Mayorista business issue rather than hiding it.
- `n_pedido`/`n_albaran` cast to `bigint` so tables show `"1234"` instead of `"1234.000"`.
- Albaranes "Importe Neto" wraps `base1+base2+base3` in `COALESCE` to avoid silent NULL-propagated zeros.

### Documentation (Verified)

- File header now spells out: (a) wholesale-channel discipline — channel is defined by the `ps_gc_*` table, **NOT** by a `ccrefejofacm LIKE 'M%'` filter, which would drop ~96 % of GC rows; (b) D-017's int16 decoder is NEVER applied to `GCLin*` quantities; (c) the line→header join key gotcha (`num_<parent>` matches `reg_*`, not `n_*`).
- Three regression tests in `templates.test.ts`:
  1. Forbid `lf.num_factura = f.n_factura` joins.
  2. Forbid `ccrefejofacm LIKE 'M%'` / `codigo LIKE 'M%'` predicates inside the mayorista template.
  3. Forbid `decode_signed_int16_word` references in any GC widget SQL.

### Needs browser verification

- Drilldown ("Analizar con IA") payload from the new Top Clientes / Por Comercial widgets — visual smoke test only; no API contract changes.
- Visual rendering of the new aging column and `% Cumplimiento` (numeric format).
- TweaksPanel theme/density unchanged; no new visual chrome.

## Test plan

- [x] `npm test` (vitest run) — 115/115 template-related tests pass; the 2 failing tests in `lib/__tests__/llm-usage.test.ts` are pre-existing on `main` (verified) and unrelated to this PR.
- [x] `npx tsc --noEmit -p tsconfig.typecheck.json` — clean.
- [x] Every widget executed against Postgres with `:curr_from='2026-03-25'`, `:curr_to='2026-04-23'`, all `__gf_*__ = TRUE`. Captured outputs in the issue comment.
- [ ] Manually load template via `http://localhost:4000` → "Crear desde plantilla" → Director Mayorista, verify each widget renders.
- [ ] Cycle through time-picker presets (mes actual, mes anterior, trimestre, YTD) and confirm Comparativa Mensual still shows ≥12 months.
- [ ] Activate cliente / familia / marca / temporada filters individually and confirm widgets respond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)