### PR TITLE
fix(dashboard/templates): stock template review (issue #415)

### DIFF
--- a/dashboard/lib/template-global-filters.ts
+++ b/dashboard/lib/template-global-filters.ts
@@ -180,12 +180,23 @@ GROUP BY c."reg_cliente", c."nombre"
 ORDER BY 2`,
 };
 
-/** Familia for purchasing / stock when there is no ps_ventas scope on the date. */
+/**
+ * Familia for purchasing / stock when there is no ps_ventas scope on the date.
+ *
+ * `bind_expr` and `options_sql` both TRIM `fm."fami_grup_marc"` so filtering
+ * matches the trimmed display value used by stock widgets. Without TRIM,
+ * `ps_familias` rows like "PANTALON " (trailing space) and "PANTALON" appear
+ * as a single deduplicated option in the combobox but selecting it would
+ * otherwise filter only one of the underlying rows — leaving the chart total
+ * inconsistent with the unfiltered chart. See PR #426 review.
+ */
 const FAMILIA_CATALOG: GlobalFilter = {
   ...FAMILIA,
-  options_sql: `SELECT fm."fami_grup_marc" AS value, fm."fami_grup_marc" AS label
+  bind_expr: `TRIM(fm."fami_grup_marc")`,
+  options_sql: `SELECT DISTINCT TRIM(fm."fami_grup_marc") AS value,
+       TRIM(fm."fami_grup_marc") AS label
 FROM "public"."ps_familias" fm
-WHERE fm."fami_grup_marc" IS NOT NULL AND fm."fami_grup_marc" <> ''
+WHERE fm."fami_grup_marc" IS NOT NULL AND TRIM(fm."fami_grup_marc") <> ''
 ORDER BY 1`,
 };
 

--- a/dashboard/lib/templates/stock.ts
+++ b/dashboard/lib/templates/stock.ts
@@ -221,9 +221,11 @@ LIMIT 50`,
       // widget — that widget required tienda='99' rows in ps_stock_tienda
       // (the central warehouse) which do NOT exist in the mirror, so it
       // always returned zero. The list is intentionally large; combine with
-      // the global Temporada / Familia / Marca filters to narrow it down.
+      // the global Tienda / Temporada / Familia / Marca filters to narrow it down.
       // LEFT JOIN ps_stock_tienda so SKUs that have no row at all (never
-      // distributed to stores) are still surfaced.
+      // distributed to stores) are still surfaced. __gf_tienda__ is wired into
+      // the LEFT JOIN ON-clause so selecting a store narrows the meaning to
+      // "no stock in the selected store" without breaking left-join semantics.
       sql: `SELECT
        COALESCE(NULLIF(p."ccrefejofacm", ''), '—') AS "Referencia",
        COALESCE(NULLIF(p."descripcion", ''), '—') AS "Descripción",
@@ -235,6 +237,7 @@ LEFT JOIN "public"."ps_stock_tienda" s
        ON s."codigo" = p."codigo"
       AND s."stock" > 0
       AND s."tienda" <> '99'
+      AND __gf_tienda__
 WHERE p."anulado" = false
   AND __gf_familia__
   AND __gf_temporada__
@@ -269,11 +272,12 @@ WHERE s."stock" > 0
   AND __gf_familia__
   AND __gf_temporada__
   AND __gf_marca__
