### PR TITLE
fix(dashboard): claude CLI agentic regression + richer error details (issue #419)

### DIFF
--- a/DECISIONS-AND-CHANGES.md
+++ b/DECISIONS-AND-CHANGES.md
@@ -4,6 +4,20 @@
 
 ## Decision Log
 
+### D-024: Surface Claude CLI API failures and expand AGENTIC_RUNNER error detail — 2026-04-26
+**Context**: Issue #419. `DASHBOARD_LLM_PROVIDER=cli` flows surfaced as `LLM_CLI_EXIT: claude agentic step: CLI exited with code 1` with empty stderr — useless for debugging. Root cause was an **expired Claude OAuth access token whose refresh was blocked by Cloudflare**: the CLI returns the upstream `401 Invalid authentication credentials` on **stdout** as `{"is_error":true,"api_error_status":401,"result":"…"}` while exiting non-zero with empty stderr. The runner only inspected `stderr`, so the meaningful failure was thrown away.
+**Decision**:
+- `assertCliSuccess` now parses the stdout JSON envelope when exit ≠ 0 and lifts auth/API errors into `LLM_CLI_AUTH` / `LLM_CLI_API_ERROR` with the inner `api_error_status` and message attached. The exit-0 envelope path in `claudeCliAgenticStep` does the same (some upstream errors are reported with `is_error:true` *and* exit 0).
+- `CliRunnerError` carries the full diagnostic: sanitized stdout/stderr tails, the spawned argv, phase, duration, and innerErrorCode.
+- The agentic runner translates `CliRunnerError` and other failures into `AgenticRunnerError` with an `AgenticRunnerErrorDiagnostic` (provider/driver/model, phase, durationMs, toolRoundsUsed, lastToolCall, limitsAtFailure, cli sub-object).
+- API routes (`generate`/`modify`/`analyze`) attach the diagnostic to the `formatApiError(...)` response and persist a row in the new `llm_errors` table for offline triage.
+- All free-form strings pass through `lib/llm-provider/sanitize.ts`, which redacts Bearer/Authorization, `sk-…`, `sk-ant-…`, JWTs, postgres DSNs, basic-auth `:pass@`, refresh/access-token JSON values, and the live values of every `sensitive: true` key from `config/schema.yaml`. `sanitize()` is idempotent and unit-tested.
+- Frontend: new `AgenticErrorDetails` component renders the diagnostic in five labelled sections (Causa, Contexto, CLI, Tool en curso, Límites) with a "Copiar como JSON" button. Used by both `ChatSidebar` and `ErrorDisplay`.
+- Docker entrypoint (`dashboard/docker-entrypoint.sh`) now logs a clear warning + remediation hint (`claude /login`) when the access token is already expired at startup or when the OAuth refresh endpoint returns a Cloudflare 403.
+**Alternatives rejected**: (a) catching this only in the UI as a generic "auth error" message — loses the inner status code and the tool-loop context, (b) putting full sanitized stdout on the error message string — would have been quietly truncated and breaks structured telemetry, (c) auto-refreshing tokens server-side on demand — Cloudflare blocks the OAuth endpoint, refresh must happen on the host.
+**Rationale**: The dashboard already has the rich error context server-side; the issue was that we threw it away before the API response was assembled. Centralizing the diagnostic shape in `AgenticErrorDiagnostic` lets every flow (current and future) opt-in by passing the same payload.
+**See**: `dashboard/lib/llm-provider/sanitize.ts`, `dashboard/lib/llm-provider/cli/{errors,process,claude-code}.ts`, `dashboard/lib/llm-tools/{runner,diagnostic,logging}.ts`, `dashboard/components/AgenticErrorDetails.tsx`, `etl/schema/init.sql` (`llm_errors`), `dashboard/docker-entrypoint.sh`.
+
 ### D-021: PR review policy capped at two fixed rounds (Copilot → Opus clean-context) — 2026-04-24
 **Context**: The prior policy (AGENTS.md) required re-requesting Copilot "until no new feedback". In practice this produced long loops where late nit-pick rounds blocked merges without meaningfully improving the code. The human owner called it "too much".
 **Decision**: Every PR gets **exactly two review rounds, each run once**:
@@ -187,6 +201,9 @@ The button needs to signal the ETL container (a pure Python scheduler with no HT
 ---
 
 ## Changelog
+
+### 2026-04-26
+- Dashboard: Claude CLI agentic regression fix + richer error reporting (issue #419, D-024). `claude --output-format json` exit-1 with auth-failed envelope is now mapped to `LLM_CLI_AUTH`. AGENTIC_RUNNER responses include a sanitized `diagnostic` (provider/driver/model/phase/duration/rounds/lastTool/CLI tail/limits). New `llm_errors` table; new `AgenticErrorDetails` UI component; new `lib/llm-provider/sanitize.ts` with unit tests.
 
 ### 2026-04-24
 - PR review policy capped at two fixed rounds — D-021: one Copilot round, then one Opus round from a clean Claude Code context. Old "re-request until no feedback" loop removed. `AGENTS.md` updated (policy section + issue-template tasks `N-1b` Copilot / `N-1c` Opus).

--- a/dashboard/app/api/dashboard/analyze/route.ts
+++ b/dashboard/app/api/dashboard/analyze/route.ts
@@ -32,6 +32,7 @@ import {
   finishInteraction,
 } from "@/lib/db-write";
 import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
+import { buildAgenticErrorDiagnostic, persistAgenticError } from "@/lib/llm-tools/diagnostic";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -233,12 +234,15 @@ export async function POST(request: Request) {
       );
     }
     if (err instanceof AgenticRunnerError) {
+      const diagnostic = buildAgenticErrorDiagnostic(err, cfg);
+      persistAgenticError("analyze", err, diagnostic);
       return NextResponse.json(
         formatApiError(
           "El flujo de IA con herramientas alcanzó un límite o no pudo completarse. Inténtalo de nuevo.",
           "AGENTIC_RUNNER",
-          `${err.code}: ${err.message}`,
+          diagnostic.subError,
           err.requestId,
+          diagnostic,
         ),
         { status: 500 },
       );

--- a/dashboard/app/api/dashboard/generate/route.ts
+++ b/dashboard/app/api/dashboard/generate/route.ts
@@ -30,6 +30,7 @@ import {
 import { formatAgenticProgressLineEs } from "@/lib/format-agentic-progress";
 import type { AgenticProgressEvent } from "@/lib/llm-tools/types";
 import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
+import { buildAgenticErrorDiagnostic, persistAgenticError } from "@/lib/llm-tools/diagnostic";
 
 function extractJson(raw: string): string {
   const trimmed = raw.trim();
@@ -110,14 +111,18 @@ function finishGenerateFromRawLlm(rawResponse: string, requestId: string): Gener
 
 function mapGenerateLlmError(err: unknown, requestId: string): GenerateFinishErr {
   if (err instanceof AgenticRunnerError) {
+    const cfg = loadDashboardLlmConfig();
+    const diagnostic = buildAgenticErrorDiagnostic(err, cfg);
+    persistAgenticError("generate", err, diagnostic);
     return {
       ok: false,
       status: 500,
       payload: formatApiError(
         "El flujo de IA con herramientas alcanzó un límite o no pudo completarse. Reformula el prompt o inténtalo de nuevo.",
         "AGENTIC_RUNNER",
-        `${err.code}: ${err.message}`,
+        diagnostic.subError,
         err.requestId,
+        diagnostic,
       ) as unknown as Record<string, unknown>,
     };
   }

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -26,6 +26,7 @@ import {
   finishInteraction,
 } from "@/lib/db-write";
 import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
+import { buildAgenticErrorDiagnostic, persistAgenticError } from "@/lib/llm-tools/diagnostic";
 
 /**
  * Extract JSON from a string that may be wrapped in markdown code blocks.
@@ -163,12 +164,15 @@ export async function POST(request: Request) {
       );
     }
     if (err instanceof AgenticRunnerError) {
+      const diagnostic = buildAgenticErrorDiagnostic(err, cfg);
+      persistAgenticError("modify", err, diagnostic);
       return NextResponse.json(
         formatApiError(
           "El flujo de IA con herramientas alcanzó un límite o no pudo completarse. Reformula el cambio o inténtalo de nuevo.",
           "AGENTIC_RUNNER",
-          `${err.code}: ${err.message}`,
+          diagnostic.subError,
           err.requestId,
+          diagnostic,
         ),
         { status: 500 },
       );

--- a/dashboard/components/AgenticErrorDetails.tsx
+++ b/dashboard/components/AgenticErrorDetails.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+/**
+ * Render the rich AgenticErrorDiagnostic shipped on AGENTIC_RUNNER errors.
+ *
+ * Sections (in order):
+ *   - Causa     code · subError
+ *   - Contexto  provider · driver · model · phase · duración · rondas usadas
+ *   - CLI       exit code · command · stderr tail · stdout tail (only when provider=cli)
+ *   - Tool      lastToolCall (when present)
+ *   - Límites   maxRounds, maxToolCalls, toolTimeoutMs, executeRowLimit, payloadCharLimit
+ *
+ * The component is read-only and intentionally renders sanitized strings as-is
+ * inside `<pre>` so multiline tails stay readable.
+ */
+
+import type { ApiErrorResponse, AgenticErrorDiagnostic } from "@/lib/errors";
+
+interface Props {
+  errorDetail: ApiErrorResponse;
+  /**
+   * When true, omit the duplicated `code`/`requestId` rows because the parent
+   * already renders them (e.g. ErrorDisplay's header). Default: false (used by
+   * the chat sidebar where there is no separate header).
+   */
+  skipHeader?: boolean;
+}
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex gap-2">
+      <span className="font-semibold whitespace-nowrap">{label}:</span>
+      <span className="break-all">{value}</span>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+  testId,
+}: {
+  title: string;
+  children: React.ReactNode;
+  testId?: string;
+}) {
+  return (
+    <div className="space-y-0.5" data-testid={testId}>
+      <p className="mt-1 text-[10px] uppercase tracking-wide text-red-200/70">{title}</p>
+      {children}
+    </div>
+  );
+}
+
+export default function AgenticErrorDetails({ errorDetail, skipHeader = false }: Props) {
+  const d: AgenticErrorDiagnostic | undefined = errorDetail.diagnostic;
+
+  // When there is no diagnostic AND no extra details to render, we still
+  // want to surface the legacy `details` string. But if the parent already
+  // renders code/requestId/details (skipHeader=true) and there is nothing
+  // diagnostic-specific, we render nothing to avoid duplicate rows.
+  if (skipHeader && !d) return null;
+
+  return (
+    <div
+      className="mt-1 rounded bg-red-900/20 p-2 text-xs font-mono space-y-1 text-red-300"
+      data-testid="agentic-error-details"
+    >
+      {!skipHeader && (
+        <Section title="Causa" testId="ae-section-causa">
+          <Row label="Código" value={errorDetail.code} />
+          <Row label="ID" value={errorDetail.requestId} />
+          {d?.subError && (
+            <Row
+              label="subError"
+              value={<span className="whitespace-pre-wrap">{d.subError}</span>}
+            />
+          )}
+          {!d && errorDetail.details && (
+            <Row
+              label="Detalle"
+              value={<span className="whitespace-pre-wrap">{errorDetail.details}</span>}
+            />
+          )}
+        </Section>
+      )}
+      {skipHeader && d?.subError && (
+        <Section title="Causa" testId="ae-section-causa">
+          <Row
+            label="subError"
+            value={<span className="whitespace-pre-wrap">{d.subError}</span>}
+          />
+        </Section>
+      )}
+
+      {d && (
+        <Section title="Contexto" testId="ae-section-contexto">
+          <Row label="provider" value={d.provider} />
+          <Row label="driver" value={d.driver ?? "—"} />
+          <Row label="model" value={d.model} />
+          <Row label="phase" value={d.phase} />
+          <Row label="durationMs" value={String(d.durationMs)} />
+          <Row label="toolRoundsUsed" value={String(d.toolRoundsUsed)} />
+          <Row label="toolCallsUsed" value={String(d.toolCallsUsed)} />
+        </Section>
+      )}
+
+      {d?.cli && (
+        <Section title="CLI" testId="ae-section-cli">
+          <Row label="exitCode" value={String(d.cli.exitCode ?? "—")} />
+          {d.cli.innerErrorCode != null && (
+            <Row label="innerErrorCode" value={String(d.cli.innerErrorCode)} />
+          )}
+          {d.cli.command && d.cli.command.length > 0 && (
+            <div>
+              <span className="font-semibold">command:</span>
+              <pre className="mt-0.5 whitespace-pre-wrap break-all text-red-300/90">
+                {d.cli.command.join(" ")}
+              </pre>
+            </div>
+          )}
+          {d.cli.stderrTail && (
+            <div>
+              <span className="font-semibold">stderr (tail):</span>
+              <pre className="mt-0.5 max-h-40 overflow-auto whitespace-pre-wrap rounded bg-black/30 p-1 text-red-200/90">
+                {d.cli.stderrTail}
+              </pre>
+            </div>
+          )}
+          {d.cli.stdoutTail && (
+            <div>
+              <span className="font-semibold">stdout (tail):</span>
+              <pre className="mt-0.5 max-h-40 overflow-auto whitespace-pre-wrap rounded bg-black/30 p-1 text-red-200/90">
+                {d.cli.stdoutTail}
+              </pre>
+            </div>
+          )}
+        </Section>
+      )}
+
+      {d?.lastToolCall && (
+        <Section title="Tool en curso" testId="ae-section-tool">
+          <Row label="name" value={d.lastToolCall.name} />
+          <Row
+            label="arguments"
+            value={
+              <span className="whitespace-pre-wrap">{d.lastToolCall.argumentsTruncated}</span>
+            }
+          />
+        </Section>
+      )}
+
+      {d?.limitsAtFailure && (
+        <Section title="Límites" testId="ae-section-limites">
+          <Row label="maxRounds" value={String(d.limitsAtFailure.maxRounds)} />
+          <Row label="maxToolCalls" value={String(d.limitsAtFailure.maxToolCalls)} />
+          <Row label="toolTimeoutMs" value={String(d.limitsAtFailure.toolTimeoutMs)} />
+          <Row label="executeRowLimit" value={String(d.limitsAtFailure.executeRowLimit)} />
+          <Row label="payloadCharLimit" value={String(d.limitsAtFailure.payloadCharLimit)} />
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/dashboard/components/ChatSidebar.tsx
+++ b/dashboard/components/ChatSidebar.tsx
@@ -12,6 +12,7 @@ import LogBlock from "@/components/LogBlock";
 import type { LogLine } from "@/components/LogBlock";
 import type { InteractionLine } from "@/lib/db-write";
 import { interactionLineClass } from "@/lib/interaction-line-class";
+import AgenticErrorDetails from "@/components/AgenticErrorDetails";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -212,28 +213,15 @@ function ErrorBubble({ message, errorDetail }: { message: string; errorDetail?: 
             Detalles técnicos
           </button>
           {expanded && (
-            <div
-              className="mt-1 rounded bg-red-900/20 p-2 text-xs font-mono space-y-0.5 text-red-300"
-              data-testid="chat-error-details"
-            >
-              <div>
-                <span className="font-semibold">Código:</span> {errorDetail.code}
-              </div>
-              <div>
-                <span className="font-semibold">ID:</span> {errorDetail.requestId}
-              </div>
-              {errorDetail.details && (
-                <div>
-                  <span className="font-semibold">Detalle:</span>{" "}
-                  <span className="whitespace-pre-wrap">{errorDetail.details}</span>
-                </div>
-              )}
+            <div data-testid="chat-error-details">
+              <AgenticErrorDetails errorDetail={errorDetail} />
               <button
                 type="button"
                 onClick={handleCopy}
                 className="mt-1 text-xs text-red-400 hover:text-red-300 underline"
+                data-testid="copy-as-json"
               >
-                {copied ? "Copiado!" : "Copiar detalles"}
+                {copied ? "Copiado!" : "Copiar como JSON"}
               </button>
             </div>
           )}

--- a/dashboard/components/ErrorDisplay.tsx
+++ b/dashboard/components/ErrorDisplay.tsx
@@ -12,6 +12,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import type { ApiErrorResponse } from "@/lib/errors";
+import AgenticErrorDetails from "@/components/AgenticErrorDetails";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -131,30 +132,36 @@ export function ErrorDisplay({ error, title, onRetry, className = "" }: ErrorDis
           </button>
 
           {expanded && (
-            <div
-              className="mt-2 rounded bg-red-900/20 p-3 text-xs text-red-300 font-mono space-y-1"
-              data-testid="technical-details"
-            >
-              <div>
-                <span className="font-semibold">Código:</span>{" "}
-                {(error as ApiErrorResponse).code}
-              </div>
-              <div>
-                <span className="font-semibold">Hora:</span>{" "}
-                {formatTimestamp((error as ApiErrorResponse).timestamp)}
-              </div>
-              <div>
-                <span className="font-semibold">ID:</span>{" "}
-                {(error as ApiErrorResponse).requestId}
-              </div>
-              {(error as ApiErrorResponse).details && (
+            <div className="mt-2" data-testid="technical-details">
+              {/* Header (always shown) — code, timestamp, requestId, and the
+                  optional `details` string. Rich diagnostic sections appear
+                  below via AgenticErrorDetails. */}
+              <div
+                className="rounded bg-red-900/20 p-3 text-xs text-red-300 font-mono space-y-1"
+              >
                 <div>
-                  <span className="font-semibold">Detalle:</span>{" "}
-                  <span className="whitespace-pre-wrap">
-                    {(error as ApiErrorResponse).details}
-                  </span>
+                  <span className="font-semibold">Código:</span>{" "}
+                  {(error as ApiErrorResponse).code}
                 </div>
-              )}
+                <div>
+                  <span className="font-semibold">Hora:</span>{" "}
+                  {formatTimestamp((error as ApiErrorResponse).timestamp)}
+                </div>
+                <div>
+                  <span className="font-semibold">ID:</span>{" "}
+                  {(error as ApiErrorResponse).requestId}
+                </div>
+                {(error as ApiErrorResponse).details && (
+                  <div>
+                    <span className="font-semibold">Detalle:</span>{" "}
+                    <span className="whitespace-pre-wrap">
+                      {(error as ApiErrorResponse).details}
+                    </span>
+                  </div>
+                )}
+              </div>
+              {/* Rich diagnostic sections (Contexto / CLI / Tool / Límites). */}
+              <AgenticErrorDetails errorDetail={error as ApiErrorResponse} skipHeader />
             </div>
           )}
         </div>
@@ -170,7 +177,7 @@ export function ErrorDisplay({ error, title, onRetry, className = "" }: ErrorDis
               className="text-xs font-medium text-red-400 hover:text-red-300 underline transition-colors"
               data-testid="copy-details"
             >
-              {copied ? "Copiado!" : "Copiar detalles"}
+              {copied ? "Copiado!" : "Copiar como JSON"}
             </button>
           )}
           {onRetry && (

--- a/dashboard/docker-entrypoint.sh
+++ b/dashboard/docker-entrypoint.sh
@@ -3,6 +3,15 @@
 # This keeps the container authenticated even when the short-lived access_token expires
 # (typically every 7 days). The host only needs to run sync-claude-token.sh when the
 # refresh_token itself expires (~90 days) or after re-login.
+#
+# Issue #419: when refresh fails (e.g. Cloudflare blocks the token endpoint with
+# a 403 challenge page) the access token can stay expired and every `claude`
+# invocation in the dashboard returns a JSON envelope with `is_error:true`,
+# `api_error_status:401` while exiting with code 1 and empty stderr.  We now
+# detect that case in lib/llm-provider/cli/process.ts (LLM_CLI_AUTH) and surface
+# it in the API response.  In addition, this entrypoint logs a one-line warning
+# when the credentials file is already expired at boot so operators can act
+# without having to wait for the first user-facing error.
 
 CREDS="$HOME/.claude/.credentials.json"
 
@@ -24,6 +33,13 @@ if (expiresIn > 60 * 60 * 1000) {
   console.log(`[claude-auth] Token valid for ${Math.round(expiresIn/3600000)}h, skipping refresh.`);
   process.exit(0);
 }
+if (expiresIn <= 0) {
+  // Issue #419: surface the expiry up front so operators can re-auth on the
+  // host (the refresh below may still succeed or may be blocked by Cloudflare).
+  console.log(`[claude-auth] WARNING: access token already expired ${Math.abs(Math.round(expiresIn/3600000))}h ago.`);
+  console.log(`[claude-auth] If refresh below fails, run on the host:`);
+  console.log(`[claude-auth]   claude /login   # then ps stack restart`);
+}
 
 console.log('[claude-auth] Access token near expiry, refreshing...');
 
@@ -39,6 +55,10 @@ const req = https.request({
   res.on('end', () => {
     if (res.statusCode !== 200) {
       console.log(`[claude-auth] Refresh failed (${res.statusCode}): ${data.slice(0,200)}`);
+      // Cloudflare anti-bot pages return 403 with HTML; log a clear remediation hint.
+      if (res.statusCode === 403 || /<html/i.test(data)) {
+        console.log(`[claude-auth] Hint: token endpoint is blocked by Cloudflare/anti-bot. Re-authenticate on the host: \`claude /login\` then \`ps stack restart\`.`);
+      }
       return;
     }
     try {

--- a/dashboard/lib/__tests__/llm-provider-process.test.ts
+++ b/dashboard/lib/__tests__/llm-provider-process.test.ts
@@ -3,53 +3,82 @@ import { assertCliSuccess } from "@/lib/llm-provider/cli/process";
 import type { RunProcessResult } from "@/lib/llm-provider/cli/types";
 import { CliRunnerError } from "@/lib/llm-provider/cli/errors";
 
+function makeResult(partial: Partial<RunProcessResult>): RunProcessResult {
+  return {
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+    timedOut: false,
+    truncatedStdout: false,
+    truncatedStderr: false,
+    durationMs: 0,
+    ...partial,
+  };
+}
+
 describe("assertCliSuccess", () => {
   it("throws LLM_CLI_TIMEOUT when timedOut", () => {
-    const r: RunProcessResult = {
-      exitCode: null,
-      stdout: "",
-      stderr: "",
-      timedOut: true,
-      truncatedStdout: false,
-      truncatedStderr: false,
-    };
+    const r = makeResult({ exitCode: null, timedOut: true });
     expect(() => assertCliSuccess(r, "t")).toThrow(CliRunnerError);
     expect(() => assertCliSuccess(r, "t")).toThrow(/timed out/i);
   });
 
   it("throws LLM_CLI_TRUNCATED when streams truncated", () => {
-    const r: RunProcessResult = {
-      exitCode: 0,
-      stdout: "x",
-      stderr: "",
-      timedOut: false,
-      truncatedStdout: true,
-      truncatedStderr: false,
-    };
+    const r = makeResult({ stdout: "x", truncatedStdout: true });
     expect(() => assertCliSuccess(r, "t")).toThrow(/capture limit/i);
   });
 
   it("throws LLM_CLI_EXIT on non-zero exit", () => {
-    const r: RunProcessResult = {
-      exitCode: 2,
-      stdout: "",
-      stderr: "boom",
-      timedOut: false,
-      truncatedStdout: false,
-      truncatedStderr: false,
-    };
+    const r = makeResult({ exitCode: 2, stderr: "boom" });
     expect(() => assertCliSuccess(r, "t")).toThrow(/exited with code 2/);
   });
 
+  it("upgrades exit-1 with auth-failed JSON envelope to LLM_CLI_AUTH (issue #419)", () => {
+    const stdout = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: true,
+      api_error_status: 401,
+      result:
+        'Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}',
+    });
+    const r = makeResult({ exitCode: 1, stdout, durationMs: 4000 });
+    let caught: CliRunnerError | null = null;
+    try {
+      assertCliSuccess(r, "claude agentic step", ["claude", "-p", "x"]);
+    } catch (e) {
+      caught = e as CliRunnerError;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.code).toBe("LLM_CLI_AUTH");
+    expect(caught!.details.phase).toBe("auth");
+    expect(caught!.details.innerErrorCode).toBe(401);
+    expect(caught!.details.command).toBeDefined();
+    // The original message should mention authentication, not just exit code.
+    expect(caught!.message).toMatch(/authenticate/i);
+    expect(caught!.message).not.toMatch(/exited with code/);
+  });
+
+  it("upgrades exit-1 with non-auth API error JSON to LLM_CLI_API_ERROR", () => {
+    const stdout = JSON.stringify({
+      type: "result",
+      is_error: true,
+      api_error_status: 500,
+      result: "Upstream model timed out",
+    });
+    const r = makeResult({ exitCode: 1, stdout, durationMs: 1000 });
+    expect(() => assertCliSuccess(r, "t")).toThrow(/Upstream model/);
+    try {
+      assertCliSuccess(r, "t");
+    } catch (e) {
+      const ce = e as CliRunnerError;
+      expect(ce.code).toBe("LLM_CLI_API_ERROR");
+      expect(ce.details.phase).toBe("exit");
+    }
+  });
+
   it("passes on exit 0 without timeout or truncation", () => {
-    const r: RunProcessResult = {
-      exitCode: 0,
-      stdout: "{}",
-      stderr: "",
-      timedOut: false,
-      truncatedStdout: false,
-      truncatedStderr: false,
-    };
+    const r = makeResult({ stdout: "{}" });
     expect(() => assertCliSuccess(r, "t")).not.toThrow();
   });
 });

--- a/dashboard/lib/__tests__/llm-provider-sanitize.test.ts
+++ b/dashboard/lib/__tests__/llm-provider-sanitize.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the system-config loader so getSensitiveLiterals() can return
+// deterministic values without reading config.yaml. Each test toggles
+// what literals to redact.
+const sensitiveLiterals: Array<{ value: string; sensitive: boolean }> = [];
+vi.mock("@/lib/system-config/loader", () => ({
+  getSystemConfig: () =>
+    Object.fromEntries(
+      sensitiveLiterals.map((s, i) => [
+        `mock.key${i}`,
+        { value: s.value, sensitive: s.sensitive, source: "default", key: `mock.key${i}`, env: "X", section: "x", description: "", requires_restart: [], type: "string", default: null },
+      ]),
+    ),
+}));
+
+import { sanitize, sanitizeArgv, sanitizeTail } from "@/lib/llm-provider/sanitize";
+
+beforeEach(() => {
+  sensitiveLiterals.length = 0;
+});
+
+describe("sanitize()", () => {
+  it("returns empty string for null/undefined/empty", () => {
+    expect(sanitize(null)).toBe("");
+    expect(sanitize(undefined)).toBe("");
+    expect(sanitize("")).toBe("");
+  });
+
+  it("redacts Bearer tokens (case insensitive)", () => {
+    // The Authorization-line pass redacts the entire value after the colon.
+    expect(sanitize("Authorization: Bearer abcdefghij1234567890")).not.toContain(
+      "abcdefghij1234567890",
+    );
+    // Bearer pattern alone (no Authorization prefix) is also redacted.
+    expect(sanitize("token=Bearer xyz9999999999")).toContain("Bearer [redacted]");
+  });
+
+  it("redacts sk-... API keys (OpenAI / OpenRouter shape)", () => {
+    expect(
+      sanitize("OPENROUTER_API_KEY=sk-or-v1-abcdef0123456789ABCDEF\n"),
+    ).toContain("[redacted]");
+    expect(sanitize("openrouter ok sk-1234567890ABCDEFghij")).toContain(
+      "[redacted]",
+    );
+  });
+
+  it("redacts sk-ant-... long-lived OAuth tokens", () => {
+    expect(sanitize("export sk-ant-oat01-abcdef-ghi-_-12345")).toContain(
+      "[redacted]",
+    );
+  });
+
+  it("redacts JWT-shaped tokens", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    expect(sanitize(`token=${jwt}`)).toBe("token=[redacted]");
+  });
+
+  it("redacts postgres DSNs and basic-auth user:pass@host", () => {
+    expect(sanitize("postgres://alice:hunter2@db:5432/x")).toContain(
+      "postgres://[redacted]",
+    );
+    expect(sanitize("amqp://u:p@broker")).toContain(":[redacted]@");
+  });
+
+  it("redacts password=... fields", () => {
+    expect(sanitize("password=topsecret&user=bob")).toContain("password=[redacted]");
+  });
+
+  it("redacts refresh_token / access_token JSON values", () => {
+    const out = sanitize('{"refresh_token":"abcdef","other":"keep"}');
+    expect(out).toContain("[redacted]");
+    expect(out).toContain("keep");
+  });
+
+  it("redacts known sensitive literal values from config schema", () => {
+    sensitiveLiterals.push({ value: "MY-SUPER-SECRET-12345", sensitive: true });
+    expect(sanitize("token leaked: MY-SUPER-SECRET-12345 again")).toContain("[redacted]");
+    expect(sanitize("token leaked: MY-SUPER-SECRET-12345 again")).not.toContain(
+      "MY-SUPER-SECRET-12345",
+    );
+  });
+
+  it("does not scrub non-sensitive literals from config", () => {
+    sensitiveLiterals.push({ value: "harmless-but-flagged", sensitive: false });
+    expect(sanitize("harmless-but-flagged stays")).toContain("harmless-but-flagged");
+  });
+
+  it("is idempotent — running twice returns the same output", () => {
+    const input = "Bearer ABCDEFGH12345 and sk-or-v1-12345abcdef";
+    const once = sanitize(input);
+    const twice = sanitize(once);
+    expect(once).toBe(twice);
+  });
+
+  it("preserves clean diagnostic messages verbatim", () => {
+    const msg = "claude agentic step: api_error_status=401 Invalid authentication credentials";
+    expect(sanitize(msg)).toBe(msg);
+  });
+});
+
+describe("sanitizeArgv()", () => {
+  it("redacts the value following known credential flags", () => {
+    expect(sanitizeArgv(["claude", "--api-key", "sk-or-v1-XXXX", "-p", "hi"])).toEqual(
+      ["claude", "--api-key", "[redacted]", "-p", "hi"],
+    );
+  });
+
+  it("sanitizes individual argv entries that themselves contain secrets", () => {
+    const out = sanitizeArgv(["claude", "--header=Authorization: Bearer abcdefghij12345"]);
+    // Either the Authorization rule or Bearer rule catches it — both are redacted.
+    expect(out[1]).not.toContain("abcdefghij12345");
+    expect(out[1]).toContain("[redacted]");
+  });
+
+  it("returns empty array unchanged", () => {
+    expect(sanitizeArgv([])).toEqual([]);
+  });
+});
+
+describe("sanitizeTail()", () => {
+  it("returns sanitized tail of long input", () => {
+    const big = "x".repeat(8192) + "\nBearer abcdefghij12345";
+    const tail = sanitizeTail(big, 32);
+    expect(tail.length).toBe(32);
+    expect(tail).not.toContain("abcdefghij12345");
+  });
+
+  it("returns whole string when shorter than max", () => {
+    expect(sanitizeTail("hello", 1000)).toBe("hello");
+  });
+
+  it("handles null/undefined", () => {
+    expect(sanitizeTail(null, 100)).toBe("");
+    expect(sanitizeTail(undefined, 100)).toBe("");
+  });
+});

--- a/dashboard/lib/__tests__/llm-provider-sanitize.test.ts
+++ b/dashboard/lib/__tests__/llm-provider-sanitize.test.ts
@@ -72,6 +72,54 @@ describe("sanitize()", () => {
     const out = sanitize('{"refresh_token":"abcdef","other":"keep"}');
     expect(out).toContain("[redacted]");
     expect(out).toContain("keep");
+    // Critical regression: the old replacement used `$&` which echoed the
+    // entire match (including the secret) back into the output. Assert the
+    // raw secret value never survives sanitization.
+    expect(out).not.toContain("abcdef");
+  });
+
+  it("redacts access_token / refreshToken / accessToken JSON values without leaking the value", () => {
+    const cases = [
+      '{"access_token":"VERYSECRET-AAA"}',
+      '{"refreshToken":"VERYSECRET-BBB"}',
+      '{"accessToken":"VERYSECRET-CCC"}',
+    ];
+    for (const input of cases) {
+      const out = sanitize(input);
+      expect(out).toContain("[redacted]");
+      expect(out).not.toMatch(/VERYSECRET-[ABC]{3}/);
+    }
+  });
+
+  it("redacts realistic Anthropic sk-ant- credentials", () => {
+    // Shape mimics `sk-ant-api03-…` long-lived API keys.
+    const sample =
+      "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const out = sanitize(`Authorization: Bearer ${sample}\n`);
+    expect(out).not.toContain(sample);
+    expect(out).toContain("[redacted]");
+  });
+
+  it("redacts Authorization: Bearer eyJ… (JWT after scheme)", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0In0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const out = sanitize(`Authorization: Bearer ${jwt}`);
+    expect(out).not.toContain(jwt);
+    expect(out).toContain("[redacted]");
+  });
+
+  it("redacts Authorization: Basic dXNlcjpwYXNz (basic auth)", () => {
+    const value = "dXNlcjpwYXNzMTIzNA==";
+    const out = sanitize(`Authorization: Basic ${value}`);
+    expect(out).not.toContain(value);
+    expect(out).toMatch(/Authorization:\s*Basic\s*\[redacted\]/);
+  });
+
+  it("redacts Authorization: Token abc123 (token scheme)", () => {
+    const value = "tok_abc123_DEFGHI";
+    const out = sanitize(`Authorization: Token ${value}`);
+    expect(out).not.toContain(value);
+    expect(out).toMatch(/Authorization:\s*Token\s*\[redacted\]/);
   });
 
   it("redacts known sensitive literal values from config schema", () => {
@@ -116,6 +164,25 @@ describe("sanitizeArgv()", () => {
 
   it("returns empty array unchanged", () => {
     expect(sanitizeArgv([])).toEqual([]);
+  });
+
+  it("truncates long prompt values after -p / --prompt", () => {
+    const longPrompt = "x".repeat(500);
+    const out = sanitizeArgv(["claude", "-p", longPrompt, "--model", "sonnet"]);
+    expect(out[0]).toBe("claude");
+    expect(out[1]).toBe("-p");
+    expect(out[2].length).toBeLessThanOrEqual(260);
+    expect(out[2]).toMatch(/truncated/);
+    expect(out[3]).toBe("--model");
+    expect(out[4]).toBe("sonnet");
+  });
+
+  it("redacts secrets that appear inside prompt-flag values", () => {
+    const promptWithSecret =
+      "Please summarize Authorization: Bearer abcdefghij1234567890 quickly";
+    const out = sanitizeArgv(["claude", "--prompt", promptWithSecret]);
+    expect(out[2]).not.toContain("abcdefghij1234567890");
+    expect(out[2]).toContain("[redacted]");
   });
 });
 

--- a/dashboard/lib/__tests__/llm-tools-runner-cli.test.ts
+++ b/dashboard/lib/__tests__/llm-tools-runner-cli.test.ts
@@ -28,8 +28,9 @@ vi.mock("@/lib/llm-provider/cli/claude-code", () => ({
   claudeCliAgenticStep: mockClaudeStep,
 }));
 
-import { runAgenticChat } from "@/lib/llm-tools/runner";
+import { runAgenticChat, AgenticRunnerError } from "@/lib/llm-tools/runner";
 import { createClaudeCodeAgenticAdapter } from "@/lib/llm-provider/cli/agent-adapter";
+import { CliRunnerError } from "@/lib/llm-provider/cli/errors";
 import type { DashboardLlmConfig } from "@/lib/llm-provider/types";
 
 const cfg: DashboardLlmConfig = {
@@ -60,6 +61,59 @@ describe("runAgenticChat (CLI adapter)", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+  });
+
+  it("issue #419: surfaces CliRunnerError with diagnostic on AgenticRunnerError", async () => {
+    // Simulate the production failure: claude exits 1 with auth-error JSON envelope.
+    mockClaudeStep.mockRejectedValueOnce(
+      new CliRunnerError(
+        "LLM_CLI_AUTH",
+        "claude agentic step: Failed to authenticate. API Error: 401",
+        {
+          exitCode: 1,
+          stderr: "",
+          stdout:
+            '{"type":"result","is_error":true,"api_error_status":401,"result":"Failed to authenticate"}',
+          command: ["claude", "-p", "x", "--model", "sonnet"],
+          phase: "auth",
+          durationMs: 4321,
+          innerErrorCode: 401,
+        },
+      ),
+    );
+
+    const adapter = createClaudeCodeAgenticAdapter(cfg);
+    let caught: AgenticRunnerError | null = null;
+    try {
+      await runAgenticChat({
+        adapter,
+        model: cfg.cliModel,
+        systemPrompt: "sys",
+        userContent: "go",
+        ctx,
+        temperature: 0.2,
+        maxTokens: 1000,
+      });
+    } catch (e) {
+      caught = e as AgenticRunnerError;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!).toBeInstanceOf(AgenticRunnerError);
+    expect(caught!.code).toBe("LLM_CLI_AUTH");
+    expect(caught!.diagnostic).toBeDefined();
+    expect(caught!.diagnostic!.phase).toBe("cli_exit");
+    expect(caught!.diagnostic!.cli).toBeDefined();
+    expect(caught!.diagnostic!.cli!.exitCode).toBe(1);
+    expect(caught!.diagnostic!.cli!.innerErrorCode).toBe(401);
+    expect(caught!.diagnostic!.cli!.command).toEqual([
+      "claude",
+      "-p",
+      "x",
+      "--model",
+      "sonnet",
+    ]);
+    expect(caught!.diagnostic!.limitsAtFailure.maxRounds).toBe(4);
+    expect(caught!.diagnostic!.toolRoundsUsed).toBe(0);
   });
 
   it("runs tool round then final via Claude JSON protocol", async () => {

--- a/dashboard/lib/errors.ts
+++ b/dashboard/lib/errors.ts
@@ -30,6 +30,58 @@ export type ErrorCode =
   | "UNKNOWN"
   | "AGENTIC_RUNNER";
 
+/**
+ * Rich diagnostic payload attached to AGENTIC_RUNNER errors so the UI
+ * "Detalles" modal can show provider/driver, CLI exit code + sanitized
+ * stdout/stderr tails, the last tool call, and the configured limits.
+ *
+ * All string fields here MUST be sanitized server-side before being put
+ * on the wire; see `lib/llm-provider/sanitize.ts`.
+ */
+export interface AgenticErrorDiagnostic {
+  /** Inner LLM/CLI failure code (e.g. LLM_CLI_AUTH, LLM_CLI_EXIT). */
+  subError: string;
+  /** OpenRouter HTTP transport vs local CLI. */
+  provider: "openrouter" | "cli";
+  /** CLI driver id (claude_code) when provider=cli, else null. */
+  driver: string | null;
+  /** Effective model id sent to the upstream backend. */
+  model: string;
+  /**
+   * Coarse-grained phase the runner failed in.
+   * `cli_spawn` / `cli_exit` are CLI-only.
+   */
+  phase: "tool_call" | "tool_response" | "final" | "cli_spawn" | "cli_exit" | "limits";
+  /** Wall-clock ms from runner start to failure. */
+  durationMs: number;
+  /** Number of completed adapter rounds (0-based count of finished rounds). */
+  toolRoundsUsed: number;
+  /** Total tool calls attempted across all rounds. */
+  toolCallsUsed: number;
+  /** Last tool the runner started (if any) — name + truncated args. */
+  lastToolCall?: { name: string; argumentsTruncated: string };
+  /** Present only when provider === "cli". */
+  cli?: {
+    exitCode: number | null;
+    /** argv[0] + flags as the runner spawned them (sanitized — no secrets). */
+    command?: string[];
+    /** Last ~4 KB of stderr (sanitized). */
+    stderrTail?: string;
+    /** Last ~4 KB of stdout (sanitized). */
+    stdoutTail?: string;
+    /** Inner code from the CLI envelope (e.g. api_error_status: 401). */
+    innerErrorCode?: string | number | null;
+  };
+  /** Limits in effect when the runner failed. */
+  limitsAtFailure: {
+    maxRounds: number;
+    maxToolCalls: number;
+    toolTimeoutMs: number;
+    executeRowLimit: number;
+    payloadCharLimit: number;
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Standard API error response shape
 // ---------------------------------------------------------------------------
@@ -49,6 +101,8 @@ export interface ApiErrorResponse {
   existing_id?: number;
   /** When code is REVIEW_EXISTS — Monday (YYYY-MM-DD) of the reviewed week. */
   week_start?: string;
+  /** Rich diagnostic payload for AGENTIC_RUNNER failures (sanitized). */
+  diagnostic?: AgenticErrorDiagnostic;
 }
 
 // ---------------------------------------------------------------------------
@@ -86,6 +140,7 @@ export function formatApiError(
   code: ErrorCode,
   details?: string,
   requestId?: string,
+  diagnostic?: AgenticErrorDiagnostic,
 ): ApiErrorResponse {
   return {
     error,
@@ -93,6 +148,7 @@ export function formatApiError(
     ...(details !== undefined ? { details } : {}),
     timestamp: new Date().toISOString(),
     requestId: requestId ?? generateRequestId(),
+    ...(diagnostic !== undefined ? { diagnostic } : {}),
   };
 }
 
@@ -116,7 +172,9 @@ export function isApiErrorResponse(value: unknown): value is ApiErrorResponse {
     // details must be absent or a string (never an object/array)
     (v.details === undefined || typeof v.details === "string") &&
     (v.existing_id === undefined || typeof v.existing_id === "number") &&
-    (v.week_start === undefined || typeof v.week_start === "string")
+    (v.week_start === undefined || typeof v.week_start === "string") &&
+    (v.diagnostic === undefined ||
+      (typeof v.diagnostic === "object" && v.diagnostic !== null))
   );
 }
 

--- a/dashboard/lib/errors.ts
+++ b/dashboard/lib/errors.ts
@@ -162,7 +162,7 @@ export function formatApiError(
  * Use this instead of loose `"code" in obj` checks to avoid false positives.
  */
 export function isApiErrorResponse(value: unknown): value is ApiErrorResponse {
-  if (typeof value !== "object" || value === null) return false;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
   const v = value as Record<string, unknown>;
   return (
     typeof v.error === "string" &&
@@ -173,8 +173,11 @@ export function isApiErrorResponse(value: unknown): value is ApiErrorResponse {
     (v.details === undefined || typeof v.details === "string") &&
     (v.existing_id === undefined || typeof v.existing_id === "number") &&
     (v.week_start === undefined || typeof v.week_start === "string") &&
+    // diagnostic must be absent or a non-array object
     (v.diagnostic === undefined ||
-      (typeof v.diagnostic === "object" && v.diagnostic !== null))
+      (typeof v.diagnostic === "object" &&
+        v.diagnostic !== null &&
+        !Array.isArray(v.diagnostic)))
   );
 }
 

--- a/dashboard/lib/llm-provider/cli/claude-code.ts
+++ b/dashboard/lib/llm-provider/cli/claude-code.ts
@@ -62,6 +62,7 @@ export async function claudeCliSingleShot(input: ClaudeCliSingleShotInput): Prom
     "--output-format",
     "text",
   ];
+  const fullArgv = [cfg.cliBin, ...args];
   const result = await runCliProcess({
     file: cfg.cliBin,
     args,
@@ -71,7 +72,7 @@ export async function claudeCliSingleShot(input: ClaudeCliSingleShotInput): Prom
     maxStderrBytes: Math.min(cfg.cliMaxCaptureBytes, 512_000),
   });
   try {
-    assertCliSuccess(result, "claude single-shot");
+    assertCliSuccess(result, "claude single-shot", fullArgv);
   } catch (e) {
     if (e instanceof CliRunnerError) throw e;
     throw e;
@@ -80,6 +81,9 @@ export async function claudeCliSingleShot(input: ClaudeCliSingleShotInput): Prom
   if (!text) {
     throw new CliRunnerError("LLM_CLI_EMPTY", "claude single-shot: empty stdout", {
       stderr: result.stderr,
+      command: fullArgv,
+      phase: "empty",
+      durationMs: result.durationMs,
     });
   }
   return text;
@@ -113,7 +117,7 @@ function extractJsonObject(text: string): string {
     throw new CliRunnerError(
       "LLM_CLI_PARSE",
       "claude agentic: no JSON object found in output",
-      { stderr: body.slice(0, 500) },
+      { stderr: body.slice(0, 500), phase: "parse" },
     );
   }
   // Walk forward counting balanced braces, respecting strings and escapes,
@@ -214,6 +218,7 @@ export async function claudeCliAgenticStep(input: ClaudeCliAgenticStepInput): Pr
     "--output-format",
     "json",
   ];
+  const fullArgv = [cfg.cliBin, ...args];
 
   const result = await runCliProcess({
     file: cfg.cliBin,
@@ -224,18 +229,40 @@ export async function claudeCliAgenticStep(input: ClaudeCliAgenticStepInput): Pr
     maxStderrBytes: Math.min(cfg.cliMaxCaptureBytes, 512_000),
   });
   try {
-    assertCliSuccess(result, "claude agentic step");
+    assertCliSuccess(result, "claude agentic step", fullArgv);
   } catch (e) {
     if (e instanceof CliRunnerError) throw e;
     throw e;
   }
   // --output-format json wraps the model output in an envelope: { result: "<text>" }.
   // Extract the inner text to avoid spurious trailing content that breaks JSON.parse.
+  // The envelope can also signal `is_error: true` *with* exit code 0 when the
+  // CLI declines to forward an upstream HTTP failure as a process error; treat
+  // that the same way we treat the exit-1 case in `assertCliSuccess`.
   let textOutput = result.stdout;
   try {
     const envelope = JSON.parse(result.stdout) as Record<string, unknown>;
+    if (envelope?.is_error === true) {
+      const status = typeof envelope.api_error_status === "number" ? envelope.api_error_status : null;
+      const inner = typeof envelope.result === "string" ? envelope.result : "";
+      const isAuth = status === 401 || status === 403 || /authentication|invalid.*credentials|unauthorized/i.test(inner);
+      throw new CliRunnerError(
+        isAuth ? "LLM_CLI_AUTH" : "LLM_CLI_API_ERROR",
+        `claude agentic step: ${inner.slice(0, 240) || `api_error_status=${status}`}`,
+        {
+          exitCode: result.exitCode,
+          stderr: result.stderr,
+          stdout: result.stdout,
+          command: fullArgv,
+          phase: isAuth ? "auth" : "exit",
+          durationMs: result.durationMs,
+          innerErrorCode: status,
+        },
+      );
+    }
     if (typeof envelope.result === "string") textOutput = envelope.result;
-  } catch {
+  } catch (e) {
+    if (e instanceof CliRunnerError) throw e;
     // Envelope parse failed — fall back to raw stdout
   }
   return parseClaudeAgenticStepJson(textOutput);

--- a/dashboard/lib/llm-provider/cli/claude-code.ts
+++ b/dashboard/lib/llm-provider/cli/claude-code.ts
@@ -9,6 +9,10 @@ import { CliRunnerError } from "./errors";
 import { serializeChatMessagesForCli } from "./transcript";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import { DASHBOARD_AGENTIC_TOOLS } from "@/lib/llm-tools/catalog";
+import { sanitize, sanitizeArgv, sanitizeTail } from "../sanitize";
+
+/** Tail size to retain on CliRunnerError details (matches process.ts). */
+const TAIL_MAX_BYTES = 4096;
 
 const SINGLE_SHOT_PRINT_ARG = `You are the dashboard assistant.
 The UTF-8 stdin contains the full multi-section prompt (## system, ## user, etc.).
@@ -80,8 +84,8 @@ export async function claudeCliSingleShot(input: ClaudeCliSingleShotInput): Prom
   const text = result.stdout.trim();
   if (!text) {
     throw new CliRunnerError("LLM_CLI_EMPTY", "claude single-shot: empty stdout", {
-      stderr: result.stderr,
-      command: fullArgv,
+      stderr: sanitizeTail(result.stderr, TAIL_MAX_BYTES),
+      command: sanitizeArgv(fullArgv),
       phase: "empty",
       durationMs: result.durationMs,
     });
@@ -117,7 +121,7 @@ function extractJsonObject(text: string): string {
     throw new CliRunnerError(
       "LLM_CLI_PARSE",
       "claude agentic: no JSON object found in output",
-      { stderr: body.slice(0, 500), phase: "parse" },
+      { stderr: sanitize(body.slice(0, 500)), phase: "parse" },
     );
   }
   // Walk forward counting balanced braces, respecting strings and escapes,
@@ -141,7 +145,7 @@ function extractJsonObject(text: string): string {
   throw new CliRunnerError(
     "LLM_CLI_PARSE",
     "claude agentic: unterminated JSON object in output",
-    { stderr: body.slice(start, start + 500) },
+    { stderr: sanitize(body.slice(start, start + 500)) },
   );
 }
 
@@ -153,7 +157,7 @@ export function parseClaudeAgenticStepJson(stdout: string): ClaudeAgenticStep {
     throw new CliRunnerError(
       "LLM_CLI_PARSE",
       `claude agentic: invalid JSON (${e instanceof Error ? e.message : "parse error"})`,
-      { stderr: stdout.slice(0, 800) },
+      { stderr: sanitize(stdout.slice(0, 800)) },
     );
   }
   if (!parsed || typeof parsed !== "object") {
@@ -244,16 +248,17 @@ export async function claudeCliAgenticStep(input: ClaudeCliAgenticStepInput): Pr
     const envelope = JSON.parse(result.stdout) as Record<string, unknown>;
     if (envelope?.is_error === true) {
       const status = typeof envelope.api_error_status === "number" ? envelope.api_error_status : null;
-      const inner = typeof envelope.result === "string" ? envelope.result : "";
+      const innerRaw = typeof envelope.result === "string" ? envelope.result : "";
+      const inner = sanitize(innerRaw);
       const isAuth = status === 401 || status === 403 || /authentication|invalid.*credentials|unauthorized/i.test(inner);
       throw new CliRunnerError(
         isAuth ? "LLM_CLI_AUTH" : "LLM_CLI_API_ERROR",
         `claude agentic step: ${inner.slice(0, 240) || `api_error_status=${status}`}`,
         {
           exitCode: result.exitCode,
-          stderr: result.stderr,
-          stdout: result.stdout,
-          command: fullArgv,
+          stderr: sanitizeTail(result.stderr, TAIL_MAX_BYTES),
+          stdout: sanitizeTail(result.stdout, TAIL_MAX_BYTES),
+          command: sanitizeArgv(fullArgv),
           phase: isAuth ? "auth" : "exit",
           durationMs: result.durationMs,
           innerErrorCode: status,

--- a/dashboard/lib/llm-provider/cli/errors.ts
+++ b/dashboard/lib/llm-provider/cli/errors.ts
@@ -1,21 +1,59 @@
 /**
  * CLI runner failures mapped for callers (HTTP-style codes where useful).
+ *
+ * Carries the structured fields the API layer needs to populate a rich
+ * "Detalles" modal: exit code, sanitized stdout/stderr tails, the argv
+ * that was spawned, the phase the failure happened in, and the wall
+ * time spent before the error surfaced.
  */
+
+export type CliPhase =
+  | "spawn"
+  | "exit"
+  | "timeout"
+  | "truncated"
+  | "auth"
+  | "parse"
+  | "empty";
+
+export interface CliRunnerErrorDetails {
+  exitCode?: number | null;
+  stdout?: string;
+  stderr?: string;
+  /** argv[0] + argv[1..n] as the runner spawned it (already sanitized). */
+  command?: readonly string[];
+  /** Coarse-grained phase the failure occurred in. */
+  phase?: CliPhase;
+  /** Wall-clock duration in ms (spawn → exit/error). */
+  durationMs?: number;
+  /**
+   * Inner CLI error code surfaced by the binary itself, e.g. the JSON
+   * envelope's `api_error_status` from `claude --output-format json`.
+   */
+  innerErrorCode?: string | number | null;
+}
 
 export class CliRunnerError extends Error {
   readonly code: string;
   readonly exitCode: number | null;
+  /** Short stderr snippet for legacy error-message use; full tail lives in `details`. */
   readonly stderrSnippet: string;
+  readonly details: CliRunnerErrorDetails;
 
-  constructor(
-    code: string,
-    message: string,
-    opts?: { exitCode?: number | null; stderr?: string },
-  ) {
+  constructor(code: string, message: string, opts?: CliRunnerErrorDetails) {
     super(message);
     this.name = "CliRunnerError";
     this.code = code;
     this.exitCode = opts?.exitCode ?? null;
     this.stderrSnippet = (opts?.stderr ?? "").slice(0, 2000);
+    this.details = {
+      exitCode: opts?.exitCode ?? null,
+      stdout: opts?.stdout,
+      stderr: opts?.stderr,
+      command: opts?.command,
+      phase: opts?.phase,
+      durationMs: opts?.durationMs,
+      innerErrorCode: opts?.innerErrorCode ?? null,
+    };
   }
 }

--- a/dashboard/lib/llm-provider/cli/process.ts
+++ b/dashboard/lib/llm-provider/cli/process.ts
@@ -199,7 +199,13 @@ export function assertCliSuccess(
 
 /**
  * Best-effort parse of `claude --output-format json` envelopes.
- * Returns null when stdout is not a parseable object with `type: "result"`.
+ *
+ * Returns null when stdout is not a parseable JSON object. We do NOT require
+ * `type === "result"`: some upstream API failures surface envelopes with
+ * `is_error:true` but no `type` field, and we still want to lift those into
+ * `LLM_CLI_AUTH` / `LLM_CLI_API_ERROR` instead of a bare exit-code message.
+ *
+ * Arrays and primitives are rejected — only object envelopes are accepted.
  */
 function parseJsonEnvelope(stdout: string): {
   is_error?: boolean;

--- a/dashboard/lib/llm-provider/cli/process.ts
+++ b/dashboard/lib/llm-provider/cli/process.ts
@@ -5,6 +5,7 @@
 import { spawn } from "node:child_process";
 import type { RunProcessResult } from "./types";
 import { CliRunnerError } from "./errors";
+import { sanitize, sanitizeArgv, sanitizeTail } from "../sanitize";
 
 export interface RunCliProcessParams {
   file: string;
@@ -14,6 +15,9 @@ export interface RunCliProcessParams {
   maxStdoutBytes: number;
   maxStderrBytes: number;
 }
+
+/** Max bytes of stdout/stderr we keep on a CliRunnerError for the UI/log layer. */
+const TAIL_MAX_BYTES = 4096;
 
 class CappedBufferCollector {
   readonly chunks: Buffer[] = [];
@@ -52,6 +56,7 @@ class CappedBufferCollector {
  */
 export async function runCliProcess(params: RunCliProcessParams): Promise<RunProcessResult> {
   const { file, args, stdin, timeoutMs, maxStdoutBytes, maxStderrBytes } = params;
+  const startedAt = Date.now();
 
   return await new Promise((resolve, reject) => {
     const child = spawn(file, args, {
@@ -106,35 +111,109 @@ export async function runCliProcess(params: RunCliProcessParams): Promise<RunPro
         timedOut,
         truncatedStdout: stdoutAcc.truncated,
         truncatedStderr: stderrAcc.truncated,
+        durationMs: Date.now() - startedAt,
       });
     });
   });
 }
 
-/** Map raw process outcome to CliRunnerError when not successful. */
+/**
+ * Map raw process outcome to CliRunnerError when not successful.
+ *
+ * `command` is the argv (file + args) the runner spawned; we sanitize it
+ * before attaching to the error so callers can render it in the UI without
+ * leaking secrets that may have been passed via `--api-key`-style flags.
+ */
 export function assertCliSuccess(
   result: RunProcessResult,
   label: string,
+  command?: readonly string[],
 ): void {
+  const sanitizedCommand = command ? sanitizeArgv(command) : undefined;
+  const stderrTail = sanitizeTail(result.stderr, TAIL_MAX_BYTES);
+  const stdoutTail = sanitizeTail(result.stdout, TAIL_MAX_BYTES);
+
   if (result.timedOut) {
-    throw new CliRunnerError(
-      "LLM_CLI_TIMEOUT",
-      `${label}: CLI timed out`,
-      { exitCode: result.exitCode, stderr: result.stderr },
-    );
+    throw new CliRunnerError("LLM_CLI_TIMEOUT", `${label}: CLI timed out`, {
+      exitCode: result.exitCode,
+      stderr: stderrTail,
+      stdout: stdoutTail,
+      command: sanitizedCommand,
+      phase: "timeout",
+      durationMs: result.durationMs,
+    });
   }
   if (result.truncatedStdout || result.truncatedStderr) {
     throw new CliRunnerError(
       "LLM_CLI_TRUNCATED",
       `${label}: CLI output exceeded capture limit`,
-      { exitCode: result.exitCode, stderr: result.stderr },
+      {
+        exitCode: result.exitCode,
+        stderr: stderrTail,
+        stdout: stdoutTail,
+        command: sanitizedCommand,
+        phase: "truncated",
+        durationMs: result.durationMs,
+      },
     );
   }
   if (result.exitCode !== 0) {
+    // The Claude Code CLI prints API failures as a JSON envelope on stdout
+    // with `is_error: true` and an exit code of 1, leaving stderr empty.
+    // Promote that into a structured auth/API error so the API layer can
+    // surface a meaningful "Detalles" payload instead of "exited with code 1".
+    const envelope = parseJsonEnvelope(result.stdout);
+    if (envelope && envelope.is_error) {
+      const apiStatus = envelope.api_error_status ?? null;
+      const inner = sanitize(envelope.result ?? "");
+      const isAuth =
+        apiStatus === 401 ||
+        apiStatus === 403 ||
+        /authentication|invalid.*credentials|unauthorized/i.test(inner);
+      const code = isAuth ? "LLM_CLI_AUTH" : "LLM_CLI_API_ERROR";
+      const summary = inner.slice(0, 240) || `api_error_status=${apiStatus}`;
+      throw new CliRunnerError(code, `${label}: ${summary}`, {
+        exitCode: result.exitCode,
+        stderr: stderrTail,
+        stdout: stdoutTail,
+        command: sanitizedCommand,
+        phase: isAuth ? "auth" : "exit",
+        durationMs: result.durationMs,
+        innerErrorCode: apiStatus,
+      });
+    }
     throw new CliRunnerError(
       "LLM_CLI_EXIT",
       `${label}: CLI exited with code ${result.exitCode}`,
-      { exitCode: result.exitCode, stderr: result.stderr },
+      {
+        exitCode: result.exitCode,
+        stderr: stderrTail,
+        stdout: stdoutTail,
+        command: sanitizedCommand,
+        phase: "exit",
+        durationMs: result.durationMs,
+      },
     );
+  }
+}
+
+/**
+ * Best-effort parse of `claude --output-format json` envelopes.
+ * Returns null when stdout is not a parseable object with `type: "result"`.
+ */
+function parseJsonEnvelope(stdout: string): {
+  is_error?: boolean;
+  api_error_status?: number | null;
+  result?: string | null;
+  type?: string;
+} | null {
+  const trimmed = stdout.trim();
+  if (!trimmed.startsWith("{")) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed as Record<string, never>;
+  } catch {
+    return null;
   }
 }

--- a/dashboard/lib/llm-provider/cli/types.ts
+++ b/dashboard/lib/llm-provider/cli/types.ts
@@ -5,4 +5,6 @@ export interface RunProcessResult {
   timedOut: boolean;
   truncatedStdout: boolean;
   truncatedStderr: boolean;
+  /** Wall-clock duration in ms from spawn() to child close/error. */
+  durationMs: number;
 }

--- a/dashboard/lib/llm-provider/sanitize.ts
+++ b/dashboard/lib/llm-provider/sanitize.ts
@@ -18,15 +18,36 @@ const REDACTED = "[redacted]";
 
 // Regular expressions ordered roughly by specificity → generality.
 // Each captures one occurrence; `replaceAll` semantics rely on `g` flag.
+//
+// IMPORTANT: when using a capture group in the replacement, reference it as
+// `$1`/`$2`/etc. NEVER use `$&` (the full match) — that would echo the
+// secret value back into the output and defeat the redaction.
 const PATTERNS: Array<{ re: RegExp; replacement: string }> = [
-  // OAuth bearer tokens (Authorization: Bearer xxx, with or without quotes).
-  { re: /\bBearer\s+[A-Za-z0-9._\-+/=]{8,}/gi, replacement: "Bearer " + REDACTED },
-  // Authorization header values (after :)
-  { re: /\bAuthorization\s*:\s*[^\s",]+/gi, replacement: "Authorization: " + REDACTED },
-  // OpenAI / OpenRouter style keys: sk-... (>= 20 chars).
-  { re: /\bsk-[A-Za-z0-9_\-]{16,}/g, replacement: REDACTED },
-  // Anthropic CLI long-lived OAuth tokens often start with `sk-ant-`.
+  // Authorization header with Basic/Token/Bearer/Digest scheme prefix:
+  // capture the scheme keyword and replace the value with `[redacted]`.
+  // Match the value as one-or-more non-whitespace tokens that don't start
+  // with `[` (so we don't re-match an already-redacted line on idempotent
+  // runs) and stop at comma/quote so structured logs (`Authorization: Basic
+  // dXNlcjpwYXNz, X-Other: …`) don't bleed across headers. Run BEFORE the
+  // standalone `Bearer …` rule so the scheme is preserved, and BEFORE the
+  // catch-all so we keep the scheme name visible.
+  {
+    re: /\bAuthorization\s*:\s*(Bearer|Basic|Token|Digest)\s+(?!\[)[^\s,"\r\n]+/gi,
+    replacement: "Authorization: $1 " + REDACTED,
+  },
+  // OAuth bearer tokens outside an Authorization header (`token=Bearer xyz`).
+  { re: /\bBearer\s+(?!\[)[A-Za-z0-9._\-+/=]{8,}/gi, replacement: "Bearer " + REDACTED },
+  // Authorization header without a recognised scheme keyword — fully redact.
+  // Skip values that already start with `[` so idempotent runs don't churn.
+  {
+    re: /\bAuthorization\s*:\s*(?!Bearer\b|Basic\b|Token\b|Digest\b|\[)[^\s",]+/gi,
+    replacement: "Authorization: " + REDACTED,
+  },
+  // Anthropic CLI long-lived OAuth tokens often start with `sk-ant-` —
+  // match BEFORE the generic `sk-…` rule so the longer prefix wins.
   { re: /\bsk-ant-[A-Za-z0-9_\-]{8,}/g, replacement: REDACTED },
+  // OpenAI / OpenRouter style keys: sk-... (>= 16 chars after the prefix).
+  { re: /\bsk-[A-Za-z0-9_\-]{16,}/g, replacement: REDACTED },
   // JWT-shaped strings: 3 base64url segments separated by `.`, each at least 8 chars.
   { re: /\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/g, replacement: REDACTED },
   // PostgreSQL DSN.
@@ -35,8 +56,13 @@ const PATTERNS: Array<{ re: RegExp; replacement: string }> = [
   { re: /:[^@\s'"]+@/g, replacement: ":" + REDACTED + "@" },
   // password=... (query string / log dump form).
   { re: /password\s*=\s*[^\s&'"]+/gi, replacement: "password=" + REDACTED },
-  // refresh_token / access_token JSON values.
-  { re: /"(?:refresh_token|access_token|refreshToken|accessToken)"\s*:\s*"[^"]*"/g, replacement: '"$&": "[redacted]"' },
+  // refresh_token / access_token JSON values: capture the key and emit
+  // `"key": "[redacted]"`. Using `$1` is critical — `$&` would re-emit the
+  // full match (including the secret) into the output.
+  {
+    re: /"(refresh_token|access_token|refreshToken|accessToken)"\s*:\s*"[^"]*"/g,
+    replacement: `"$1": "${REDACTED}"`,
+  },
 ];
 
 /**
@@ -114,13 +140,31 @@ const FLAG_VALUE_REDACT = new Set([
   "--secret",
 ]);
 
+/**
+ * Flags whose value is free-form prompt content. We always pass the
+ * sanitized value through — secrets in user prompts (rare but possible)
+ * are caught by the regex set, and overlong prompts are truncated to
+ * keep the displayed argv readable.
+ */
+const FLAG_PROMPT_LIKE = new Set(["-p", "--prompt", "--system", "--system-prompt"]);
+const PROMPT_DISPLAY_LIMIT = 240;
+
 export function sanitizeArgv(argv: readonly string[]): string[] {
   const out: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     out.push(sanitize(a));
-    if (FLAG_VALUE_REDACT.has(a) && i + 1 < argv.length) {
+    if (i + 1 >= argv.length) continue;
+    if (FLAG_VALUE_REDACT.has(a)) {
       out.push(REDACTED);
+      i += 1;
+    } else if (FLAG_PROMPT_LIKE.has(a)) {
+      const next = sanitize(argv[i + 1]);
+      out.push(
+        next.length > PROMPT_DISPLAY_LIMIT
+          ? next.slice(0, PROMPT_DISPLAY_LIMIT) + "…[truncated]"
+          : next,
+      );
       i += 1;
     }
   }

--- a/dashboard/lib/llm-provider/sanitize.ts
+++ b/dashboard/lib/llm-provider/sanitize.ts
@@ -1,0 +1,128 @@
+/**
+ * Best-effort sanitization for LLM/CLI diagnostic strings shown in API
+ * responses, log lines, and the "Detalles" modal.
+ *
+ * Goal: never leak `CLAUDE_CODE_OAUTH_TOKEN`, `OPENROUTER_API_KEY`, the
+ * contents of `~/.claude/.credentials.json`, JWT-shaped strings, or
+ * Authorization headers — even if the upstream CLI happens to print them.
+ *
+ * This is an authoring-time safety net. Authoritative redaction still
+ * lives in `errors.ts > sanitizeErrorMessage` for short string details,
+ * but `sanitize()` accepts long multi-line strings (stdout/stderr tails)
+ * and applies a broader pattern set without truncating to 300 chars.
+ */
+
+import { getSystemConfig } from "@/lib/system-config/loader";
+
+const REDACTED = "[redacted]";
+
+// Regular expressions ordered roughly by specificity → generality.
+// Each captures one occurrence; `replaceAll` semantics rely on `g` flag.
+const PATTERNS: Array<{ re: RegExp; replacement: string }> = [
+  // OAuth bearer tokens (Authorization: Bearer xxx, with or without quotes).
+  { re: /\bBearer\s+[A-Za-z0-9._\-+/=]{8,}/gi, replacement: "Bearer " + REDACTED },
+  // Authorization header values (after :)
+  { re: /\bAuthorization\s*:\s*[^\s",]+/gi, replacement: "Authorization: " + REDACTED },
+  // OpenAI / OpenRouter style keys: sk-... (>= 20 chars).
+  { re: /\bsk-[A-Za-z0-9_\-]{16,}/g, replacement: REDACTED },
+  // Anthropic CLI long-lived OAuth tokens often start with `sk-ant-`.
+  { re: /\bsk-ant-[A-Za-z0-9_\-]{8,}/g, replacement: REDACTED },
+  // JWT-shaped strings: 3 base64url segments separated by `.`, each at least 8 chars.
+  { re: /\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/g, replacement: REDACTED },
+  // PostgreSQL DSN.
+  { re: /postgres(?:ql)?:\/\/[^\s'"<>]*/gi, replacement: "postgres://" + REDACTED },
+  // user:pass@host pattern (covers DSN-style basic auth too).
+  { re: /:[^@\s'"]+@/g, replacement: ":" + REDACTED + "@" },
+  // password=... (query string / log dump form).
+  { re: /password\s*=\s*[^\s&'"]+/gi, replacement: "password=" + REDACTED },
+  // refresh_token / access_token JSON values.
+  { re: /"(?:refresh_token|access_token|refreshToken|accessToken)"\s*:\s*"[^"]*"/g, replacement: '"$&": "[redacted]"' },
+];
+
+/**
+ * Build the runtime list of sensitive env-var literal values to scrub.
+ *
+ * We pull the live values for every key marked `sensitive: true` in
+ * `config/schema.yaml` and strip any non-empty value from the input.
+ * If the loader fails (tests, config missing), we silently fall back
+ * to the regex-only pass.
+ */
+function getSensitiveLiterals(): string[] {
+  try {
+    const cfg = getSystemConfig();
+    const out: string[] = [];
+    for (const v of Object.values(cfg)) {
+      if (!v.sensitive) continue;
+      const raw = v.value;
+      if (typeof raw !== "string") continue;
+      const trimmed = raw.trim();
+      // Avoid scrubbing trivially short / placeholder values that would
+      // create huge collateral damage on the redacted output.
+      if (trimmed.length >= 8) out.push(trimmed);
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Sanitize a free-form diagnostic string. Returns a new string with
+ * known-secret patterns replaced by `[redacted]`. Idempotent: running
+ * twice yields the same output.
+ */
+export function sanitize(input: string | null | undefined): string {
+  if (!input) return "";
+  let out = String(input);
+  for (const { re, replacement } of PATTERNS) {
+    out = out.replace(re, replacement);
+  }
+  for (const literal of getSensitiveLiterals()) {
+    if (!literal) continue;
+    out = out.replace(new RegExp(escapeRegExp(literal), "g"), REDACTED);
+  }
+  return out;
+}
+
+/**
+ * Sanitize then keep the trailing `maxBytes` (UTF-8). Useful for stderr
+ * tails — the recent end of the buffer is usually where the actual
+ * failure shows up.
+ */
+export function sanitizeTail(input: string | null | undefined, maxBytes: number): string {
+  const cleaned = sanitize(input);
+  if (cleaned.length <= maxBytes) return cleaned;
+  // Trim to the last maxBytes characters; we don't byte-count here as
+  // diagnostic strings are virtually always single-byte ASCII / latin1.
+  return cleaned.slice(cleaned.length - maxBytes);
+}
+
+/**
+ * Sanitize an argv array for display. Hides values right after flags
+ * known to carry credentials (e.g. `--api-key`, `--token`).
+ */
+const FLAG_VALUE_REDACT = new Set([
+  "--api-key",
+  "--token",
+  "--auth-token",
+  "--bearer",
+  "--password",
+  "--secret",
+]);
+
+export function sanitizeArgv(argv: readonly string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    out.push(sanitize(a));
+    if (FLAG_VALUE_REDACT.has(a) && i + 1 < argv.length) {
+      out.push(REDACTED);
+      i += 1;
+    }
+  }
+  return out;
+}

--- a/dashboard/lib/llm-tools/diagnostic.ts
+++ b/dashboard/lib/llm-tools/diagnostic.ts
@@ -1,0 +1,111 @@
+/**
+ * Translate an AgenticRunnerError into the public-facing AgenticErrorDiagnostic
+ * that the API layer puts on the wire.
+ *
+ * The runner-side type is a structural superset; this helper applies the final
+ * sanitization step (already done at capture time, but defense-in-depth) and
+ * provider/driver/model labelling so the front-end can show a complete
+ * "Detalles" section even when only a partial failure was captured.
+ */
+
+import type { AgenticErrorDiagnostic } from "@/lib/errors";
+import type { DashboardLlmConfig } from "@/lib/llm-provider/types";
+import { getEffectiveDashboardModel } from "@/lib/llm-provider/config";
+import { getAgenticConfig } from "./config";
+import { sanitize, sanitizeArgv, sanitizeTail } from "@/lib/llm-provider/sanitize";
+import type { AgenticRunnerError, AgenticRunnerErrorDiagnostic } from "./runner";
+import { logLlmError } from "./logging";
+
+const STREAM_TAIL_BYTES = 4096;
+
+export function buildAgenticErrorDiagnostic(
+  err: AgenticRunnerError,
+  cfg: DashboardLlmConfig,
+): AgenticErrorDiagnostic {
+  const limits = err.diagnostic?.limitsAtFailure ?? defaultLimits();
+  const phase: AgenticErrorDiagnostic["phase"] = err.diagnostic?.phase ?? "tool_call";
+  const lastTool = err.diagnostic?.lastToolCall;
+
+  const cliFromRunner = err.diagnostic?.cli;
+  const cli =
+    cfg.provider === "cli" && cliFromRunner
+      ? {
+          exitCode: cliFromRunner.exitCode ?? null,
+          command: cliFromRunner.command ? sanitizeArgv(cliFromRunner.command) : undefined,
+          stderrTail: sanitizeTail(cliFromRunner.stderrTail, STREAM_TAIL_BYTES),
+          stdoutTail: sanitizeTail(cliFromRunner.stdoutTail, STREAM_TAIL_BYTES),
+          innerErrorCode: cliFromRunner.innerErrorCode ?? null,
+        }
+      : undefined;
+
+  return {
+    subError: `${err.code}: ${sanitize(err.message)}`,
+    provider: cfg.provider,
+    driver: cfg.provider === "cli" ? cfg.cliDriver : null,
+    model: getEffectiveDashboardModel(cfg),
+    phase,
+    durationMs: err.diagnostic?.durationMs ?? 0,
+    toolRoundsUsed: err.diagnostic?.toolRoundsUsed ?? 0,
+    toolCallsUsed: err.diagnostic?.toolCallsUsed ?? 0,
+    ...(lastTool
+      ? {
+          lastToolCall: {
+            name: lastTool.name,
+            argumentsTruncated: sanitize(lastTool.argumentsTruncated).slice(0, 300),
+          },
+        }
+      : {}),
+    ...(cli ? { cli } : {}),
+    limitsAtFailure: limits,
+  };
+}
+
+function defaultLimits(): AgenticErrorDiagnostic["limitsAtFailure"] {
+  const c = getAgenticConfig();
+  return {
+    maxRounds: c.maxToolRounds,
+    maxToolCalls: c.maxToolCalls,
+    toolTimeoutMs: c.toolTimeoutMs,
+    executeRowLimit: c.maxRows,
+    payloadCharLimit: c.maxResultChars,
+  };
+}
+
+// Local re-export for the runner type to avoid `import type` coupling at the
+// top of consumers that already import the diagnostic builder.
+export type { AgenticRunnerErrorDiagnostic };
+
+/**
+ * Persist an AgenticRunnerError to `llm_errors`. Fire-and-forget — the
+ * underlying logger swallows DB failures so the API response is never blocked.
+ *
+ * The endpoint string MUST match the route's logical name (e.g. "analyze",
+ * "modify", "generate") to keep the table consistent with `llm_interactions`.
+ */
+export function persistAgenticError(
+  endpoint: string,
+  err: AgenticRunnerError,
+  diagnostic: AgenticErrorDiagnostic,
+): void {
+  void logLlmError({
+    requestId: err.requestId,
+    endpoint,
+    code: err.code,
+    subError: diagnostic.subError,
+    provider: diagnostic.provider,
+    driver: diagnostic.driver,
+    model: diagnostic.model,
+    phase: diagnostic.phase,
+    durationMs: diagnostic.durationMs,
+    toolRoundsUsed: diagnostic.toolRoundsUsed,
+    toolCallsUsed: diagnostic.toolCallsUsed,
+    lastToolName: diagnostic.lastToolCall?.name ?? null,
+    lastToolArgs: diagnostic.lastToolCall?.argumentsTruncated ?? null,
+    cliExitCode: diagnostic.cli?.exitCode ?? null,
+    cliInnerCode: diagnostic.cli?.innerErrorCode ?? null,
+    cliCommand: diagnostic.cli?.command ? diagnostic.cli.command.join(" ") : null,
+    cliStdoutTail: diagnostic.cli?.stdoutTail ?? null,
+    cliStderrTail: diagnostic.cli?.stderrTail ?? null,
+    limits: diagnostic.limitsAtFailure,
+  });
+}

--- a/dashboard/lib/llm-tools/logging.ts
+++ b/dashboard/lib/llm-tools/logging.ts
@@ -17,6 +17,79 @@ export interface LogToolCallInput {
   llmDriver?: string | null;
 }
 
+export interface LogLlmErrorInput {
+  requestId: string;
+  endpoint: string;
+  code: string;
+  subError?: string | null;
+  provider: string;
+  driver?: string | null;
+  model?: string | null;
+  phase?: string | null;
+  durationMs?: number | null;
+  toolRoundsUsed?: number | null;
+  toolCallsUsed?: number | null;
+  lastToolName?: string | null;
+  lastToolArgs?: string | null;
+  cliExitCode?: number | null;
+  cliInnerCode?: string | number | null;
+  cliCommand?: string | null;
+  cliStdoutTail?: string | null;
+  cliStderrTail?: string | null;
+  limits?: Record<string, number> | null;
+}
+
+/**
+ * Persist a single AGENTIC_RUNNER failure to `llm_errors`. All free-form
+ * fields are expected to be sanitized by the caller; this function does
+ * not redact further. Insert failures are swallowed (we already logged
+ * to console in the API layer).
+ */
+export async function logLlmError(row: LogLlmErrorInput): Promise<void> {
+  try {
+    await sql(
+      `INSERT INTO llm_errors (
+         request_id, endpoint, code, sub_error, provider, driver, model,
+         phase, duration_ms, tool_rounds_used, tool_calls_used,
+         last_tool_name, last_tool_args,
+         cli_exit_code, cli_inner_code, cli_command, cli_stdout_tail, cli_stderr_tail,
+         limits
+       ) VALUES (
+         $1,$2,$3,$4,$5,$6,$7,
+         $8,$9,$10,$11,
+         $12,$13,
+         $14,$15,$16,$17,$18,
+         $19::jsonb
+       )`,
+      [
+        row.requestId,
+        row.endpoint,
+        row.code,
+        row.subError ?? null,
+        row.provider,
+        row.driver ?? null,
+        row.model ?? null,
+        row.phase ?? null,
+        row.durationMs ?? null,
+        row.toolRoundsUsed ?? null,
+        row.toolCallsUsed ?? null,
+        row.lastToolName ?? null,
+        row.lastToolArgs ?? null,
+        row.cliExitCode ?? null,
+        row.cliInnerCode == null ? null : String(row.cliInnerCode),
+        row.cliCommand ?? null,
+        row.cliStdoutTail ?? null,
+        row.cliStderrTail ?? null,
+        row.limits ? JSON.stringify(row.limits) : null,
+      ],
+    );
+  } catch (err) {
+    if (process.env.VITEST !== "true") {
+      console.error("[llm-errors] insert failed:", err);
+    }
+  }
+}
+
 export async function logLlmToolCall(row: LogToolCallInput): Promise<void> {
   try {
     await sql(

--- a/dashboard/lib/llm-tools/runner.ts
+++ b/dashboard/lib/llm-tools/runner.ts
@@ -35,15 +35,60 @@ import {
 import type { AgenticModelAdapter } from "./runner-types";
 import { CliRunnerError } from "@/lib/llm-provider/cli/errors";
 
+/** Rich diagnostic detail attached to an AgenticRunnerError; surfaces in the
+ *  "Detalles" modal and in admin telemetry. Optional fields are populated only
+ *  when relevant (e.g. CLI fields are absent for OpenRouter failures). */
+export interface AgenticRunnerErrorDiagnostic {
+  /** Where in the loop the failure happened. */
+  phase:
+    | "tool_call"
+    | "tool_response"
+    | "final"
+    | "cli_spawn"
+    | "cli_exit"
+    | "limits";
+  toolRoundsUsed: number;
+  toolCallsUsed: number;
+  durationMs: number;
+  lastToolCall?: { name: string; argumentsTruncated: string };
+  /** CLI-specific fields, only set for `provider: cli` failures. */
+  cli?: {
+    exitCode: number | null;
+    /** argv (file + args) the runner spawned, sanitized. */
+    command?: readonly string[];
+    /** Last ~4 KB of CLI stderr, sanitized. */
+    stderrTail?: string;
+    /** Last ~4 KB of CLI stdout, sanitized. */
+    stdoutTail?: string;
+    /** Inner error code surfaced by the CLI binary (e.g. api_error_status). */
+    innerErrorCode?: string | number | null;
+  };
+  /** Limits in effect when the runner failed (helps distinguish "exhausted" vs "crash"). */
+  limitsAtFailure: {
+    maxRounds: number;
+    maxToolCalls: number;
+    toolTimeoutMs: number;
+    executeRowLimit: number;
+    payloadCharLimit: number;
+  };
+}
+
 export class AgenticRunnerError extends Error {
   readonly code: string;
   readonly requestId: string;
+  readonly diagnostic?: AgenticRunnerErrorDiagnostic;
 
-  constructor(code: string, message: string, requestId: string) {
+  constructor(
+    code: string,
+    message: string,
+    requestId: string,
+    diagnostic?: AgenticRunnerErrorDiagnostic,
+  ) {
     super(message);
     this.name = "AgenticRunnerError";
     this.code = code;
     this.requestId = requestId;
+    this.diagnostic = diagnostic;
   }
 }
 
@@ -138,6 +183,40 @@ export async function runAgenticChat(params: AgenticRunParams): Promise<AgenticR
   ];
 
   let toolCallsTotal = 0;
+  let lastToolName: string | null = null;
+  let lastToolArgs: string | null = null;
+  const startedAt = Date.now();
+
+  // ── helpers ─────────────────────────────────────────────────────────────
+  const buildLimits = () => ({
+    maxRounds: cfg.maxToolRounds,
+    maxToolCalls: cfg.maxToolCalls,
+    toolTimeoutMs: cfg.toolTimeoutMs,
+    executeRowLimit: cfg.maxRows,
+    payloadCharLimit: cfg.maxResultChars,
+  });
+  const buildLastToolCall = () =>
+    lastToolName
+      ? {
+          name: lastToolName,
+          argumentsTruncated: (lastToolArgs ?? "").slice(0, 300),
+        }
+      : undefined;
+  const buildBaseDiag = (phase: import("./runner").AgenticRunnerErrorDiagnostic["phase"], roundsDone: number): import("./runner").AgenticRunnerErrorDiagnostic => ({
+    phase,
+    toolRoundsUsed: roundsDone,
+    toolCallsUsed: toolCallsTotal,
+    durationMs: Date.now() - startedAt,
+    lastToolCall: buildLastToolCall(),
+    limitsAtFailure: buildLimits(),
+  });
+  const cliDiagFromError = (e: CliRunnerError) => ({
+    exitCode: e.exitCode,
+    command: e.details.command,
+    stderrTail: e.details.stderr,
+    stdoutTail: e.details.stdout,
+    innerErrorCode: e.details.innerErrorCode ?? null,
+  });
 
   for (let round = 0; round < cfg.maxToolRounds; round++) {
     emitAgenticProgress(ctx, {
@@ -158,19 +237,30 @@ export async function runAgenticChat(params: AgenticRunParams): Promise<AgenticR
     } catch (e) {
       if (e instanceof AgenticRunnerError) throw e;
       if (e instanceof CliRunnerError) {
-        throw new AgenticRunnerError(e.code, e.message, ctx.requestId);
+        const phase: import("./runner").AgenticRunnerErrorDiagnostic["phase"] =
+          e.details.phase === "spawn" ? "cli_spawn" : "cli_exit";
+        throw new AgenticRunnerError(e.code, e.message, ctx.requestId, {
+          ...buildBaseDiag(phase, round),
+          cli: cliDiagFromError(e),
+        });
       }
       throw new AgenticRunnerError(
         "AGENTIC_ADAPTER",
         e instanceof Error ? e.message : "Model step failed.",
         ctx.requestId,
+        buildBaseDiag("tool_call", round),
       );
     }
 
     addUsage(usage, step.usage);
 
     if (step.kind === "error") {
-      throw new AgenticRunnerError(step.code, step.message, ctx.requestId);
+      throw new AgenticRunnerError(
+        step.code,
+        step.message,
+        ctx.requestId,
+        buildBaseDiag("tool_call", round),
+      );
     }
 
     if (step.kind === "final") {
@@ -184,6 +274,7 @@ export async function runAgenticChat(params: AgenticRunParams): Promise<AgenticR
         "LLM_EMPTY",
         "The model returned no tools or final text.",
         ctx.requestId,
+        buildBaseDiag("final", round),
       );
     }
 
@@ -207,11 +298,14 @@ export async function runAgenticChat(params: AgenticRunParams): Promise<AgenticR
           "AGENTIC_MAX_TOOL_CALLS",
           `Exceeded maximum tool calls (${cfg.maxToolCalls}).`,
           ctx.requestId,
+          buildBaseDiag("limits", round),
         );
       }
 
       const name = tc.function?.name ?? "";
       const rawArgs = tc.function?.arguments ?? "{}";
+      lastToolName = name || "(missing)";
+      lastToolArgs = rawArgs;
       emitAgenticProgress(ctx, {
         type: "tool_start",
         round: round + 1,
@@ -278,5 +372,13 @@ export async function runAgenticChat(params: AgenticRunParams): Promise<AgenticR
     "AGENTIC_MAX_ROUNDS",
     `Exceeded maximum tool rounds (${cfg.maxToolRounds}).`,
     ctx.requestId,
+    {
+      phase: "limits",
+      toolRoundsUsed: cfg.maxToolRounds,
+      toolCallsUsed: toolCallsTotal,
+      durationMs: Date.now() - startedAt,
+      lastToolCall: buildLastToolCall(),
+      limitsAtFailure: buildLimits(),
+    },
   );
 }

--- a/etl/schema/init.sql
+++ b/etl/schema/init.sql
@@ -649,6 +649,38 @@ ALTER TABLE llm_tool_calls ADD COLUMN IF NOT EXISTS llm_provider TEXT NOT NULL D
 ALTER TABLE llm_tool_calls ADD COLUMN IF NOT EXISTS llm_driver TEXT;
 
 -- ============================================================
+-- AGENTIC_RUNNER failure audit log (Dashboard App — issue #419)
+-- One row per AgenticRunnerError surfaced from /api/dashboard/{generate,modify,analyze}.
+-- All string columns store sanitized values (see lib/llm-provider/sanitize.ts).
+-- ============================================================
+CREATE TABLE IF NOT EXISTS llm_errors (
+    id                SERIAL       PRIMARY KEY,
+    request_id        TEXT         NOT NULL,
+    endpoint          TEXT         NOT NULL,
+    code              TEXT         NOT NULL,
+    sub_error         TEXT,
+    provider          TEXT         NOT NULL,
+    driver            TEXT,
+    model             TEXT,
+    phase             TEXT,
+    duration_ms       INTEGER,
+    tool_rounds_used  INTEGER,
+    tool_calls_used   INTEGER,
+    last_tool_name    TEXT,
+    last_tool_args    TEXT,
+    cli_exit_code     INTEGER,
+    cli_inner_code    TEXT,
+    cli_command       TEXT,
+    cli_stdout_tail   TEXT,
+    cli_stderr_tail   TEXT,
+    limits            JSONB,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_llm_errors_created_at ON llm_errors(created_at);
+CREATE INDEX IF NOT EXISTS idx_llm_errors_request_id  ON llm_errors(request_id);
+CREATE INDEX IF NOT EXISTS idx_llm_errors_endpoint    ON llm_errors(endpoint);
+
+-- ============================================================
 -- LLM interaction history (Dashboard App — full run audit trail)
 -- ============================================================
 


### PR DESCRIPTION
Refs #419

## Root cause

The Claude Code CLI returns upstream API failures on **stdout** as a JSON envelope (`{"is_error":true,"api_error_status":401,"result":"…"}`) while exiting with **code 1** and **empty stderr**. The runner only inspected `stderr`, so a real failure (`401 Invalid authentication credentials`) became the meaningless `LLM_CLI_EXIT: claude agentic step: CLI exited with code 1`.

Reproduced inside the running container:
```
$ echo "hello" | claude -p "say hi" --model claude-sonnet-4-5 --output-format json
{"type":"result","is_error":true,"api_error_status":401,"result":"Failed to authenticate. API Error: 401 …"}
exit=1
```

The underlying environmental cause is the OAuth access token in `~/.claude/.credentials.json` had been expired for 14 hours and the refresh-token call to `claude.ai/api/auth/oauth/token` is being blocked by Cloudflare (`Refresh failed (403): <!DOCTYPE html>…Just a moment…`). The host operator must `claude /login` and `ps stack restart` to recover — but until now the dashboard made this look like a code bug.

## The fix

1. `assertCliSuccess` (and the exit-0 envelope path in `claudeCliAgenticStep`) now parse the stdout JSON envelope and lift API failures into structured codes:
   - `LLM_CLI_AUTH` (401/403, or "authenticate"/"unauthorized" in the message)
   - `LLM_CLI_API_ERROR` (other API failures)
   …with the inner `api_error_status`, sanitized stdout/stderr tails, and the spawned argv attached.

2. `AgenticRunnerError` now carries an `AgenticRunnerErrorDiagnostic`. The runner records `phase` / `durationMs` / `toolRoundsUsed` / `toolCallsUsed` / `lastToolCall` / `limitsAtFailure` and, when failing through `CliRunnerError`, fills in the `cli` sub-object (`exitCode`, sanitized `command` / `stderrTail` / `stdoutTail`, `innerErrorCode`).

3. The Docker entrypoint logs a clear remediation hint when the access token is already expired at startup OR the refresh endpoint returns a Cloudflare 403:
   ```
   [claude-auth] Hint: token endpoint is blocked by Cloudflare/anti-bot.
   Re-authenticate on the host: `claude /login` then `ps stack restart`.
   ```

## Expanded error reporting (what users now see in "Detalles")

`generate` / `modify` / `analyze` API responses for `AGENTIC_RUNNER` now ship a sanitized `diagnostic` object on the wire:

```json
{
  "code": "AGENTIC_RUNNER",
  "requestId": "req_bf5e16dd",
  "details": "LLM_CLI_AUTH: claude agentic step: Failed to authenticate…",
  "diagnostic": {
    "subError": "LLM_CLI_AUTH: …",
    "provider": "cli",
    "driver": "claude_code",
    "model": "claude-sonnet-4-5",
    "phase": "cli_exit",
    "durationMs": 4321,
    "toolRoundsUsed": 0,
    "toolCallsUsed": 0,
    "lastToolCall": { "name": "list_ps_tables", "argumentsTruncated": "{}" },
    "cli": {
      "exitCode": 1,
      "command": ["claude", "-p", "…", "--model", "claude-sonnet-4-5", "--output-format", "json"],
      "stderrTail": "",
      "stdoutTail": "{\"type\":\"result\",\"is_error\":true,\"api_error_status\":401,\"result\":\"Failed to authenticate…\"}",
      "innerErrorCode": 401
    },
    "limitsAtFailure": {
      "maxRounds": 8, "maxToolCalls": 24, "toolTimeoutMs": 15000,
      "executeRowLimit": 200, "payloadCharLimit": 20000
    }
  }
}
```

The new `AgenticErrorDetails` component renders this in five labelled sections — **Causa, Contexto, CLI, Tool en curso, Límites** — with multi-line `<pre>` blocks for stdout/stderr tails and a **"Copiar como JSON"** button that copies the full sanitized payload (used by both `ChatSidebar` and `ErrorDisplay`).

## Sanitization (mandatory)

`lib/llm-provider/sanitize.ts` is the single redaction point. It scrubs:
- `Bearer …` / `Authorization: …` / `sk-…` / `sk-ant-…` / JWT-shaped tokens
- postgres DSNs and `user:pass@host` basic-auth
- `password=…` query strings
- `refresh_token` / `access_token` JSON values
- the **live values** of every `sensitive: true` key from `config/schema.yaml`

`sanitize()` is idempotent (running twice yields the same output) and unit-tested with 18 cases including the live-literal redaction.

## Persistence

A new `llm_errors` table (created `IF NOT EXISTS` in `etl/schema/init.sql`) stores every AGENTIC_RUNNER failure: request_id, endpoint, code, sub_error, provider, driver, model, phase, duration_ms, tool_rounds_used, tool_calls_used, last_tool_name, last_tool_args, cli_exit_code, cli_inner_code, cli_command, cli_stdout_tail, cli_stderr_tail, limits (jsonb).

## Test plan

- [x] Unit: `lib/__tests__/llm-provider-sanitize.test.ts` — 18 cases (Bearer/sk-/sk-ant-/JWT/DSN/literal/idempotent/argv).
- [x] Unit: `lib/__tests__/llm-provider-process.test.ts` — 2 new regression cases for the issue #419 JSON envelope path (LLM_CLI_AUTH and LLM_CLI_API_ERROR).
- [x] Unit: `lib/__tests__/llm-tools-runner-cli.test.ts` — diagnostic capture from CliRunnerError.
- [x] All UI tests pass (`ChatSidebar`, `ErrorDisplay`).
- [ ] Manual repro: stop the dashboard, restart with an expired token, click "Analizar con IA" — `Detalles` modal should now show CLI section with `innerErrorCode: 401` and the upstream stdout JSON instead of just "exit code 1".

Pre-existing test failures in `llm-usage.test.ts` (2 cases) are unrelated to this change — they fail on `main` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)