### PR TITLE
fix(dashboard): repair pre-existing llm-usage budget test failures

### DIFF
--- a/dashboard/lib/__tests__/llm-usage.test.ts
+++ b/dashboard/lib/__tests__/llm-usage.test.ts
@@ -125,6 +125,16 @@ describe("logUsage", () => {
 describe("checkDailyBudget", () => {
   beforeEach(() => {
     mockQuery.mockReset();
+    // Isolate from any local ~/.config/powershop-analytics/config.yaml so the
+    // central config loader does not silently flip the dashboard LLM provider
+    // (e.g. to "cli") and short-circuit checkDailyBudget. Pointing CONFIG_FILE
+    // at a non-existent path forces the loader to use env > schema-defaults
+    // only, which is the contract these tests are exercising.
+    vi.stubEnv("CONFIG_FILE", "/nonexistent/test-isolation/config.yaml");
+    // Default to the OpenRouter provider — the budget check is OpenRouter-only
+    // by design (CLI rows log zero estimated cost, see D-019). Individual tests
+    // can override this with vi.stubEnv("DASHBOARD_LLM_PROVIDER", "cli").
+    vi.stubEnv("DASHBOARD_LLM_PROVIDER", "openrouter");
     resetDashboardLlmConfigCache();
   });
 


### PR DESCRIPTION
## Summary

Fixes #430. The two `checkDailyBudget` tests asserting `BudgetExceededError` were failing on `main` because the test environment leaked the developer's local `~/.config/powershop-analytics/config.yaml` into the central system config loader.

When that file pins `dashboard.llm_provider: cli` (common dev setup since D-019), `checkDailyBudget` correctly short-circuits — the OpenRouter-cost-based daily budget does not apply to CLI rows. So the function returned `undefined` instead of throwing `BudgetExceededError`.

## Root cause

- Production code is correct: env > config.yaml > defaults is the documented precedence (D-023).
- Test was leaky: it stubbed `LLM_DAILY_BUDGET_USD` but never declared the LLM provider, so `getSystemConfig()` fell through to the on-disk `config.yaml`, picking up `cli`.
- Several other tests in the same describe block "passed" only by silently returning early via the same path — they were not actually exercising the code they claimed to.

## Fix

Test-side only. In the `checkDailyBudget` `beforeEach`:

1. Stub `CONFIG_FILE` to a non-existent path so the loader cannot read the developer's local config.yaml.
2. Default `DASHBOARD_LLM_PROVIDER=openrouter` so the budget path is reached. The existing CLI short-circuit test still overrides this with `vi.stubEnv(...)` and works as before.

Tests are kept rigid (no `.skip`, no lowered assertions).

## Test plan

- [x] `npx vitest run lib/__tests__/llm-usage.test.ts` — 15/15 pass (was 13/15).
- [x] `npm test` — 1404/1404 pass, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)