-  AND p."codigo" NOT IN (
-    SELECT DISTINCT lv."codigo"
+  AND NOT EXISTS (
+    SELECT 1
     FROM "public"."ps_lineas_ventas" lv
     JOIN "public"."ps_ventas" v ON lv."num_ventas" = v."reg_ventas"
-    WHERE v."entrada" = true
+    WHERE lv."codigo" = p."codigo"
+      AND v."entrada" = true
       AND lv."tienda" <> '99'
       AND lv."fecha_creacion" >= :curr_from
       AND lv."fecha_creacion" <= :curr_to

--- a/dashboard/lib/templates/stock.ts
+++ b/dashboard/lib/templates/stock.ts
@@ -1,10 +1,66 @@
 /**
  * Template: Responsable de Stock
  *
- * Stock overview: totals (incl. central warehouse), distribution by store,
- * low-stock alerts, out-of-stock items, stock in central warehouse, recent transfers.
- * Stock KPI totals have no date filter (point-in-time data).
- * Time-filtered queries (transfers, dead-stock lookback) use :curr_from / :curr_to tokens.
+ * Stock overview for the warehouse / inventory manager: point-in-time stock
+ * totals, valuation at cost, distribution by store and family, low-stock and
+ * out-of-stock alerts, dead-stock detection, and recent transfers.
+ *
+ * Business decisions documented in this header (see issue #415):
+ *
+ * 1. **Point-in-time vs windowed.** All stock KPIs and the by-store / by-family
+ *    bar charts are *point-in-time* — they reflect the current state of
+ *    `ps_stock_tienda` and intentionally do **not** apply `:curr_from` /
+ *    `:curr_to`. Only the dead-stock lookback ("sin ventas en período") and
+ *    "Traspasos recientes" widgets react to the date picker.
+ *
+ * 2. **No central-warehouse mirror.** Tienda code `'99'` is the central
+ *    warehouse in PowerShop, but its stock lives in the separate `CCStock`
+ *    4D table which is **not** synced to PostgreSQL. `Exportaciones.CCStock`
+ *    (mirrored as `ps_stock_tienda.cc_stock`) is the **per-row net stock**
+ *    for `(Codigo, TiendaCodigo)` — *not* the central warehouse balance —
+ *    so attempting to pull "Almacén Central" from this table would be
+ *    misleading. We surface a Stock Negativo incidencias KPI instead, and
+ *    document the gap. (See `docs/architecture/stock-logistics.md` and
+ *    `DECISIONS-AND-CHANGES.md` D-017.)
+ *
+ * 3. **Signed-int16 stock (D-017).** `ps_stock_tienda.stock` already passes
+ *    through the ETL `decode_signed_int16_word()` decoder, so negatives from
+ *    POS (e.g. `-1`) appear as negatives, not as `65535`. Verified at review
+ *    time: 9 222 rows with `stock < 0`, range `-122..-1`, 0 rows with
+ *    `stock > 32767`. The "Incidencias Stock Negativo" KPI gives a daily
+ *    sanity check that the decoder is still applied end-to-end.
+ *
+ * 4. **MA-prefix articles.** `ccrefejofacm LIKE 'MA%'` (materials: bags,
+ *    hangers, packaging) are **excluded at ETL load time** — they never
+ *    reach `ps_articulos` or `ps_stock_tienda`, so widgets do not need an
+ *    explicit `NOT LIKE 'MA%'` filter. (See `lib/knowledge.ts`.)
+ *
+ * 5. **Wholesale (M-prefix) articles.** `ccrefejofacm LIKE 'M%'` (without
+ *    'MA') are wholesale references that DO live in `ps_articulos` and may
+ *    carry stock. They are *kept* in this stock dashboard because the
+ *    inventory manager owns physical units regardless of channel; if a
+ *    retail-only view is ever required, add `AND p."ccrefejofacm" NOT LIKE 'M%'`
+ *    or expose it via a dedicated filter.
+ *
+ * 6. **Anulados.** `p."anulado" = false` is required on every widget that
+ *    joins `ps_articulos`; without it ~20% of catalog rows (cancelled SKUs)
+ *    bleed into the totals. The dead-stock subquery does *not* filter
+ *    `anulado` on `ps_lineas_ventas` because that field lives on
+ *    `ps_articulos` and the subquery only needs the `codigo` set.
+ *
+ * 7. **Familia join.** Always `LEFT JOIN ps_familias` (alias `fm`) so SKUs
+ *    whose `num_familia` does not resolve to a `ps_familias` row are still
+ *    counted (~1 254 units / ~4 000 SKUs in the live mirror would be silently
+ *    dropped by an `INNER JOIN`). Familia label is `TRIM`-normalised to
+ *    collapse the duplicate `'PANTALON'` / `'PANTALON '` entries that exist
+ *    in `ps_familias`.
+ *
+ * 8. **Tienda filter on traspasos.** `__gf_tienda__` binds to `s."tienda"`
+ *    via `templateGlobalFiltersStock.TIENDA_STOCK` and therefore cannot be
+ *    applied to `ps_traspasos` rows (which have `tienda_salida` / `tienda_entrada`,
+ *    not `tienda`). The traspasos table is intentionally not filtered by
+ *    the global Tienda combobox; users can still filter it by date via the
+ *    time picker.
  */
 import type { DashboardSpec } from "@/lib/schema";
 import { templateGlobalFiltersStock } from "@/lib/template-global-filters";
@@ -12,7 +68,7 @@ import { templateGlobalFiltersStock } from "@/lib/template-global-filters";
 export const name = "Responsable de Stock";
 
 export const description =
-  "Panel para el responsable de stock: unidades totales, valoracion al coste, distribucion por tienda y familia, stock bajo, dead stock, sin stock y traspasos recientes.";
+  "Panel para el responsable de stock: unidades totales, valoración al coste, distribución por tienda y familia, stock bajo, dead stock, sin stock y traspasos recientes.";
 
 export const spec: DashboardSpec = {
   title: "Cuadro de Mandos — Stock",
@@ -24,32 +80,40 @@ export const spec: DashboardSpec = {
       type: "kpi_row",
       items: [
         {
+          // Point-in-time KPI — no :curr_from/:curr_to filter by design.
+          // Alias ps_stock_tienda as `s` so __gf_tienda__ (bind: s."tienda") resolves.
           label: "Unidades en Tiendas",
-          // Alias ps_stock_tienda as `s` so the __gf_tienda__ token (bound
-          // to `s."tienda"` in templateGlobalFiltersStock) resolves cleanly.
           sql: `SELECT COALESCE(SUM(s."stock"), 0) AS value
 FROM "public"."ps_stock_tienda" s
-WHERE s."stock" > 0 AND s."tienda" <> '99'
+WHERE s."stock" > 0
+  AND s."tienda" <> '99'
   AND __gf_tienda__`,
           format: "number",
         },
         {
-          label: "Unidades en Almacén Central",
-          // Central warehouse (tienda '99') — intentionally ignores the
-          // __gf_tienda__ selection because this KPI measures the almacén
-          // total regardless of which retail tienda the user is focused on.
-          sql: `SELECT COALESCE(SUM("stock"), 0) AS value
-FROM "public"."ps_stock_tienda"
-WHERE "stock" > 0 AND "tienda" = '99'`,
+          // Replaces the previous (broken) "Unidades en Almacén Central" KPI:
+          // tienda='99' rows do not exist in ps_stock_tienda (the central
+          // warehouse stock lives in the un-mirrored CCStock 4D table). This
+          // KPI surfaces the count of rows with negative stock — a direct
+          // health check on the D-017 signed-int16 decoder and on inventory
+          // regularisation pending in POS.
+          label: "Incidencias Stock Negativo",
+          sql: `SELECT COUNT(*) AS value
+FROM "public"."ps_stock_tienda" s
+WHERE s."stock" < 0
+  AND s."tienda" <> '99'
+  AND __gf_tienda__`,
           format: "number",
+          inverted: true,
         },
         {
           label: "Valor Stock al Coste",
-          sql: `SELECT COALESCE(ROUND(SUM(s."stock" * p."precio_coste"), 2), 0) AS value
+          sql: `SELECT COALESCE(ROUND(SUM(s."stock" * COALESCE(p."precio_coste", 0)), 2), 0) AS value
 FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
-LEFT JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
-WHERE s."stock" > 0 AND p."anulado" = false
+WHERE s."stock" > 0
+  AND s."tienda" <> '99'
+  AND p."anulado" = false
   AND __gf_tienda__
   AND __gf_familia__
   AND __gf_temporada__
@@ -62,8 +126,9 @@ WHERE s."stock" > 0 AND p."anulado" = false
           sql: `SELECT COUNT(DISTINCT s."codigo") AS value
 FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
-LEFT JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
-WHERE s."stock" > 0 AND p."anulado" = false
+WHERE s."stock" > 0
+  AND s."tienda" <> '99'
+  AND p."anulado" = false
   AND __gf_tienda__
   AND __gf_familia__
   AND __gf_temporada__
@@ -76,11 +141,15 @@ WHERE s."stock" > 0 AND p."anulado" = false
       id: "stock-por-tienda",
       type: "bar_chart",
       title: "Stock por Tienda (excluye almacén central)",
+      // LEFT JOIN ps_familias so SKUs without a matching family row still count
+      // (~1 254 units would be silently dropped by an INNER JOIN against the
+      // current mirror).
       sql: `SELECT s."tienda" AS label, SUM(s."stock") AS value
 FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
-JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
-WHERE s."stock" > 0 AND s."tienda" <> '99'
+LEFT JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
+WHERE s."stock" > 0
+  AND s."tienda" <> '99'
   AND p."anulado" = false
   AND __gf_tienda__
   AND __gf_familia__
@@ -95,17 +164,23 @@ ORDER BY value DESC`,
       id: "stock-por-familia",
       type: "bar_chart",
       title: "Stock por Familia (unidades, top 10)",
-      sql: `SELECT fm."fami_grup_marc" AS label,
+      // TRIM collapses the duplicate "PANTALON" / "PANTALON " family rows that
+      // exist in ps_familias. LEFT JOIN keeps articles whose num_familia does
+      // not resolve and labels them "Sin clasificar".
+      sql: `SELECT
+       COALESCE(NULLIF(TRIM(fm."fami_grup_marc"), ''), 'Sin clasificar') AS label,
        SUM(s."stock") AS value
 FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
-JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
-WHERE s."stock" > 0 AND p."anulado" = false
+LEFT JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
+WHERE s."stock" > 0
+  AND s."tienda" <> '99'
+  AND p."anulado" = false
   AND __gf_tienda__
   AND __gf_familia__
   AND __gf_temporada__
   AND __gf_marca__
-GROUP BY fm."fami_grup_marc"
+GROUP BY 1
 ORDER BY value DESC
 LIMIT 10`,
       x: "label",
@@ -115,13 +190,18 @@ LIMIT 10`,
       id: "stock-bajo",
       type: "table",
       title: "Artículos con Stock Bajo (< 5 unidades en alguna tienda)",
-      sql: `SELECT s."tienda" AS "Tienda",
-       p."ccrefejofacm" AS "Referencia",
-       p."descripcion" AS "Descripción",
+      // Identifier → ubicación → descripción → cantidad. Familia added so the
+      // manager can scan low-stock items by category. NULL/empty references
+      // surface as "—" instead of leaking through as raw NULL.
+      sql: `SELECT
+       s."tienda" AS "Tienda",
+       COALESCE(NULLIF(p."ccrefejofacm", ''), '—') AS "Referencia",
+       COALESCE(NULLIF(p."descripcion", ''), '—') AS "Descripción",
+       COALESCE(NULLIF(TRIM(fm."fami_grup_marc"), ''), '—') AS "Familia",
        SUM(s."stock") AS "Stock"
 FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
-JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
+LEFT JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
 WHERE s."stock" > 0 AND s."stock" < 5
   AND s."tienda" <> '99'
   AND p."anulado" = false
@@ -129,38 +209,66 @@ WHERE s."stock" > 0 AND s."stock" < 5
   AND __gf_familia__
   AND __gf_temporada__
   AND __gf_marca__
-GROUP BY s."tienda", p."ccrefejofacm", p."descripcion"
-ORDER BY "Stock" ASC
+GROUP BY s."tienda", p."ccrefejofacm", p."descripcion", fm."fami_grup_marc"
+ORDER BY "Stock" ASC, "Tienda" ASC
 LIMIT 50`,
     },
     {
       id: "stock-sin-stock",
       type: "table",
-      title: "Artículos Sin Stock en Tiendas (con stock en almacén)",
-      sql: `SELECT p."ccrefejofacm" AS "Referencia",
-       p."descripcion" AS "Descripción",
-       SUM(CASE WHEN s."tienda" = '99' THEN s."stock" ELSE 0 END) AS "Stock Almacén"
-FROM "public"."ps_stock_tienda" s
-JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
+      title: "Roturas: Artículos activos sin stock en tiendas",
+      // Replaces the broken "Sin Stock en Tiendas (con stock en almacén)"
+      // widget — that widget required tienda='99' rows in ps_stock_tienda
+      // (the central warehouse) which do NOT exist in the mirror, so it
+      // always returned zero. The list is intentionally large; combine with
+      // the global Temporada / Familia / Marca filters to narrow it down.
+      // LEFT JOIN ps_stock_tienda so SKUs that have no row at all (never
+      // distributed to stores) are still surfaced.
+      sql: `SELECT
+       COALESCE(NULLIF(p."ccrefejofacm", ''), '—') AS "Referencia",
+       COALESCE(NULLIF(p."descripcion", ''), '—') AS "Descripción",
+       COALESCE(NULLIF(TRIM(fm."fami_grup_marc"), ''), '—') AS "Familia",
+       COALESCE(NULLIF(p."clave_temporada", ''), '—') AS "Temporada"
+FROM "public"."ps_articulos" p
+LEFT JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
+LEFT JOIN "public"."ps_stock_tienda" s
+       ON s."codigo" = p."codigo"
+      AND s."stock" > 0
+      AND s."tienda" <> '99'
 WHERE p."anulado" = false
-GROUP BY p."ccrefejofacm", p."descripcion"
-HAVING SUM(CASE WHEN s."tienda" <> '99' THEN s."stock" ELSE 0 END) = 0
-   AND SUM(CASE WHEN s."tienda" = '99' THEN s."stock" ELSE 0 END) > 0
-ORDER BY "Stock Almacén" DESC
-LIMIT 30`,
+  AND __gf_familia__
+  AND __gf_temporada__
+  AND __gf_marca__
+GROUP BY p."codigo", p."ccrefejofacm", p."descripcion", fm."fami_grup_marc", p."clave_temporada"
+HAVING COALESCE(SUM(s."stock"), 0) <= 0
+ORDER BY p."clave_temporada" DESC NULLS LAST, p."descripcion" ASC
+LIMIT 50`,
     },
     {
       id: "stock-dead-stock",
       type: "table",
       title: "Dead Stock (stock total > 10, sin ventas en período seleccionado)",
-      sql: `SELECT p."ccrefejofacm" AS "Referencia",
-       p."descripcion" AS "Descripción",
-       SUM(s."stock") AS "Stock",
-       p."clave_temporada" AS "Temporada"
+      // Identifier → familia → temporada → cantidad. Global filters apply on
+      // the catalog side; the lookback window (curr_from/curr_to) defines the
+      // "sin ventas" criterion. tienda <> '99' is a no-op on the live mirror
+      // (no rows exist with tienda='99' in either ps_stock_tienda or
+      // ps_lineas_ventas) but is kept for defence-in-depth.
+      sql: `SELECT
+       COALESCE(NULLIF(p."ccrefejofacm", ''), '—') AS "Referencia",
+       COALESCE(NULLIF(p."descripcion", ''), '—') AS "Descripción",
+       COALESCE(NULLIF(TRIM(fm."fami_grup_marc"), ''), '—') AS "Familia",
+       COALESCE(NULLIF(p."clave_temporada", ''), '—') AS "Temporada",
+       SUM(s."stock") AS "Stock"
 FROM "public"."ps_stock_tienda" s
 JOIN "public"."ps_articulos" p ON s."codigo" = p."codigo"
+LEFT JOIN "public"."ps_familias" fm ON p."num_familia" = fm."reg_familia"
 WHERE s."stock" > 0
+  AND s."tienda" <> '99'
   AND p."anulado" = false
+  AND __gf_tienda__
+  AND __gf_familia__
+  AND __gf_temporada__
+  AND __gf_marca__
   AND p."codigo" NOT IN (
     SELECT DISTINCT lv."codigo"
     FROM "public"."ps_lineas_ventas" lv
@@ -170,27 +278,32 @@ WHERE s."stock" > 0
       AND lv."fecha_creacion" >= :curr_from
       AND lv."fecha_creacion" <= :curr_to
   )
-GROUP BY p."ccrefejofacm", p."descripcion", p."clave_temporada"
+GROUP BY p."ccrefejofacm", p."descripcion", fm."fami_grup_marc", p."clave_temporada"
 HAVING SUM(s."stock") > 10
 ORDER BY "Stock" DESC
-LIMIT 30`,
+LIMIT 50`,
     },
     {
       id: "stock-traspasos-recientes",
       type: "table",
       title: "Traspasos Recientes (período seleccionado)",
-      sql: `SELECT t."fecha_s" AS "Fecha",
-       t."tienda_salida" AS "Origen",
-       t."tienda_entrada" AS "Destino",
-       COUNT(*) AS "Lineas",
-       SUM(t."unidades_s") AS "Unidades"
+      // Traspasos has tienda_salida / tienda_entrada (no plain "tienda"
+      // column), so __gf_tienda__ — which binds to s."tienda" — is
+      // intentionally NOT applied here. Filter via the time picker.
+      // Header order: Fecha → Origen → Destino → Líneas → Unidades.
+      sql: `SELECT
+       t."fecha_s" AS "Fecha",
+       COALESCE(NULLIF(t."tienda_salida", ''), '—') AS "Origen",
+       COALESCE(NULLIF(t."tienda_entrada", ''), '—') AS "Destino",
+       COUNT(*) AS "Líneas",
+       COALESCE(SUM(t."unidades_s"), 0) AS "Unidades"
 FROM "public"."ps_traspasos" t
 WHERE t."entrada" = false
   AND t."fecha_s" >= :curr_from
   AND t."fecha_s" <= :curr_to
 GROUP BY t."fecha_s", t."tienda_salida", t."tienda_entrada"
-ORDER BY t."fecha_s" DESC
-LIMIT 30`,
+ORDER BY t."fecha_s" DESC, "Unidades" DESC
+LIMIT 50`,
     },
   ],
 };


### PR DESCRIPTION
Refs #415, #413

## Summary

Reviewed the **Responsable de Stock** dashboard template against the live PostgreSQL mirror (50 stores, 12.3M `ps_stock_tienda` rows) and fixed several correctness and quality issues.

### Critical bugs found

1. **KPI \"Unidades en Almacén Central\" always returned 0.** Filtered on `tienda = '99'` but `ps_stock_tienda` has no rows for tienda 99 — the central warehouse stock lives in the un-mirrored `CCStock` 4D table (`Exportaciones.CCStock` is the per-row total of size slots, not a central balance). Confirmed: 50 stores in `ps_stock_tienda`, none = 99.
2. **\"Sin Stock en Tiendas (con stock en almacén)\" always returned 0 rows** — same root cause.
3. **`stock-por-tienda` / `stock-por-familia` silently dropped ~1 254 units** because of an `INNER JOIN ps_familias` for articles whose `num_familia` does not resolve.
4. **`stock-por-familia` showed PANTALON twice** because `ps_familias.fami_grup_marc` has both \"PANTALON\" and \"PANTALON \" (trailing space).
5. **`stock-dead-stock` and `stock-sin-stock` did not honour the global filters** (no `__gf_*__` tokens).

### Fixes

- KPI #2 replaced with **\"Incidencias Stock Negativo\"** — count of `stock < 0` rows, doubles as a daily D-017 decoder health-check.
- KPI #3 + #4: drop the unused `fm` LEFT JOIN; defensive `COALESCE(precio_coste, 0)`; add `tienda <> '99'` for consistency.
- Bar charts: `LEFT JOIN ps_familias`; `TRIM(fami_grup_marc)` to collapse duplicates; `'Sin clasificar'` fallback.
- Tables: NULL/empty values render as `—`; Familia column added to `stock-bajo` and `stock-dead-stock`; deterministic `ORDER BY` tie-breaks; global filter tokens applied where appropriate.
- `stock-sin-stock` widget rewritten to anchor on `ps_articulos` (LEFT JOIN to stock) so it actually surfaces SKUs without store stock.
- Comprehensive header documenting: point-in-time vs windowed semantics, no central-warehouse mirror, D-017 decoder, MA exclusion at ETL, M-prefix wholesale handling, why `__gf_tienda__` does not apply to `ps_traspasos`.

## Verified (SQL evidence)

| Check | Before | After |
|---|---|---|
| KPI \"Unidades en Almacén Central\" / \"Incidencias Stock Negativo\" | 0 (broken) | 9 222 negative-stock rows |
| Stock por tienda — top 5 sum | 35 423 (1 254 units lost to inner join) | 36 062 |
| Stock por familia — \"PANTALON\" | listed twice (12 609 + 4 280) | merged (16 889) |
| `stock-sin-stock` rows | 0 (broken) | 25 160 active SKUs without store stock |
| Negative-stock decoder (D-017) | n/a | 9 222 rows, range \\[-122, -1]; 0 rows > 32 767 |
| KPI Valor stock al coste | 697 623,32 € | 697 623,32 € (unchanged — defensive COALESCE no-op) |

Live mirror queries used during review:

\`\`\`sql
-- D-017 spot-check
SELECT COUNT(*), MIN(stock), MAX(stock) FROM ps_stock_tienda WHERE stock < 0;
-- → 9222, -122, -1

-- No tienda='99' in ps_stock_tienda
SELECT COUNT(DISTINCT tienda) FROM ps_stock_tienda WHERE tienda='99';
-- → 0

-- ps_familias has duplicate PANTALON
SELECT '\"' || fami_grup_marc || '\"', COUNT(*) FROM ps_familias
WHERE TRIM(fami_grup_marc) ILIKE 'pantalon' GROUP BY 1;
-- → \"PANTALON \" / \"PANTALON\"
\`\`\`

## Needs browser verification

These cannot be checked from SQL alone — please open the live dashboard and confirm:

- [ ] KPI row renders 4 cards (Unidades, Incidencias Stock Negativo, Valor Stock, Referencias).
- [ ] \"Incidencias Stock Negativo\" shows red/inverted styling because `inverted: true`.
- [ ] Time picker has no effect on the four KPIs and the two bar charts (point-in-time).
- [ ] Time picker DOES affect dead-stock and traspasos (windowed).
- [ ] Tienda / Familia / Temporada / Marca filters propagate to all widgets that reference them.
- [ ] Empty-state and SQL-error UX for the new widgets is sensible (B1).
- [ ] Drilldown (\"Analizar\") on stock-bajo / stock-sin-stock / dead-stock surfaces SKU + Familia + Temporada in the analyze payload.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.typecheck.json` — clean.
- [x] `npx vitest run lib/__tests__/templates.test.ts lib/__tests__/date-params-templates.test.ts lib/__tests__/template-global-filters.test.ts` — 106/106 pass.
- [x] Full suite: 1 362 pre-existing pass; 2 pre-existing failures in `llm-usage.test.ts` are unrelated to this PR (verified on baseline).
- [x] Each widget SQL ran against the live PostgreSQL mirror with sample tokens substituted.
- [ ] Browser verification (see above).

## Out of scope

- Spacing/donut UX (#420).
- CLI agentic regression (#419).
- Adding a central-warehouse stock mirror (would require a new ETL sync of the `CCStock` 4D table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)