### PR TITLE
feat(dashboard): NDJSON streaming progress + drilldown empty-value fix + UI improvements (issue #434)

### DIFF
--- a/dashboard/app/__tests__/analyze-route-streaming.test.ts
+++ b/dashboard/app/__tests__/analyze-route-streaming.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Streaming-path tests for POST /api/dashboard/analyze.
+ *
+ * The deferred-stream design opens an NDJSON response only when the agentic
+ * runner emits at least one progress event before finishing. These tests
+ * exercise that path explicitly.
+ *
+ * See dashboard/app/api/dashboard/analyze/route.ts for the contract.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/llm", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/llm")>("@/lib/llm");
+  return {
+    ...actual,
+    analyzeDashboard: vi.fn(),
+    generateSuggestions: vi.fn(),
+  };
+});
+
+import { POST } from "../api/dashboard/analyze/route";
+import * as llm from "@/lib/llm";
+
+const baseSpec = {
+  title: "Test Dashboard",
+  widgets: [
+    {
+      type: "number",
+      title: "Total",
+      sql: "SELECT 1",
+      format: "number",
+    },
+  ],
+};
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/dashboard/analyze", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function readNdjson(stream: ReadableStream<Uint8Array>): Promise<Record<string, unknown>[]> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const out: Record<string, unknown>[] = [];
+  let buf = "";
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    const lines = buf.split("\n");
+    buf = lines.pop() ?? "";
+    for (const line of lines) {
+      const t = line.trim();
+      if (!t) continue;
+      out.push(JSON.parse(t));
+    }
+  }
+  if (buf.trim()) out.push(JSON.parse(buf.trim()));
+  return out;
+}
+
+describe("POST /api/dashboard/analyze (streaming)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(llm.generateSuggestions).mockResolvedValue(["sugerencia 1"]);
+  });
+
+  it("opens NDJSON stream when the agentic runner emits at least one progress event", async () => {
+    vi.mocked(llm.analyzeDashboard).mockImplementation(async (_data, _prompt, _action, opts) => {
+      opts?.onAgenticProgress?.({ type: "tool_done", name: "execute_query", ok: true, ms: 12 });
+      await new Promise((r) => setTimeout(r, 0));
+      return "Análisis completo.";
+    });
+
+    const res = await POST(makeRequest({ spec: baseSpec, widgetData: {}, prompt: "Analiza" }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/x-ndjson");
+
+    const frames = await readNdjson(res.body!);
+    expect(frames.length).toBeGreaterThanOrEqual(2);
+    expect(frames[0]).toMatchObject({ type: "progress", logLine: { kind: "tool" } });
+    const last = frames[frames.length - 1];
+    expect(last).toMatchObject({
+      type: "result",
+      response: "Análisis completo.",
+      suggestions: ["sugerencia 1"],
+    });
+  });
+
+  it("emits a terminal error frame with httpStatus when the LLM fails after streaming starts", async () => {
+    vi.mocked(llm.analyzeDashboard).mockImplementation(async (_d, _p, _a, opts) => {
+      opts?.onAgenticProgress?.({ type: "tool_done", name: "validate_query", ok: false, ms: 8, errorCode: "BAD_SQL" });
+      await new Promise((r) => setTimeout(r, 0));
+      throw new Error("upstream rate limit 429 exceeded");
+    });
+
+    const res = await POST(makeRequest({ spec: baseSpec, widgetData: {}, prompt: "Analiza" }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/x-ndjson");
+
+    const frames = await readNdjson(res.body!);
+    const last = frames[frames.length - 1];
+    expect(last).toMatchObject({
+      type: "error",
+      httpStatus: 429,
+      code: "LLM_RATE_LIMIT",
+    });
+  });
+
+  it("falls back to JSON 5xx when the LLM fails BEFORE any progress event", async () => {
+    vi.mocked(llm.analyzeDashboard).mockRejectedValue(new Error("boom"));
+
+    const res = await POST(makeRequest({ spec: baseSpec, widgetData: {}, prompt: "Analiza" }));
+    expect(res.status).toBe(500);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = await res.json();
+    expect(body.code).toBe("LLM_ERROR");
+  });
+});

--- a/dashboard/app/__tests__/view-page.test.tsx
+++ b/dashboard/app/__tests__/view-page.test.tsx
@@ -8,6 +8,8 @@ import type { DashboardSpec } from "@/lib/schema";
 const chatSidebarCapture = vi.hoisted(() => ({
   pendingModifyInput: undefined as string | undefined,
   pendingModifyTriggerId: undefined as number | undefined,
+  pendingAnalyzeInput: undefined as string | undefined,
+  pendingAnalyzeTriggerId: undefined as number | undefined,
 }));
 
 // ---------------------------------------------------------------------------
@@ -75,6 +77,8 @@ vi.mock("@/components/ChatSidebar", () => ({
     onToggle,
     pendingModifyInput,
     pendingModifyTriggerId,
+    pendingAnalyzeInput,
+    pendingAnalyzeTriggerId,
   }: {
     spec: DashboardSpec;
     onSpecUpdate: (s: DashboardSpec, prompt: string) => void;
@@ -82,14 +86,20 @@ vi.mock("@/components/ChatSidebar", () => ({
     onToggle: () => void;
     pendingModifyInput?: string;
     pendingModifyTriggerId?: number;
+    pendingAnalyzeInput?: string;
+    pendingAnalyzeTriggerId?: number;
   }) => {
     chatSidebarCapture.pendingModifyInput = pendingModifyInput;
     chatSidebarCapture.pendingModifyTriggerId = pendingModifyTriggerId;
+    chatSidebarCapture.pendingAnalyzeInput = pendingAnalyzeInput;
+    chatSidebarCapture.pendingAnalyzeTriggerId = pendingAnalyzeTriggerId;
     return isOpen ? (
       <div
         data-testid="chat-sidebar"
         data-pending={pendingModifyInput ?? ""}
         data-trigger-id={pendingModifyTriggerId ?? ""}
+        data-pending-analyze={pendingAnalyzeInput ?? ""}
+        data-analyze-trigger-id={pendingAnalyzeTriggerId ?? ""}
       >
         <button type="button" onClick={onToggle}>
           Cerrar
@@ -135,6 +145,8 @@ describe("ViewDashboard page", () => {
     mockSearchParamsRef.current = new URLSearchParams();
     chatSidebarCapture.pendingModifyInput = undefined;
     chatSidebarCapture.pendingModifyTriggerId = undefined;
+    chatSidebarCapture.pendingAnalyzeInput = undefined;
+    chatSidebarCapture.pendingAnalyzeTriggerId = undefined;
   });
 
   afterEach(() => {
@@ -178,7 +190,10 @@ describe("ViewDashboard page", () => {
     expect(screen.getByTestId("last-refreshed")).toBeInTheDocument();
   });
 
-  it("chart drill-down opens chat sidebar with Spanish Modificar prefill", async () => {
+  it("chart drill-down opens chat sidebar with Spanish Analizar prefill (drilldown → Analizar tab)", async () => {
+    // Drill-downs ask "why?" — the page now routes them to the Analizar
+    // tab via pendingAnalyze (not pendingModify). The bar_chart prompt
+    // template includes both the segment label AND its value.
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(dashboardRecord),
@@ -192,14 +207,79 @@ describe("ViewDashboard page", () => {
 
     fireEvent.click(screen.getByTestId("sim-chart-click"));
 
-    const expected =
-      "Detalle de Tienda 05 en Ventas por tienda: desglose por categoría, top artículos y tendencia";
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-sidebar")).toBeInTheDocument();
+    });
+    const sidebar = screen.getByTestId("chat-sidebar");
+    // Modify prefill must be untouched.
+    expect(sidebar).toHaveAttribute("data-pending", "");
+    expect(sidebar).toHaveAttribute("data-trigger-id", "");
+    // Analyze prefill must contain the label and value (bar_chart drilldown).
+    const analyzePrompt = sidebar.getAttribute("data-pending-analyze") ?? "";
+    expect(analyzePrompt).toContain("Tienda 05");
+    expect(analyzePrompt).toContain("Ventas por tienda");
+    expect(analyzePrompt).toContain("999");
+    expect(sidebar).toHaveAttribute("data-analyze-trigger-id", "1");
+  });
+
+  it("chart drill-down with empty value omits the value clause (no 'tiene .' artifact)", async () => {
+    // Regression for the user-reported drilldown bug: TableWidget click
+    // emits `value: ""`, which used to produce "la fila X tiene .".
+    // Override the renderer mock for this single test so it sends an
+    // empty value with widgetType = "table".
+    rendererProps.length = 0;
+    const TestRenderer = ({
+      onDataPointClick,
+    }: {
+      onDataPointClick?: (ctx: { label: string; value: string; widgetTitle: string; widgetType: string }) => void;
+    }) => (
+      <div data-testid="dashboard-renderer">
+        <button
+          type="button"
+          data-testid="sim-table-click"
+          onClick={() =>
+            onDataPointClick?.({
+              label: "Tienda 05",
+              value: "",
+              widgetTitle: "Detalle por tienda",
+              widgetType: "table",
+            })
+          }
+        >
+          Sim table click
+        </button>
+      </div>
+    );
+    vi.doMock("@/components/DashboardRenderer", () => ({ DashboardRenderer: TestRenderer }));
+
+    // Re-import the page with the new mock active.
+    vi.resetModules();
+    const { default: FreshViewDashboard } = await import("../dashboard/[id]/page");
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(dashboardRecord),
+    });
+
+    render(<FreshViewDashboard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("dashboard-renderer")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("sim-table-click"));
 
     await waitFor(() => {
       expect(screen.getByTestId("chat-sidebar")).toBeInTheDocument();
     });
-    expect(screen.getByTestId("chat-sidebar")).toHaveAttribute("data-pending", expected);
-    expect(screen.getByTestId("chat-sidebar")).toHaveAttribute("data-trigger-id", "1");
+    const prompt = screen.getByTestId("chat-sidebar").getAttribute("data-pending-analyze") ?? "";
+    expect(prompt).toContain("Tienda 05");
+    expect(prompt).toContain("Detalle por tienda");
+    // The bug: when value was empty the prompt produced "tiene .". Assert
+    // this artifact is absent.
+    expect(prompt).not.toMatch(/tiene\s*\./);
+    // And no dangling " muestra ." either.
+    expect(prompt).not.toMatch(/muestra\s*\./);
+
+    vi.doUnmock("@/components/DashboardRenderer");
   });
 
   it("shows 404 when dashboard not found", async () => {

--- a/dashboard/app/api/dashboard/analyze/route.ts
+++ b/dashboard/app/api/dashboard/analyze/route.ts
@@ -406,7 +406,9 @@ export async function POST(request: Request) {
         }
         const { status, payload } = buildLlmErrorPayload(err, requestId, cfg);
         console.error(`[${requestId}] Error al analizar dashboard con LLM (mid-stream):`, err);
-        send({ type: "error", requestId, httpStatus: status, ...payload });
+        // Spread payload first so its `requestId` is the canonical one;
+        // then add type / httpStatus which are not part of ApiErrorResponse.
+        send({ ...payload, type: "error", httpStatus: status });
         controller.close();
         return;
       }

--- a/dashboard/app/api/dashboard/analyze/route.ts
+++ b/dashboard/app/api/dashboard/analyze/route.ts
@@ -2,12 +2,29 @@
  * POST /api/dashboard/analyze
  *
  * Accepts a dashboard spec + widget data + user prompt, calls the LLM to
- * produce a data analysis, and returns the response plus suggestion chips.
+ * produce a data analysis, and either:
  *
- * Request body:
- *   { spec: DashboardSpec, widgetData: Record<string, unknown>, prompt: string, action?: string }
- * Response:
- *   { response: string, suggestions: string[] }
+ *  a) returns the response as a single JSON document (legacy contract,
+ *     also used for ALL error responses — HTTP status reflects 4xx/5xx), or
+ *  b) streams progress events as NDJSON when the agentic runner emits at
+ *     least one progress event before completing.
+ *
+ * Status / contract:
+ *   • Validation errors        → HTTP 4xx, JSON `ApiErrorResponse`.
+ *   • LLM errors (no progress) → HTTP 4xx/5xx, JSON `ApiErrorResponse`.
+ *   • LLM errors (mid-stream)  → HTTP 200 NDJSON; final frame is
+ *                                `{type:"error", httpStatus, ...ApiErrorResponse}`.
+ *                                Clients MUST check the frame `httpStatus`
+ *                                field rather than `res.status` for
+ *                                mid-stream failures.
+ *   • Success (no progress)    → HTTP 200, JSON `{response, suggestions}`.
+ *   • Success (with progress)  → HTTP 200 NDJSON; final frame is
+ *                                `{type:"result", response, suggestions}`.
+ *
+ * Streaming frames (NDJSON):
+ *   { type: "progress", requestId, logLine: LogLine }   per agentic step
+ *   { type: "result",   requestId, response, suggestions }
+ *   { type: "error",    requestId, httpStatus, error, code, details?, diagnostic? }
  */
 import { NextResponse } from "next/server";
 import {
@@ -25,6 +42,7 @@ import {
   formatApiError,
   generateRequestId,
   sanitizeErrorMessage,
+  type ApiErrorResponse,
 } from "@/lib/errors";
 import type { WidgetData } from "@/components/widgets/types";
 import {
@@ -33,6 +51,9 @@ import {
 } from "@/lib/db-write";
 import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
 import { buildAgenticErrorDiagnostic, persistAgenticError } from "@/lib/llm-tools/diagnostic";
+import { agenticEventToLogLine } from "@/lib/format-agentic-progress";
+import type { AgenticProgressEvent } from "@/lib/llm-tools/types";
+import type { LogLine } from "@/components/LogBlock";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -86,6 +107,61 @@ function deserializeWidgetData(
     map.set(idx, widgetState);
   }
   return map;
+}
+
+/**
+ * Build the LLM error response payload (ApiErrorResponse shape) AND the
+ * HTTP status that should accompany it. Centralized so the JSON-only path
+ * and the NDJSON error frame stay in lock-step.
+ */
+function buildLlmErrorPayload(
+  err: unknown,
+  requestId: string,
+  cfg: ReturnType<typeof loadDashboardLlmConfig>,
+): { status: number; payload: ApiErrorResponse } {
+  if (err instanceof AgenticRunnerError) {
+    const diagnostic = buildAgenticErrorDiagnostic(err, cfg);
+    persistAgenticError("analyze", err, diagnostic);
+    return {
+      status: 500,
+      payload: formatApiError(
+        "El flujo de IA con herramientas alcanzó un límite o no pudo completarse. Inténtalo de nuevo.",
+        "AGENTIC_RUNNER",
+        diagnostic.subError,
+        err.requestId,
+        diagnostic,
+      ),
+    };
+  }
+  if (err instanceof BudgetExceededError) {
+    return {
+      status: 429,
+      payload: formatApiError(err.message, "LLM_BUDGET_EXCEEDED", undefined, requestId),
+    };
+  }
+  if (err instanceof CircuitBreakerOpenError) {
+    return {
+      status: 503,
+      payload: formatApiError(err.message, "LLM_CIRCUIT_OPEN", undefined, requestId),
+    };
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  const normalizedMessage = message.toLowerCase();
+  const isRateLimit =
+    normalizedMessage.includes("rate limit") ||
+    normalizedMessage.includes("ratelimit") ||
+    normalizedMessage.includes("429");
+  return {
+    status: isRateLimit ? 429 : 500,
+    payload: formatApiError(
+      isRateLimit
+        ? "Límite de uso del modelo de IA alcanzado. Inténtalo en unos minutos."
+        : "No se pudo analizar el dashboard. Inténtalo de nuevo.",
+      isRateLimit ? "LLM_RATE_LIMIT" : "LLM_ERROR",
+      sanitizeErrorMessage(err),
+      requestId,
+    ),
+  };
 }
 
 // ─── Route handler ────────────────────────────────────────────────────────────
@@ -213,83 +289,147 @@ export async function POST(request: Request) {
     console.error(`[${requestId}] createInteraction(analyze) failed:`, e);
   }
 
-  // --- Call LLM to analyze dashboard ----------------------------------------
-  let analysisResponse: string;
-  try {
-    analysisResponse = await analyzeDashboard(
-      serializedData,
-      prompt.trim(),
-      typeof action === "string" ? action : undefined,
-      {
-        requestId,
-        endpoint: "analyzeDashboard",
-        dashboardId: dashboardIdNum,
-      },
-    );
-  } catch (err) {
+  // --- Run the LLM call, collecting progress events into a buffer ----------
+  // We start the LLM call in the background. The progress callback pushes
+  // log lines into a buffer. We then await either the call's completion or
+  // the first progress event:
+  //
+  //   • If the call completes (success or failure) BEFORE any progress event
+  //     is buffered, we return a normal JSON response with proper HTTP
+  //     status. This is the "fast path" most tests / clients use.
+  //
+  //   • If at least one progress event was buffered before the call
+  //     resolved, we open an NDJSON stream that replays the buffered events
+  //     and continues live. From that point on errors must be reported as a
+  //     terminal `{type:"error", httpStatus, …}` frame because HTTP headers
+  //     have already been committed at status 200.
+  const t0 = Date.now();
+  const buffer: { type: "progress"; logLine: LogLine }[] = [];
+  let firstEventResolve: (() => void) | null = null;
+  const firstEvent = new Promise<void>((resolve) => {
+    firstEventResolve = resolve;
+  });
+
+  const onAgenticProgress = (ev: AgenticProgressEvent) => {
+    const logLine = agenticEventToLogLine(ev, Date.now() - t0);
+    if (!logLine) return;
+    buffer.push({ type: "progress", logLine });
+    if (firstEventResolve) {
+      firstEventResolve();
+      firstEventResolve = null;
+    }
+  };
+
+  type LlmOutcome =
+    | { kind: "ok"; response: string }
+    | { kind: "err"; err: unknown };
+
+  const llmPromise: Promise<LlmOutcome> = analyzeDashboard(
+    serializedData,
+    prompt.trim(),
+    typeof action === "string" ? action : undefined,
+    {
+      requestId,
+      endpoint: "analyzeDashboard",
+      dashboardId: dashboardIdNum,
+      onAgenticProgress,
+    },
+  ).then(
+    (response): LlmOutcome => ({ kind: "ok", response }),
+    (err): LlmOutcome => ({ kind: "err", err }),
+  );
+
+  // Race: first progress event vs. call completion.
+  const raceWinner = await Promise.race([
+    llmPromise.then(() => "done" as const),
+    firstEvent.then(() => "progress" as const),
+  ]);
+
+  if (raceWinner === "done") {
+    // Fast path: no progress was emitted before the call resolved.
+    const outcome = await llmPromise;
+    if (outcome.kind === "err") {
+      const { err } = outcome;
+      if (interactionId) {
+        const errText = err instanceof Error ? err.message : "Error al analizar";
+        await finishInteraction(interactionId, "error", errText).catch((e) =>
+          console.error(`[${requestId}] finishInteraction(analyze,error) failed:`, e),
+        );
+      }
+      const { status, payload } = buildLlmErrorPayload(err, requestId, cfg);
+      console.error(`[${requestId}] Error al analizar dashboard con LLM:`, err);
+      return NextResponse.json(payload, { status });
+    }
+    // Success without progress: keep legacy JSON contract.
+    const analysisResponse = outcome.response;
+    const lastExchange = `Usuario: ${prompt.trim()}\n\nAsistente: ${analysisResponse}`;
+    const suggestions = await generateSuggestions(serializedData, lastExchange, { requestId });
     if (interactionId) {
-      const errText = err instanceof Error ? err.message : "Error al analizar";
-      await finishInteraction(interactionId, "error", errText).catch((e) =>
-        console.error(`[${requestId}] finishInteraction(analyze,error) failed:`, e),
+      await finishInteraction(interactionId, "completed", analysisResponse).catch((e) =>
+        console.error(`[${requestId}] finishInteraction(analyze,completed) failed:`, e),
       );
     }
-    if (err instanceof AgenticRunnerError) {
-      const diagnostic = buildAgenticErrorDiagnostic(err, cfg);
-      persistAgenticError("analyze", err, diagnostic);
-      return NextResponse.json(
-        formatApiError(
-          "El flujo de IA con herramientas alcanzó un límite o no pudo completarse. Inténtalo de nuevo.",
-          "AGENTIC_RUNNER",
-          diagnostic.subError,
-          err.requestId,
-          diagnostic,
-        ),
-        { status: 500 },
-      );
-    }
-    if (err instanceof BudgetExceededError) {
-      return NextResponse.json(
-        formatApiError(err.message, "LLM_BUDGET_EXCEEDED", undefined, requestId),
-        { status: 429 },
-      );
-    }
-    if (err instanceof CircuitBreakerOpenError) {
-      return NextResponse.json(
-        formatApiError(err.message, "LLM_CIRCUIT_OPEN", undefined, requestId),
-        { status: 503 },
-      );
-    }
-    const message = err instanceof Error ? err.message : String(err);
-    const normalizedMessage = message.toLowerCase();
-    console.error(`[${requestId}] Error al analizar dashboard con LLM:`, err);
-
-    const isRateLimit =
-      normalizedMessage.includes("rate limit") ||
-      normalizedMessage.includes("ratelimit") ||
-      normalizedMessage.includes("429");
-
-    return NextResponse.json(
-      formatApiError(
-        isRateLimit
-          ? "Límite de uso del modelo de IA alcanzado. Inténtalo en unos minutos."
-          : "No se pudo analizar el dashboard. Inténtalo de nuevo.",
-        isRateLimit ? "LLM_RATE_LIMIT" : "LLM_ERROR",
-        sanitizeErrorMessage(err),
-        requestId,
-      ),
-      { status: isRateLimit ? 429 : 500 },
-    );
+    return NextResponse.json({ response: analysisResponse, suggestions });
   }
 
-  // --- Generate suggestions before returning the response ------------------
-  const lastExchange = `Usuario: ${prompt.trim()}\n\nAsistente: ${analysisResponse}`;
-  const suggestions = await generateSuggestions(serializedData, lastExchange, { requestId });
+  // Streaming path: at least one progress event was emitted.
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (obj: Record<string, unknown>) => {
+        controller.enqueue(encoder.encode(`${JSON.stringify(obj)}\n`));
+      };
 
-  if (interactionId) {
-    await finishInteraction(interactionId, "completed", analysisResponse).catch((e) =>
-      console.error(`[${requestId}] finishInteraction(analyze,completed) failed:`, e),
-    );
-  }
+      // Replay events buffered up to this point. New events will continue
+      // arriving via `onAgenticProgress` → push into `liveBuffer` then drain.
+      const drainBuffer = () => {
+        while (buffer.length) {
+          const ev = buffer.shift()!;
+          send({ ...ev, requestId });
+        }
+      };
+      drainBuffer();
 
-  return NextResponse.json({ response: analysisResponse, suggestions });
+      // Swap the progress callback so future events stream directly.
+      // (Closure-captured `onAgenticProgress` is no longer needed; we just
+      //  poll `buffer` after each await tick.)
+      const outcome = await llmPromise;
+      drainBuffer();
+
+      if (outcome.kind === "err") {
+        const { err } = outcome;
+        if (interactionId) {
+          const errText = err instanceof Error ? err.message : "Error al analizar";
+          await finishInteraction(interactionId, "error", errText).catch((e) =>
+            console.error(`[${requestId}] finishInteraction(analyze,error) failed:`, e),
+          );
+        }
+        const { status, payload } = buildLlmErrorPayload(err, requestId, cfg);
+        console.error(`[${requestId}] Error al analizar dashboard con LLM (mid-stream):`, err);
+        send({ type: "error", requestId, httpStatus: status, ...payload });
+        controller.close();
+        return;
+      }
+
+      const analysisResponse = outcome.response;
+      const lastExchange = `Usuario: ${prompt.trim()}\n\nAsistente: ${analysisResponse}`;
+      const suggestions = await generateSuggestions(serializedData, lastExchange, { requestId });
+      if (interactionId) {
+        await finishInteraction(interactionId, "completed", analysisResponse).catch((e) =>
+          console.error(`[${requestId}] finishInteraction(analyze,completed) failed:`, e),
+        );
+      }
+      send({ type: "result", requestId, response: analysisResponse, suggestions });
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/x-ndjson; charset=utf-8",
+      "Cache-Control": "no-store",
+      "X-Request-Id": requestId,
+    },
+  });
 }

--- a/dashboard/app/api/dashboard/modify/__tests__/route-streaming.test.ts
+++ b/dashboard/app/api/dashboard/modify/__tests__/route-streaming.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Streaming-path tests for POST /api/dashboard/modify.
+ *
+ * The deferred-stream design opens an NDJSON response only when the agentic
+ * runner emits at least one progress event before finishing. These tests
+ * exercise that path explicitly.
+ *
+ * See dashboard/app/api/dashboard/modify/route.ts for the contract.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockModifyDashboard } = vi.hoisted(() => ({
+  mockModifyDashboard: vi.fn(),
+}));
+
+vi.mock("@/lib/llm", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/llm")>("@/lib/llm");
+  return {
+    ...actual,
+    modifyDashboard: mockModifyDashboard,
+  };
+});
+
+vi.mock("@/lib/db-write", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/db-write")>("@/lib/db-write");
+  return {
+    ...actual,
+    createInteraction: vi.fn().mockResolvedValue("mock-interaction-id"),
+    finishInteraction: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { POST } from "../route";
+
+const validSpec = {
+  title: "Ventas Marzo",
+  widgets: [
+    {
+      type: "kpi_row" as const,
+      items: [
+        {
+          label: "Total Ventas",
+          sql: "SELECT SUM(total_si) FROM ps_ventas",
+          format: "currency" as const,
+        },
+      ],
+    },
+  ],
+};
+
+const updatedSpec = {
+  title: "Ventas Marzo Actualizado",
+  widgets: [
+    {
+      type: "kpi_row" as const,
+      items: [
+        {
+          label: "Total Ventas",
+          sql: "SELECT SUM(total_si) FROM ps_ventas",
+          format: "currency" as const,
+        },
+      ],
+    },
+  ],
+};
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/dashboard/modify", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function readNdjson(stream: ReadableStream<Uint8Array>): Promise<Record<string, unknown>[]> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const out: Record<string, unknown>[] = [];
+  let buf = "";
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    const lines = buf.split("\n");
+    buf = lines.pop() ?? "";
+    for (const line of lines) {
+      const t = line.trim();
+      if (!t) continue;
+      out.push(JSON.parse(t));
+    }
+  }
+  if (buf.trim()) out.push(JSON.parse(buf.trim()));
+  return out;
+}
+
+describe("POST /api/dashboard/modify (streaming)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens an NDJSON stream when the agentic runner emits at least one progress event", async () => {
+    // Simulate an agentic runner that emits a `tool_done` event then resolves.
+    mockModifyDashboard.mockImplementation(async (_spec, _prompt, opts) => {
+      opts?.onAgenticProgress?.({ type: "tool_done", name: "validate_query", ok: true, ms: 42 });
+      // Allow a microtask so the route observes the event before completion.
+      await new Promise((r) => setTimeout(r, 0));
+      return JSON.stringify(updatedSpec);
+    });
+
+    const res = await POST(
+      makeRequest({ spec: validSpec, prompt: "añade ventas por tienda" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/x-ndjson");
+    expect(res.headers.get("x-request-id")).toMatch(/^req_/);
+
+    const frames = await readNdjson(res.body!);
+    expect(frames.length).toBeGreaterThanOrEqual(2);
+    expect(frames[0]).toMatchObject({ type: "progress", logLine: { kind: "tool" } });
+    const last = frames[frames.length - 1];
+    expect(last).toMatchObject({ type: "result", spec: { title: "Ventas Marzo Actualizado" } });
+  });
+
+  it("emits a terminal error frame with httpStatus when the LLM fails after streaming starts", async () => {
+    mockModifyDashboard.mockImplementation(async (_spec, _prompt, opts) => {
+      opts?.onAgenticProgress?.({ type: "tool_done", name: "execute_query", ok: true, ms: 10 });
+      await new Promise((r) => setTimeout(r, 0));
+      throw new Error("upstream rate limit 429 exceeded");
+    });
+
+    const res = await POST(makeRequest({ spec: validSpec, prompt: "test" }));
+
+    // HTTP status must remain 200 here because headers were already
+    // committed when the first progress frame was sent. Clients must
+    // observe the terminal error frame's `httpStatus` field.
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/x-ndjson");
+
+    const frames = await readNdjson(res.body!);
+    const last = frames[frames.length - 1];
+    expect(last).toMatchObject({
+      type: "error",
+      httpStatus: 429,
+      code: "LLM_RATE_LIMIT",
+    });
+  });
+
+  it("falls back to JSON 5xx when the LLM fails BEFORE any progress event", async () => {
+    mockModifyDashboard.mockRejectedValue(new Error("boom"));
+
+    const res = await POST(makeRequest({ spec: validSpec, prompt: "test" }));
+    expect(res.status).toBe(500);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = await res.json();
+    expect(body.code).toBe("LLM_ERROR");
+  });
+});

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -404,7 +404,8 @@ export async function POST(request: Request) {
         }
         const { status, payload } = buildLlmErrorPayload(err, requestId, cfg);
         console.error(`[${requestId}] Error al modificar dashboard con LLM (mid-stream):`, err);
-        send({ type: "error", requestId, httpStatus: status, ...payload });
+        // Spread payload first so its `requestId` is canonical.
+        send({ ...payload, type: "error", httpStatus: status });
         controller.close();
         return;
       }
@@ -421,10 +422,9 @@ export async function POST(request: Request) {
           );
         }
         send({
-          type: "error",
-          requestId,
-          httpStatus: validation.status,
           ...validation.payload,
+          type: "error",
+          httpStatus: validation.status,
         });
         controller.close();
         return;

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -2,10 +2,27 @@
  * POST /api/dashboard/modify
  *
  * Accepts a current DashboardSpec and a user prompt, calls the LLM to produce
- * an updated spec, validates it, and returns the result.
+ * an updated spec, validates it, and either:
  *
- * Request body: { spec: DashboardSpec, prompt: string }
- * Response: 200 with updated DashboardSpec, or 400/429/500 on error.
+ *  a) returns the updated spec as a single JSON document (legacy contract,
+ *     also used for ALL error responses — HTTP status reflects 4xx/5xx), or
+ *  b) streams progress events as NDJSON when the agentic runner emits at
+ *     least one progress event before completing.
+ *
+ * Status / contract:
+ *   • Validation errors        → HTTP 4xx, JSON `ApiErrorResponse`.
+ *   • LLM/parse/lint errors    → HTTP 4xx/5xx, JSON `ApiErrorResponse` when
+ *                                no progress was emitted yet; otherwise
+ *                                HTTP 200 NDJSON terminating in
+ *                                `{type:"error", httpStatus, ...}`.
+ *   • Success (no progress)    → HTTP 200, JSON updated `DashboardSpec`.
+ *   • Success (with progress)  → HTTP 200 NDJSON terminating in
+ *                                `{type:"result", spec}`.
+ *
+ * Streaming frames (NDJSON):
+ *   { type: "progress", requestId, logLine: LogLine }
+ *   { type: "result",   requestId, spec: DashboardSpec }
+ *   { type: "error",    requestId, httpStatus, error, code, details?, diagnostic? }
  */
 import { NextResponse } from "next/server";
 import {
@@ -20,6 +37,7 @@ import {
   formatApiError,
   generateRequestId,
   sanitizeErrorMessage,
+  type ApiErrorResponse,
 } from "@/lib/errors";
 import {
   createInteraction,
@@ -27,6 +45,9 @@ import {
 } from "@/lib/db-write";
 import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
 import { buildAgenticErrorDiagnostic, persistAgenticError } from "@/lib/llm-tools/diagnostic";
+import { agenticEventToLogLine } from "@/lib/format-agentic-progress";
+import type { AgenticProgressEvent } from "@/lib/llm-tools/types";
+import type { LogLine } from "@/components/LogBlock";
 
 /**
  * Extract JSON from a string that may be wrapped in markdown code blocks.
@@ -38,6 +59,61 @@ function extractJson(raw: string): string {
     return fenced[1].trim();
   }
   return raw.trim();
+}
+
+/**
+ * Build the LLM error response payload (ApiErrorResponse shape) AND the
+ * HTTP status that should accompany it. Centralized so the JSON-only path
+ * and the NDJSON error frame stay in lock-step.
+ */
+function buildLlmErrorPayload(
+  err: unknown,
+  requestId: string,
+  cfg: ReturnType<typeof loadDashboardLlmConfig>,
+): { status: number; payload: ApiErrorResponse } {
+  if (err instanceof AgenticRunnerError) {
+    const diagnostic = buildAgenticErrorDiagnostic(err, cfg);
+    persistAgenticError("modify", err, diagnostic);
+    return {
+      status: 500,
+      payload: formatApiError(
+        "El flujo de IA con herramientas alcanzó un límite o no pudo completarse. Reformula el cambio o inténtalo de nuevo.",
+        "AGENTIC_RUNNER",
+        diagnostic.subError,
+        err.requestId,
+        diagnostic,
+      ),
+    };
+  }
+  if (err instanceof BudgetExceededError) {
+    return {
+      status: 429,
+      payload: formatApiError(err.message, "LLM_BUDGET_EXCEEDED", undefined, requestId),
+    };
+  }
+  if (err instanceof CircuitBreakerOpenError) {
+    return {
+      status: 503,
+      payload: formatApiError(err.message, "LLM_CIRCUIT_OPEN", undefined, requestId),
+    };
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  const normalizedMessage = message.toLowerCase();
+  const isRateLimit =
+    normalizedMessage.includes("rate limit") ||
+    normalizedMessage.includes("ratelimit") ||
+    normalizedMessage.includes("429");
+  return {
+    status: isRateLimit ? 429 : 500,
+    payload: formatApiError(
+      isRateLimit
+        ? "Límite de uso del modelo de IA alcanzado. Inténtalo en unos minutos."
+        : "No se pudo modificar el dashboard. Inténtalo de nuevo.",
+      isRateLimit ? "LLM_RATE_LIMIT" : "LLM_ERROR",
+      sanitizeErrorMessage(err),
+      requestId,
+    ),
+  };
 }
 
 export async function POST(request: Request) {
@@ -148,144 +224,229 @@ export async function POST(request: Request) {
     console.error(`[${requestId}] createInteraction(modify) failed:`, e);
   }
 
-  // --- Call LLM to modify the dashboard -------------------------------------
-  let rawResponse: string;
-  try {
-    rawResponse = await modifyDashboard(
-      JSON.stringify(specParse.data),
-      prompt.trim(),
-      { requestId, endpoint: "modifyDashboard" },
-    );
-  } catch (err: unknown) {
-    if (interactionId) {
-      const errText = err instanceof Error ? err.message : "Error al modificar";
-      await finishInteraction(interactionId, "error", errText).catch((e) =>
-        console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
-      );
+  // --- Run the LLM call, collecting progress events into a buffer ----------
+  // See analyze/route.ts for the rationale of the deferred-stream design:
+  // race the call's completion against the first progress event so we can
+  // (a) keep the legacy JSON contract (with proper HTTP status) for the
+  // common case, and (b) only open an NDJSON stream when the agentic runner
+  // actually streams progress events.
+  const t0 = Date.now();
+  const buffer: { type: "progress"; logLine: LogLine }[] = [];
+  let firstEventResolve: (() => void) | null = null;
+  const firstEvent = new Promise<void>((resolve) => {
+    firstEventResolve = resolve;
+  });
+
+  const onAgenticProgress = (ev: AgenticProgressEvent) => {
+    const logLine = agenticEventToLogLine(ev, Date.now() - t0);
+    if (!logLine) return;
+    buffer.push({ type: "progress", logLine });
+    if (firstEventResolve) {
+      firstEventResolve();
+      firstEventResolve = null;
     }
-    if (err instanceof AgenticRunnerError) {
-      const diagnostic = buildAgenticErrorDiagnostic(err, cfg);
-      persistAgenticError("modify", err, diagnostic);
-      return NextResponse.json(
-        formatApiError(
-          "El flujo de IA con herramientas alcanzó un límite o no pudo completarse. Reformula el cambio o inténtalo de nuevo.",
-          "AGENTIC_RUNNER",
-          diagnostic.subError,
-          err.requestId,
-          diagnostic,
+  };
+
+  type LlmOutcome =
+    | { kind: "ok"; rawResponse: string }
+    | { kind: "err"; err: unknown };
+
+  const llmPromise: Promise<LlmOutcome> = modifyDashboard(
+    JSON.stringify(specParse.data),
+    prompt.trim(),
+    { requestId, endpoint: "modifyDashboard", onAgenticProgress },
+  ).then(
+    (rawResponse): LlmOutcome => ({ kind: "ok", rawResponse }),
+    (err): LlmOutcome => ({ kind: "err", err }),
+  );
+
+  const raceWinner = await Promise.race([
+    llmPromise.then(() => "done" as const),
+    firstEvent.then(() => "progress" as const),
+  ]);
+
+  // -------------------------------------------------------------------------
+  // Helper: parse + validate the LLM raw response into a DashboardSpec.
+  // Returns a discriminated result so both code paths can react identically.
+  // -------------------------------------------------------------------------
+  type ValidationOutcome =
+    | { ok: true; spec: DashboardSpec }
+    | { ok: false; status: number; payload: ApiErrorResponse };
+
+  const validateLlmResponse = (rawResponse: string): ValidationOutcome => {
+    const jsonStr = extractJson(rawResponse);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonStr);
+    } catch {
+      console.error(
+        `[${requestId}] El LLM devolvió JSON inválido al modificar (${jsonStr.length} chars)`,
+      );
+      return {
+        ok: false,
+        status: 400,
+        payload: formatApiError(
+          "El modelo de IA devolvió una respuesta con formato incorrecto.",
+          "LLM_INVALID_RESPONSE",
+          undefined,
+          requestId,
         ),
-        { status: 500 },
-      );
+      };
     }
-    if (err instanceof BudgetExceededError) {
-      return NextResponse.json(
-        formatApiError(err.message, "LLM_BUDGET_EXCEEDED", undefined, requestId),
-        { status: 429 },
-      );
-    }
-    if (err instanceof CircuitBreakerOpenError) {
-      return NextResponse.json(
-        formatApiError(err.message, "LLM_CIRCUIT_OPEN", undefined, requestId),
-        { status: 503 },
-      );
-    }
-    const message = err instanceof Error ? err.message : String(err);
-    const normalizedMessage = message.toLowerCase();
-    console.error(`[${requestId}] Error al modificar dashboard con LLM:`, err);
 
-    const isRateLimit =
-      normalizedMessage.includes("rate limit") ||
-      normalizedMessage.includes("ratelimit") ||
-      normalizedMessage.includes("429");
-
-    return NextResponse.json(
-      formatApiError(
-        isRateLimit
-          ? "Límite de uso del modelo de IA alcanzado. Inténtalo en unos minutos."
-          : "No se pudo modificar el dashboard. Inténtalo de nuevo.",
-        isRateLimit ? "LLM_RATE_LIMIT" : "LLM_ERROR",
-        sanitizeErrorMessage(err),
-        requestId,
-      ),
-      { status: isRateLimit ? 429 : 500 },
-    );
-  }
-
-  // --- Parse and validate LLM response --------------------------------------
-  const jsonStr = extractJson(rawResponse);
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(jsonStr);
-  } catch {
-    console.error(
-      `[${requestId}] El LLM devolvió JSON inválido al modificar (${jsonStr.length} chars)`,
-    );
-    if (interactionId) {
-      await finishInteraction(interactionId, "error", "JSON inválido en respuesta del modelo").catch(
-        (e) => console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
-      );
+    let updatedSpec: DashboardSpec;
+    try {
+      updatedSpec = validateSpec(parsed);
+    } catch {
+      console.error(`[${requestId}] El LLM devolvió un spec inválido al modificar.`);
+      return {
+        ok: false,
+        status: 400,
+        payload: formatApiError(
+          "El modelo de IA generó un dashboard con estructura incorrecta.",
+          "LLM_INVALID_RESPONSE",
+          undefined,
+          requestId,
+        ),
+      };
     }
-    return NextResponse.json(
-      formatApiError(
-        "El modelo de IA devolvió una respuesta con formato incorrecto.",
-        "LLM_INVALID_RESPONSE",
-        undefined,
-        requestId,
-      ),
-      { status: 400 },
-    );
-  }
 
-  let updatedSpec: DashboardSpec;
-  try {
-    updatedSpec = validateSpec(parsed);
-  } catch {
-    console.error(`[${requestId}] El LLM devolvió un spec inválido al modificar.`);
-    if (interactionId) {
-      await finishInteraction(interactionId, "error", "Spec inválido").catch((e) =>
-        console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
+    const sqlLint = lintDashboardSpec(updatedSpec);
+    if (sqlLint.length > 0) {
+      console.error(
+        `[${requestId}] SQL heurístico rechazó el spec modificado por el LLM:`,
+        sqlLint.join(" | "),
       );
-    }
-    return NextResponse.json(
-      formatApiError(
-        "El modelo de IA generó un dashboard con estructura incorrecta.",
-        "LLM_INVALID_RESPONSE",
-        undefined,
-        requestId,
-      ),
-      { status: 400 },
-    );
-  }
-
-  const sqlLint = lintDashboardSpec(updatedSpec);
-  if (sqlLint.length > 0) {
-    console.error(
-      `[${requestId}] SQL heurístico rechazó el spec modificado por el LLM:`,
-      sqlLint.join(" | "),
-    );
-    if (interactionId) {
-      await finishInteraction(interactionId, "error", `SQL lint: ${sqlLint.join(" | ")}`).catch(
-        (e) => console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
-      );
-    }
-    return NextResponse.json(
-      {
-        ...formatApiError(
+      return {
+        ok: false,
+        status: 400,
+        payload: formatApiError(
           "El modelo devolvió SQL con patrones inválidos para PostgreSQL. Reformula el cambio o inténtalo de nuevo.",
           "SQL_LINT",
           sqlLint.join(" | "),
           requestId,
         ),
-      },
-      { status: 400 },
-    );
+      };
+    }
+
+    return { ok: true, spec: updatedSpec };
+  };
+
+  // -------------------------------------------------------------------------
+  // Fast path: no progress emitted before completion → legacy JSON contract.
+  // -------------------------------------------------------------------------
+  if (raceWinner === "done") {
+    const outcome = await llmPromise;
+    if (outcome.kind === "err") {
+      const { err } = outcome;
+      if (interactionId) {
+        const errText = err instanceof Error ? err.message : "Error al modificar";
+        await finishInteraction(interactionId, "error", errText).catch((e) =>
+          console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
+        );
+      }
+      const { status, payload } = buildLlmErrorPayload(err, requestId, cfg);
+      console.error(`[${requestId}] Error al modificar dashboard con LLM:`, err);
+      return NextResponse.json(payload, { status });
+    }
+
+    const validation = validateLlmResponse(outcome.rawResponse);
+    if (!validation.ok) {
+      if (interactionId) {
+        const errText =
+          validation.payload.code === "SQL_LINT"
+            ? `SQL lint: ${validation.payload.details ?? ""}`
+            : validation.payload.error;
+        await finishInteraction(interactionId, "error", errText).catch((e) =>
+          console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
+        );
+      }
+      return NextResponse.json(validation.payload, { status: validation.status });
+    }
+
+    const updatedSpec = validation.spec;
+    if (interactionId) {
+      await finishInteraction(interactionId, "completed", JSON.stringify(updatedSpec)).catch((e) =>
+        console.error(`[${requestId}] finishInteraction(modify,completed) failed:`, e),
+      );
+    }
+    return NextResponse.json(updatedSpec);
   }
 
-  if (interactionId) {
-    await finishInteraction(interactionId, "completed", JSON.stringify(updatedSpec)).catch((e) =>
-      console.error(`[${requestId}] finishInteraction(modify,completed) failed:`, e),
-    );
-  }
+  // -------------------------------------------------------------------------
+  // Streaming path: at least one progress event was emitted.
+  // -------------------------------------------------------------------------
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (obj: Record<string, unknown>) => {
+        controller.enqueue(encoder.encode(`${JSON.stringify(obj)}\n`));
+      };
 
-  return NextResponse.json(updatedSpec);
+      const drainBuffer = () => {
+        while (buffer.length) {
+          const ev = buffer.shift()!;
+          send({ ...ev, requestId });
+        }
+      };
+      drainBuffer();
+
+      const outcome = await llmPromise;
+      drainBuffer();
+
+      if (outcome.kind === "err") {
+        const { err } = outcome;
+        if (interactionId) {
+          const errText = err instanceof Error ? err.message : "Error al modificar";
+          await finishInteraction(interactionId, "error", errText).catch((e) =>
+            console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
+          );
+        }
+        const { status, payload } = buildLlmErrorPayload(err, requestId, cfg);
+        console.error(`[${requestId}] Error al modificar dashboard con LLM (mid-stream):`, err);
+        send({ type: "error", requestId, httpStatus: status, ...payload });
+        controller.close();
+        return;
+      }
+
+      const validation = validateLlmResponse(outcome.rawResponse);
+      if (!validation.ok) {
+        if (interactionId) {
+          const errText =
+            validation.payload.code === "SQL_LINT"
+              ? `SQL lint: ${validation.payload.details ?? ""}`
+              : validation.payload.error;
+          await finishInteraction(interactionId, "error", errText).catch((e) =>
+            console.error(`[${requestId}] finishInteraction(modify,error) failed:`, e),
+          );
+        }
+        send({
+          type: "error",
+          requestId,
+          httpStatus: validation.status,
+          ...validation.payload,
+        });
+        controller.close();
+        return;
+      }
+
+      const updatedSpec = validation.spec;
+      if (interactionId) {
+        await finishInteraction(interactionId, "completed", JSON.stringify(updatedSpec)).catch((e) =>
+          console.error(`[${requestId}] finishInteraction(modify,completed) failed:`, e),
+        );
+      }
+      send({ type: "result", requestId, spec: updatedSpec });
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/x-ndjson; charset=utf-8",
+      "Cache-Control": "no-store",
+      "X-Request-Id": requestId,
+    },
+  });
 }

--- a/dashboard/app/dashboard/[id]/page.tsx
+++ b/dashboard/app/dashboard/[id]/page.tsx
@@ -118,6 +118,7 @@ export default function ViewDashboard() {
   const [chatOpen, setChatOpen] = useState(false);
   const [chatInitialMode, setChatInitialMode] = useState<"modificar" | "analizar" | undefined>(undefined);
   const [pendingModify, setPendingModify] = useState<{ prompt: string; id: number } | null>(null);
+  const [pendingAnalyze, setPendingAnalyze] = useState<{ prompt: string; id: number } | null>(null);
   const drillDownIdRef = useRef(0);
   const [glossaryOpen, setGlossaryOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
@@ -386,19 +387,45 @@ export default function ViewDashboard() {
   }, []);
 
   const handleDataPointClick = useCallback((ctx: DrillDownContext) => {
+    // Compose a useful prompt. ctx.value may be empty for table/ranked_bars
+    // row clicks (no clean numeric value to highlight). When it is empty we
+    // omit the value clause entirely so we never produce "la fila X tiene .".
+    const value = typeof ctx.value === "string" ? ctx.value.trim() : ctx.value;
+    const hasValue = value !== "" && value !== null && value !== undefined;
+    const labelStr = String(ctx.label ?? "").trim();
+    const title = ctx.widgetTitle ?? "";
     let prompt: string;
     if (ctx.widgetType === "bar_chart" || ctx.widgetType === "donut_chart") {
-      prompt = `Detalle de ${ctx.label} en ${ctx.widgetTitle}: desglose por categoría, top artículos y tendencia`;
+      prompt = hasValue
+        ? `En el widget "${title}", el segmento "${labelStr}" muestra ${value}. ¿Por qué tiene ese valor? Compara con los demás segmentos visibles en el dashboard, identifica si es una anomalía y sugiere qué acción tomar.`
+        : `En el widget "${title}", el segmento "${labelStr}". ¿Por qué destaca? Compara con los demás segmentos visibles en el dashboard, identifica si es una anomalía y sugiere qué acción tomar.`;
     } else if (ctx.widgetType === "line_chart" || ctx.widgetType === "area_chart") {
-      prompt = `¿Qué ocurrió en ${ctx.label} en ${ctx.widgetTitle}? Detalle por tienda y categoría`;
+      prompt = hasValue
+        ? `En el widget "${title}", el punto "${labelStr}" tiene un valor de ${value}. ¿Qué factores explican ese nivel? Compara con el período anterior y con otras tiendas o categorías del dashboard.`
+        : `En el widget "${title}", el punto "${labelStr}". ¿Qué factores explican ese nivel? Compara con el período anterior y con otras tiendas o categorías del dashboard.`;
+    } else if (ctx.widgetType === "table" || ctx.widgetType === "ranked_bars") {
+      // Table/ranked_bars rows usually pass label = primary identifier and
+      // an empty value (no single numeric column to highlight). Build a
+      // prompt around the row identifier only.
+      prompt = hasValue
+        ? `En el widget "${title}", la fila "${labelStr}" tiene ${value}. ¿Es un valor atípico respecto al resto? ¿Qué lo explica y qué se puede hacer?`
+        : `En el widget "${title}", la fila "${labelStr}". ¿Es atípica respecto al resto? ¿Qué la explica y qué se puede hacer?`;
     } else {
-      prompt = `Más información sobre ${ctx.label}`;
+      prompt = hasValue
+        ? `En el widget "${title}", el elemento "${labelStr}" muestra ${value}. Dame más detalle y contexto sobre este dato.`
+        : `En el widget "${title}", dame más detalle y contexto sobre "${labelStr}".`;
     }
     setGlossaryOpen(false);
     setHistoryOpen(false);
     drillDownIdRef.current += 1;
-    setPendingModify({ prompt, id: drillDownIdRef.current });
+    // Drill-downs ask "why?" — route to the Analizar tab, not Modificar.
+    setPendingAnalyze({ prompt, id: drillDownIdRef.current });
+    setChatInitialMode("analizar");
     setChatOpen(true);
+  }, []);
+
+  const handlePendingAnalyzeInputConsumed = useCallback(() => {
+    setPendingAnalyze(null);
   }, []);
 
   const handleChatToggle = useCallback(() => {
@@ -1060,6 +1087,9 @@ export default function ViewDashboard() {
         pendingModifyInput={pendingModify?.prompt}
         pendingModifyTriggerId={pendingModify?.id}
         onPendingModifyInputConsumed={handlePendingModifyInputConsumed}
+        pendingAnalyzeInput={pendingAnalyze?.prompt}
+        pendingAnalyzeTriggerId={pendingAnalyze?.id}
+        onPendingAnalyzeInputConsumed={handlePendingAnalyzeInputConsumed}
         initialMode={chatInitialMode}
       />
 

--- a/dashboard/components/ChatSidebar.tsx
+++ b/dashboard/components/ChatSidebar.tsx
@@ -53,8 +53,16 @@ export interface ChatSidebarProps {
    */
   pendingModifyInput?: string;
   pendingModifyTriggerId?: number;
-  /** Called once the pre-fill has been applied so the parent can clear state. */
+  /** Called once the modify pre-fill has been applied so the parent can clear state. */
   onPendingModifyInputConsumed?: () => void;
+  /**
+   * When `pendingAnalyzeTriggerId` changes with a non-empty `pendingAnalyzeInput`,
+   * the Analizar tab is selected, the textarea is filled, focused, and the sidebar opens if needed.
+   */
+  pendingAnalyzeInput?: string;
+  pendingAnalyzeTriggerId?: number;
+  /** Called once the analyze pre-fill has been applied so the parent can clear state. */
+  onPendingAnalyzeInputConsumed?: () => void;
   /**
    * Idempotent open when drill-down fires while the sidebar is collapsed.
    */
@@ -73,22 +81,56 @@ export interface ChatSidebarProps {
 // Simulated log sequences
 // ---------------------------------------------------------------------------
 
-const ANALYZE_LOG_SEQUENCE: LogLine[] = [
-  { timestamp: "+0.0s", kind: "tool",   label: "parse_intent",      detail: "intent=analysis · scope=dashboard" },
-  { timestamp: "+0.3s", kind: "tool",   label: "fetch_widget_data", detail: "6 widgets" },
-  { timestamp: "+0.9s", kind: "tool",   label: "run_sql",           detail: "SELECT store, SUM(net) FROM sales …" },
-  { timestamp: "+1.4s", kind: "reason", label: "Razonando",         detail: "comparando con período anterior" },
-  { timestamp: "+2.1s", kind: "tool",   label: "detect_anomalies",  detail: "z > 2.5 · 0 hits" },
-  { timestamp: "+2.7s", kind: "done",   label: "Respuesta lista",   detail: "1.984 tokens · claude-sonnet" },
-];
+// ---------------------------------------------------------------------------
+// NDJSON stream reader
+// ---------------------------------------------------------------------------
+//
+// `/api/dashboard/analyze` and `/api/dashboard/modify` open an NDJSON stream
+// when the agentic runner emits at least one progress event before the LLM
+// finishes. Each line is one JSON object. The terminal frame is either
+// `{type:"result", …}` or `{type:"error", httpStatus, …}`.
+//
+// When no progress event is emitted (or the runtime is in fast/single-shot
+// mode), the response is a single JSON document with the proper HTTP status,
+// and we stay on the legacy `await res.json()` path.
 
-const MODIFY_LOG_SEQUENCE: LogLine[] = [
-  { timestamp: "+0.0s", kind: "tool",   label: "parse_request",     detail: "op=modify · target=dashboard" },
-  { timestamp: "+0.4s", kind: "tool",   label: "lookup_schema",     detail: "table=sales · cols=net,margin" },
-  { timestamp: "+1.0s", kind: "reason", label: "Generando spec",    detail: "planning widget changes" },
-  { timestamp: "+1.6s", kind: "tool",   label: "validate_sql",      detail: "OK · 0 errors" },
-  { timestamp: "+2.0s", kind: "done",   label: "Dashboard listo",   detail: "spec generado · persistido" },
-];
+async function* readNdjsonStream<T>(body: ReadableStream<Uint8Array>): AsyncGenerator<T> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        const t = line.trim();
+        if (!t) continue;
+        try {
+          yield JSON.parse(t) as T;
+        } catch {
+          /* skip malformed line */
+        }
+      }
+    }
+    if (buffer.trim()) {
+      try {
+        yield JSON.parse(buffer.trim()) as T;
+      } catch {
+        /* skip */
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function isNdjsonResponse(res: Response): boolean {
+  const ct = res.headers.get("content-type") ?? "";
+  return ct.includes("application/x-ndjson");
+}
 
 // ---------------------------------------------------------------------------
 // Suggestion chips per mode
@@ -513,14 +555,37 @@ function ModificarTab({
     setMessages((prev) => [...prev, userMessage]);
     setInput("");
     setLoading(true);
-
-    // Simulate streaming log
     setStreamingLog([]);
-    MODIFY_LOG_SEQUENCE.forEach((line, i) => {
-      setTimeout(() => {
-        setStreamingLog((cur) => cur ? [...cur, line] : cur);
-      }, (i + 1) * 400);
-    });
+
+    // Real progress lines streamed from the server (NDJSON path) — captured
+    // in a local mutable array so the final message logs include exactly
+    // what the user saw during the request.
+    const capturedLogs: LogLine[] = [];
+
+    /**
+     * Append the assistant message AFTER the user message in a way that is
+     * resilient to concurrent message arrivals (the streaming request is
+     * async, so `messages` captured at the start of the callback can be
+     * stale by the time we resolve). We use a functional updater that walks
+     * the current message list and appends immediately after the matching
+     * user message, never overwriting newer messages someone else added.
+     */
+    const appendAssistant = (assistant: ChatMessage) => {
+      let nextSnapshot: ChatMessage[] = [];
+      setMessages((prev) => {
+        // Find our user message by reference — userMessage is unique to
+        // this send. Insert right after it; if not found (defensive),
+        // append to the end.
+        const idx = prev.indexOf(userMessage);
+        const next =
+          idx >= 0
+            ? [...prev.slice(0, idx + 1), assistant, ...prev.slice(idx + 1)]
+            : [...prev, assistant];
+        nextSnapshot = next;
+        return next;
+      });
+      onMessagesChange?.(nextSnapshot);
+    };
 
     try {
       const res = await fetch("/api/dashboard/modify", {
@@ -529,6 +594,85 @@ function ModificarTab({
         body: JSON.stringify({ spec, prompt: trimmed }),
       });
 
+      // -------------------------------------------------------------------
+      // Streaming path: server opened an NDJSON stream (HTTP 200).
+      // -------------------------------------------------------------------
+      if (res.ok && res.body && isNdjsonResponse(res)) {
+        type ModifyMsg =
+          | { type: "progress"; requestId: string; logLine: LogLine }
+          | { type: "result"; requestId: string; spec: DashboardSpec }
+          | ({ type: "error"; requestId: string; httpStatus?: number } & Partial<ApiErrorResponse>);
+
+        let resultSpec: DashboardSpec | null = null;
+        let errorFrame: (ModifyMsg & { type: "error" }) | null = null;
+
+        for await (const msg of readNdjsonStream<ModifyMsg>(res.body)) {
+          if (msg.type === "progress") {
+            capturedLogs.push(msg.logLine);
+            setStreamingLog([...capturedLogs]);
+          } else if (msg.type === "result") {
+            resultSpec = msg.spec;
+          } else if (msg.type === "error") {
+            errorFrame = msg;
+          }
+        }
+
+        if (errorFrame) {
+          const httpStatus = errorFrame.httpStatus ?? 500;
+          const errorDetail: ApiErrorResponse | undefined = isApiErrorResponse(errorFrame)
+            ? (errorFrame as unknown as ApiErrorResponse)
+            : undefined;
+          const baseMsg = errorFrame.error
+            ?? (httpStatus >= 500
+              ? "Error interno del servidor. Inténtalo de nuevo."
+              : "No se pudo aplicar la modificación. Revisa tu petición.");
+          const userMsg = httpStatus === 429
+            ? "Límite de uso del modelo de IA alcanzado. Inténtalo en unos minutos."
+            : baseMsg;
+          console.error("Modify API error (stream):", errorDetail ?? userMsg);
+          appendAssistant({
+            role: "assistant",
+            content: userMsg,
+            timestamp: new Date(),
+            isError: true,
+            errorDetail,
+            logs: [...capturedLogs],
+          });
+          return;
+        }
+
+        if (resultSpec) {
+          onSpecUpdate(resultSpec, trimmed);
+          const widgetDelta = resultSpec.widgets.length - spec.widgets.length;
+          let summary = "Dashboard actualizado.";
+          if (widgetDelta > 0) {
+            summary += ` Se ${widgetDelta === 1 ? "ha añadido 1 widget" : `han añadido ${widgetDelta} widgets`}.`;
+          } else if (widgetDelta < 0) {
+            summary += ` Se ${widgetDelta === -1 ? "ha eliminado 1 widget" : `han eliminado ${Math.abs(widgetDelta)} widgets`}.`;
+          }
+          appendAssistant({
+            role: "assistant",
+            content: summary,
+            timestamp: new Date(),
+            logs: [...capturedLogs],
+          });
+          return;
+        }
+
+        // Stream ended without result or error — treat as transport error.
+        appendAssistant({
+          role: "assistant",
+          content: "La respuesta del servidor terminó inesperadamente.",
+          timestamp: new Date(),
+          isError: true,
+          logs: [...capturedLogs],
+        });
+        return;
+      }
+
+      // -------------------------------------------------------------------
+      // Legacy JSON path (fast / single-shot / validation errors).
+      // -------------------------------------------------------------------
       if (!res.ok) {
         let errorDetail: ApiErrorResponse | undefined;
         let userMsg: string;
@@ -557,20 +701,14 @@ function ModificarTab({
 
         console.error("Modify API error:", errorDetail ?? userMsg);
 
-        const newMessages: ChatMessage[] = [
-          ...messages,
-          userMessage,
-          {
-            role: "assistant",
-            content: userMsg,
-            timestamp: new Date(),
-            isError: true,
-            errorDetail,
-            logs: streamingLog ?? [],
-          },
-        ];
-        setMessages(newMessages);
-        onMessagesChange?.(newMessages);
+        appendAssistant({
+          role: "assistant",
+          content: userMsg,
+          timestamp: new Date(),
+          isError: true,
+          errorDetail,
+          logs: [...capturedLogs],
+        });
         return;
       }
 
@@ -585,19 +723,12 @@ function ModificarTab({
         summary += ` Se ${widgetDelta === -1 ? "ha eliminado 1 widget" : `han eliminado ${Math.abs(widgetDelta)} widgets`}.`;
       }
 
-      const capturedLogs = [...MODIFY_LOG_SEQUENCE];
-      const newMessages: ChatMessage[] = [
-        ...messages,
-        userMessage,
-        {
-          role: "assistant",
-          content: summary,
-          timestamp: new Date(),
-          logs: capturedLogs,
-        },
-      ];
-      setMessages(newMessages);
-      onMessagesChange?.(newMessages);
+      appendAssistant({
+        role: "assistant",
+        content: summary,
+        timestamp: new Date(),
+        logs: [...capturedLogs],
+      });
     } catch (err) {
       console.error("Error al procesar la solicitud del chat:", err);
 
@@ -606,23 +737,18 @@ function ModificarTab({
           ? "No se pudo conectar con el servidor."
           : "Ocurrió un problema al procesar la respuesta.";
 
-      const newMessages: ChatMessage[] = [
-        ...messages,
-        userMessage,
-        {
-          role: "assistant",
-          content: errorMessage,
-          timestamp: new Date(),
-          isError: true,
-        },
-      ];
-      setMessages(newMessages);
-      onMessagesChange?.(newMessages);
+      appendAssistant({
+        role: "assistant",
+        content: errorMessage,
+        timestamp: new Date(),
+        isError: true,
+        logs: [...capturedLogs],
+      });
     } finally {
       setLoading(false);
       setTimeout(() => setStreamingLog(null), 400);
     }
-  }, [input, loading, spec, onSpecUpdate, setMessages, onMessagesChange, messages, streamingLog]);
+  }, [input, loading, spec, onSpecUpdate, setMessages, onMessagesChange]);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -771,6 +897,8 @@ function AnalizarTab({
   onMessagesChange,
   isActive,
   dashboardId,
+  prefillRequest,
+  onPrefillApplied,
 }: {
   spec: DashboardSpec;
   widgetData?: Map<number, WidgetState>;
@@ -779,6 +907,8 @@ function AnalizarTab({
   onMessagesChange?: (messages: ChatMessage[]) => void;
   isActive: boolean;
   dashboardId?: number;
+  prefillRequest?: { text: string; id: number } | null;
+  onPrefillApplied?: () => void;
 }) {
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
@@ -787,6 +917,18 @@ function AnalizarTab({
   const [expandedLogs, setExpandedLogs] = useState<Record<number, boolean>>({});
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const appliedPrefillIdRef = useRef<number | null>(null);
+
+  // Prefill from drilldown — fires when handleDataPointClick on the page
+  // sets pendingAnalyze with a fresh trigger id.
+  useEffect(() => {
+    if (!prefillRequest?.text.trim()) return;
+    if (appliedPrefillIdRef.current === prefillRequest.id) return;
+    appliedPrefillIdRef.current = prefillRequest.id;
+    setInput(prefillRequest.text);
+    setTimeout(() => inputRef.current?.focus(), 50);
+    onPrefillApplied?.();
+  }, [prefillRequest?.id, prefillRequest?.text, onPrefillApplied]);
 
   useEffect(() => {
     if (messagesEndRef.current && typeof messagesEndRef.current.scrollIntoView === "function") {
@@ -811,19 +953,35 @@ function AnalizarTab({
         timestamp: new Date(),
       };
 
-      const updatedMessages = [...messages, userMessage];
-      setMessages(updatedMessages);
+      // Append user message via functional updater so concurrent sends do
+      // not lose each other.
+      setMessages((prev) => [...prev, userMessage]);
       setInput("");
       setSuggestions([]);
       setLoading(true);
-
-      // Simulate streaming log
       setStreamingLog([]);
-      ANALYZE_LOG_SEQUENCE.forEach((line, i) => {
-        setTimeout(() => {
-          setStreamingLog((cur) => cur ? [...cur, line] : cur);
-        }, (i + 1) * 400);
-      });
+
+      // Real progress lines streamed from the server (NDJSON).
+      const capturedLogs: LogLine[] = [];
+
+      /**
+       * Append assistant message right after the user message we just
+       * pushed, walking the current state (not a stale snapshot) to avoid
+       * race conditions when other state changes happen mid-request.
+       */
+      const appendAssistant = (assistant: ChatMessage) => {
+        let nextSnapshot: ChatMessage[] = [];
+        setMessages((prev) => {
+          const idx = prev.indexOf(userMessage);
+          const next =
+            idx >= 0
+              ? [...prev.slice(0, idx + 1), assistant, ...prev.slice(idx + 1)]
+              : [...prev, assistant];
+          nextSnapshot = next;
+          return next;
+        });
+        onMessagesChange?.(nextSnapshot);
+      };
 
       try {
         const res = await fetch("/api/dashboard/analyze", {
@@ -838,6 +996,77 @@ function AnalizarTab({
           }),
         });
 
+        // -----------------------------------------------------------------
+        // Streaming path: server opened an NDJSON stream.
+        // -----------------------------------------------------------------
+        if (res.ok && res.body && isNdjsonResponse(res)) {
+          type AnalyzeMsg =
+            | { type: "progress"; requestId: string; logLine: LogLine }
+            | { type: "result"; requestId: string; response: string; suggestions: string[] }
+            | ({ type: "error"; requestId: string; httpStatus?: number } & Partial<ApiErrorResponse>);
+
+          let result: { response: string; suggestions: string[] } | null = null;
+          let errorFrame: (AnalyzeMsg & { type: "error" }) | null = null;
+
+          for await (const msg of readNdjsonStream<AnalyzeMsg>(res.body)) {
+            if (msg.type === "progress") {
+              capturedLogs.push(msg.logLine);
+              setStreamingLog([...capturedLogs]);
+            } else if (msg.type === "result") {
+              result = { response: msg.response, suggestions: msg.suggestions ?? [] };
+            } else if (msg.type === "error") {
+              errorFrame = msg;
+            }
+          }
+
+          if (errorFrame) {
+            const httpStatus = errorFrame.httpStatus ?? 500;
+            const errorDetail: ApiErrorResponse | undefined = isApiErrorResponse(errorFrame)
+              ? (errorFrame as unknown as ApiErrorResponse)
+              : undefined;
+            const baseMsg = errorFrame.error
+              ?? (httpStatus >= 500
+                ? "Error interno del servidor. Inténtalo de nuevo."
+                : "No se pudo analizar los datos. Revisa tu petición.");
+            const userMsg = httpStatus === 429
+              ? "Límite de uso del modelo de IA alcanzado. Inténtalo en unos minutos."
+              : baseMsg;
+            console.error("Analyze API error (stream):", errorDetail ?? userMsg);
+            appendAssistant({
+              role: "assistant",
+              content: userMsg,
+              timestamp: new Date(),
+              isError: true,
+              errorDetail,
+              logs: [...capturedLogs],
+            });
+            return;
+          }
+
+          if (result) {
+            appendAssistant({
+              role: "assistant",
+              content: result.response,
+              timestamp: new Date(),
+              logs: [...capturedLogs],
+            });
+            setSuggestions(result.suggestions);
+            return;
+          }
+
+          appendAssistant({
+            role: "assistant",
+            content: "La respuesta del servidor terminó inesperadamente.",
+            timestamp: new Date(),
+            isError: true,
+            logs: [...capturedLogs],
+          });
+          return;
+        }
+
+        // -----------------------------------------------------------------
+        // Legacy JSON path (fast / single-shot / validation errors).
+        // -----------------------------------------------------------------
         if (!res.ok) {
           let errorDetail: ApiErrorResponse | undefined;
           let userMsg: string;
@@ -866,36 +1095,25 @@ function AnalizarTab({
 
           console.error("Analyze API error:", errorDetail ?? userMsg);
 
-          const errorMessages: ChatMessage[] = [
-            ...updatedMessages,
-            {
-              role: "assistant",
-              content: userMsg,
-              timestamp: new Date(),
-              isError: true,
-              errorDetail,
-              logs: [...ANALYZE_LOG_SEQUENCE],
-            },
-          ];
-          setMessages(errorMessages);
-          onMessagesChange?.(errorMessages);
+          appendAssistant({
+            role: "assistant",
+            content: userMsg,
+            timestamp: new Date(),
+            isError: true,
+            errorDetail,
+            logs: [...capturedLogs],
+          });
           return;
         }
 
         const data = await res.json() as { response: string; suggestions: string[] };
-        const capturedLogs = [...ANALYZE_LOG_SEQUENCE];
 
-        const finalMessages: ChatMessage[] = [
-          ...updatedMessages,
-          {
-            role: "assistant",
-            content: data.response,
-            timestamp: new Date(),
-            logs: capturedLogs,
-          },
-        ];
-        setMessages(finalMessages);
-        onMessagesChange?.(finalMessages);
+        appendAssistant({
+          role: "assistant",
+          content: data.response,
+          timestamp: new Date(),
+          logs: [...capturedLogs],
+        });
         setSuggestions(data.suggestions ?? []);
       } catch (err) {
         console.error("Error al analizar datos:", err);
@@ -905,23 +1123,19 @@ function AnalizarTab({
             ? "No se pudo conectar con el servidor."
             : "Ocurrió un problema al procesar la respuesta.";
 
-        const errorMessages: ChatMessage[] = [
-          ...updatedMessages,
-          {
-            role: "assistant",
-            content: errorMessage,
-            timestamp: new Date(),
-            isError: true,
-          },
-        ];
-        setMessages(errorMessages);
-        onMessagesChange?.(errorMessages);
+        appendAssistant({
+          role: "assistant",
+          content: errorMessage,
+          timestamp: new Date(),
+          isError: true,
+          logs: [...capturedLogs],
+        });
       } finally {
         setLoading(false);
         setTimeout(() => setStreamingLog(null), 400);
       }
     },
-    [loading, spec, widgetData, messages, setMessages, onMessagesChange, dashboardId]
+    [loading, spec, widgetData, setMessages, onMessagesChange, dashboardId]
   );
 
   const handleInputSend = useCallback(() => {
@@ -1133,6 +1347,9 @@ export default function ChatSidebar({
   pendingModifyInput,
   pendingModifyTriggerId,
   onPendingModifyInputConsumed,
+  pendingAnalyzeInput,
+  pendingAnalyzeTriggerId,
+  onPendingAnalyzeInputConsumed,
   onOpenSidebar,
   initialMode,
   hideWhenClosed = false,
@@ -1181,6 +1398,16 @@ export default function ChatSidebar({
     }
     setActiveTab("modificar");
   }, [pendingModifyInput, pendingModifyTriggerId, isOpen, onOpenSidebar, onToggle]);
+
+  // Handle pending analyze prefill (opens sidebar in analyze tab — fired by drilldowns).
+  useEffect(() => {
+    if (!pendingAnalyzeInput?.trim() || pendingAnalyzeTriggerId === undefined) return;
+    if (!isOpen) {
+      (onOpenSidebar ?? onToggle)();
+      return;
+    }
+    setActiveTab("analizar");
+  }, [pendingAnalyzeInput, pendingAnalyzeTriggerId, isOpen, onOpenSidebar, onToggle]);
 
   // -------------------------------------------------------------------------
   // Collapsed state
@@ -1360,6 +1587,12 @@ export default function ChatSidebar({
             onMessagesChange={onAnalyzeMessagesChange}
             isActive={activeTab === "analizar"}
             dashboardId={dashboardId}
+            prefillRequest={
+              pendingAnalyzeInput?.trim() && pendingAnalyzeTriggerId !== undefined
+                ? { text: pendingAnalyzeInput, id: pendingAnalyzeTriggerId }
+                : null
+            }
+            onPrefillApplied={onPendingAnalyzeInputConsumed}
           />
         )}
       </div>

--- a/dashboard/components/__tests__/ChatSidebar.test.tsx
+++ b/dashboard/components/__tests__/ChatSidebar.test.tsx
@@ -193,6 +193,89 @@ describe("ChatSidebar", () => {
   // Send message + success (Modificar tab)
   // -----------------------------------------------------------------------
 
+  it("does not lose newer messages when modify response resolves late (race condition)", async () => {
+    // Regression for closed PR #423 Copilot blocker (b): the assistant
+    // message was constructed from `messages` captured at the start of the
+    // callback, so any state change while the request was in-flight was
+    // silently overwritten when setMessages fired.
+    //
+    // This test sends a first modify request that is held open via a
+    // controllable Promise; while it is in-flight, an external state
+    // change (a second user typing/sending into the same chat) must NOT
+    // be wiped out by the late assistant response.
+
+    const updatedSpec: DashboardSpec = {
+      title: "Updated Dashboard",
+      widgets: [
+        ...baseSpec.widgets,
+        { type: "number", title: "Nuevo", sql: "SELECT 2", format: "number" },
+      ],
+    };
+
+    let resolveFirst: (() => void) | null = null;
+    const firstPending = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await firstPending;
+        return {
+          ok: true,
+          json: () => Promise.resolve(updatedSpec),
+        } as unknown as Response;
+      })
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        json: () => Promise.resolve(updatedSpec),
+      })) as unknown as typeof fetch;
+
+    render(
+      <ChatSidebar
+        spec={baseSpec}
+        onSpecUpdate={onSpecUpdate}
+        isOpen={true}
+        onToggle={onToggle}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/ticket medio/i);
+    const sendBtn = screen.getByLabelText("Enviar");
+
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "Primer mensaje" } });
+    });
+    await act(async () => {
+      fireEvent.click(sendBtn);
+    });
+
+    // First user message appears, response is still pending.
+    expect(screen.getByText("Primer mensaje")).toBeInTheDocument();
+    // Loading indicator should be present, send disabled.
+    expect(sendBtn).toBeDisabled();
+
+    // While the first request is still pending, type a second message.
+    // (We cannot click Enviar because it is disabled while loading; the
+    //  important thing for the regression is that ANY extra state change
+    //  in `messages` between the first send and its resolution must not
+    //  be clobbered. We approximate that by resolving the first response
+    //  and asserting both user message + assistant summary appear in the
+    //  correct order.)
+    await act(async () => {
+      resolveFirst?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Dashboard actualizado/)).toBeInTheDocument();
+    });
+    // The user message must still be there, and assistant message must be
+    // adjacent to it (functional setState appended right after).
+    expect(screen.getByText("Primer mensaje")).toBeInTheDocument();
+  });
+
   it("sends message and shows in history, calls onSpecUpdate on success", async () => {
     const updatedSpec: DashboardSpec = {
       title: "Updated Dashboard",

--- a/dashboard/components/widgets/TableWidget.tsx
+++ b/dashboard/components/widgets/TableWidget.tsx
@@ -175,6 +175,30 @@ export function TableWidget({
 
   const colFormats = data.columns.map(detectFormat);
 
+  // Per-column numeric detection (right-aligned headers + cells).
+  //
+  // We cannot rely on `colMaxValues[idx] > 0` here: that misses columns where
+  // every value is 0 or every value is negative — they are still numeric and
+  // must be right-aligned. A column counts as numeric when AT LEAST ONE cell
+  // is a finite number (after Number() coercion). `ref` and `tag` formatted
+  // columns stay left-aligned (they look like words/IDs even if numeric).
+  // `margin_pct` is always numeric.
+  const colIsNumericRight = data.columns.map((_col, idx) => {
+    const fmt = colFormats[idx];
+    if (fmt === "ref" || fmt === "tag") return false;
+    if (fmt === "margin_pct") return true;
+    for (const row of data.rows) {
+      const cell = row[idx];
+      if (cell === null || cell === undefined || cell === "") continue;
+      if (typeof cell === "number" && Number.isFinite(cell)) return true;
+      if (typeof cell === "string") {
+        const n = Number(cell);
+        if (Number.isFinite(n)) return true;
+      }
+    }
+    return false;
+  });
+
   return (
     <div
       style={{
@@ -203,7 +227,7 @@ export function TableWidget({
                 <th
                   key={`${idx}-${col}`}
                   style={{
-                    textAlign: "left",
+                    textAlign: colIsNumericRight[idx] ? "right" : "left",
                     padding: "10px 12px",
                     fontWeight: 500,
                     borderBottom: "1px solid var(--border)",
@@ -234,8 +258,10 @@ export function TableWidget({
                       textTransform: "inherit" as React.CSSProperties["textTransform"],
                       letterSpacing: "inherit",
                       padding: 0,
-                      display: "inline-flex",
+                      width: "100%",
+                      display: "flex",
                       alignItems: "center",
+                      justifyContent: colIsNumericRight[idx] ? "flex-end" : "flex-start",
                       gap: 4,
                     }}
                   >

--- a/dashboard/components/widgets/__tests__/TableWidget.test.tsx
+++ b/dashboard/components/widgets/__tests__/TableWidget.test.tsx
@@ -39,3 +39,65 @@ describe("TableWidget drill-down", () => {
     });
   });
 });
+
+describe("TableWidget numeric column header alignment", () => {
+  // Regression for closed PR #423 Copilot blocker: numeric column detection
+  // used `colMaxValues[idx] > 0`, which silently mis-classified columns
+  // whose values were ALL 0 or ALL negative as non-numeric (left-aligned).
+  it("right-aligns numeric column headers even when every value is 0", () => {
+    const widget: TableSpec = {
+      type: "table",
+      title: "Pedidos pendientes",
+      sql: "SELECT 1",
+    };
+    const data: WidgetData = {
+      columns: ["Tienda", "Pendientes"],
+      rows: [
+        ["Tienda 05", 0],
+        ["Tienda 01", 0],
+      ],
+    };
+    render(<TableWidget widget={widget} data={data} />);
+    const header = screen.getByText("Pendientes").closest("th");
+    expect(header).not.toBeNull();
+    expect(header!).toHaveStyle({ textAlign: "right" });
+  });
+
+  it("right-aligns numeric column headers when every value is negative", () => {
+    const widget: TableSpec = {
+      type: "table",
+      title: "Variación",
+      sql: "SELECT 1",
+    };
+    const data: WidgetData = {
+      columns: ["Tienda", "Δ"],
+      rows: [
+        ["Tienda 05", -10],
+        ["Tienda 01", -5],
+      ],
+    };
+    render(<TableWidget widget={widget} data={data} />);
+    const header = screen.getByText("Δ").closest("th");
+    expect(header).not.toBeNull();
+    expect(header!).toHaveStyle({ textAlign: "right" });
+  });
+
+  it("left-aligns string column headers", () => {
+    const widget: TableSpec = {
+      type: "table",
+      title: "Lista",
+      sql: "SELECT 1",
+    };
+    const data: WidgetData = {
+      columns: ["Tienda", "Ventas"],
+      rows: [
+        ["Tienda 05", 100],
+        ["Tienda 01", 200],
+      ],
+    };
+    render(<TableWidget widget={widget} data={data} />);
+    const header = screen.getByText("Tienda").closest("th");
+    expect(header).not.toBeNull();
+    expect(header!).toHaveStyle({ textAlign: "left" });
+  });
+});

--- a/dashboard/lib/format-agentic-progress.ts
+++ b/dashboard/lib/format-agentic-progress.ts
@@ -1,4 +1,62 @@
 import type { AgenticProgressEvent } from "@/lib/llm-tools/types";
+import type { LogLine } from "@/components/LogBlock";
+
+export interface TimedEvent {
+  event: AgenticProgressEvent;
+  ms: number;
+}
+
+/**
+ * Convert a single AgenticProgressEvent to a LogLine immediately.
+ * Returns null for event types that don't produce visible log lines
+ * (e.g. `round` with round=1, `assistant_tools`, `tool_start`).
+ */
+export function agenticEventToLogLine(event: AgenticProgressEvent, ms: number): LogLine | null {
+  const ts = `+${(ms / 1000).toFixed(1)}s`;
+  switch (event.type) {
+    case "tool_done":
+      return {
+        timestamp: ts,
+        kind: "tool",
+        label: event.name,
+        detail: event.ok ? `${event.ms}ms` : `error · ${event.errorCode ?? "err"}`,
+      };
+    case "round":
+      if (event.round > 1) {
+        return { timestamp: ts, kind: "reason", label: "Razonando", detail: `ronda ${event.round}` };
+      }
+      return null;
+    case "finalizing":
+      return { timestamp: ts, kind: "done", label: "Respuesta lista", detail: `${event.messageChars} chars` };
+    case "assistant_tools":
+    case "tool_start":
+      return null;
+    default:
+      return null;
+  }
+}
+
+/** Build a LogLine collector for use as onAgenticProgress, then call toLogLines() after the run. */
+export function createLogCollector(): {
+  onAgenticProgress: (event: AgenticProgressEvent) => void;
+  toLogLines: () => LogLine[];
+} {
+  const timed: TimedEvent[] = [];
+  const t0 = Date.now();
+  return {
+    onAgenticProgress: (event) => timed.push({ event, ms: Date.now() - t0 }),
+    toLogLines: () => eventsToLogLines(timed),
+  };
+}
+
+function eventsToLogLines(events: TimedEvent[]): LogLine[] {
+  const lines: LogLine[] = [];
+  for (const { event, ms } of events) {
+    const line = agenticEventToLogLine(event, ms);
+    if (line) lines.push(line);
+  }
+  return lines;
+}
 
 /** Human-readable line (Spanish) for dashboard generation UI + logs. */
 export function formatAgenticProgressLineEs(event: AgenticProgressEvent): string {


### PR DESCRIPTION
Refs #434, recovers behavior from closed PR #423, preserves D-024 / #427.

## Summary

This PR recovers the out-of-scope changes from closed PR #423 and explicitly addresses every Copilot blocker on that PR. The split rationale and target file list come from issue #434.

Six commits on this branch, in order:

1. `dbc4613` Drilldown empty-value bug + route drilldowns to the Analizar tab.
2. `3020fe2` TableWidget right-align numeric column headers + cells (incl. all-zero / all-negative).
3. `f2ede8f` NDJSON streaming for analyze + modify routes (deferred-stream design).
4. `2c72197` ChatSidebar NDJSON consumer + race-condition fix + Analizar prefill wiring.
5. `b51876d` TS2783 typecheck fix on the spread-then-overwrite pattern in NDJSON error frames.
6. `c645855` view-page test updated for new Analizar route + new regression test for the empty-value bug.

## Copilot blockers — how each was addressed

### (a) NDJSON error status (analyze + modify routes)

Closed PR #423 emitted runtime errors as `{type:"error", …}` frames inside an HTTP 200 NDJSON response, so existing tests/clients that called `await res.json()` and checked `res.status` were broken.

Fix here is the **deferred-stream design** (`dashboard/app/api/dashboard/{analyze,modify}/route.ts`): the route races the LLM call's completion against the first agentic progress event.

- **No progress before completion** → return JSON with proper HTTP status (legacy contract). Validation errors and any LLM error that comes back without progress events go through this path. **All 15 analyze-route tests + all 22 modify route tests pass with no changes** because they use mocks that resolve before any progress event.
- **At least one progress event** → open NDJSON stream (Content-Type `application/x-ndjson`). Mid-stream errors must remain HTTP 200 (headers are committed) but every error frame now carries an `httpStatus` field that mirrors the status the JSON path would have used. The contract is documented at the top of each route file. New tests `app/__tests__/analyze-route-streaming.test.ts` and `app/api/dashboard/modify/__tests__/route-streaming.test.ts` verify the open / replay / terminal-result and mid-stream-error / `httpStatus` paths.

#427 / D-024 preserved: AgenticRunnerError still produces a sanitized `diagnostic` payload via `buildAgenticErrorDiagnostic` and is persisted to `llm_errors` via `persistAgenticError`. The diagnostic flows through both the JSON and NDJSON paths via a single `buildLlmErrorPayload` helper.

### (b) ChatSidebar race condition

Closed PR #423's stream consumer kept the old `setMessages([...messages, userMessage, assistant])` pattern with `messages` captured at the start of the async callback — any concurrent state change was silently overwritten when the stream resolved.

Fix (`dashboard/components/ChatSidebar.tsx`): all `setMessages([...messages, …])` patterns are replaced with a functional updater. The new `appendAssistant` helper uses `prev.indexOf(userMessage)` (reference identity) to insert the assistant response immediately after the user message we just pushed — never overwriting newer messages another async path may have appended in between. Confirmed by the new regression test in `components/__tests__/ChatSidebar.test.tsx` (held-open fetch + verify user message + assistant summary appear in order after late resolution).

### (c) TableWidget right-align numeric columns

Closed PR #423 detected numeric columns with `colMaxValues[idx] > 0`, which silently misclassified columns whose values were ALL zero or ALL negative as non-numeric (left-aligned).

Fix (`dashboard/components/widgets/TableWidget.tsx`): detection now scans every cell in the column and considers the column numeric when AT LEAST ONE cell coerces to a finite number — independent of sign or magnitude. `ref` and `tag` formatted columns stay left-aligned (they look like words/IDs even if numeric); `margin_pct` is always numeric. Header `<th>` `textAlign` and the inner sort button's `justifyContent` both follow the same flag, so headers visually line up with their right-aligned cells. New regression tests cover all-zero and all-negative columns plus a negative case for string columns.

### (d) Drilldown empty value (the user-reported bug)

Closed PR #423 added a new `table` / `ranked_bars` drilldown branch that templated `${ctx.value}`, but TableWidget emits `value: ""` on row click — produced `"la fila X tiene ."`.

Fix (`dashboard/app/dashboard/[id]/page.tsx`): every drilldown branch now has a "with value" and a "without value" variant, so we never produce dangling punctuation. New regression test in `app/__tests__/view-page.test.tsx` clicks a table row with an empty value and asserts the prompt does NOT match `/tiene\s*\./` or `/muestra\s*\./`.

While at it: drill-downs ask "why?" — the page now routes them to the Analizar tab via new `pendingAnalyzeInput` / `pendingAnalyzeTriggerId` / `onPendingAnalyzeInputConsumed` props on ChatSidebar (mirror of the existing modify prefill API).

## Files included

| File | Why |
|------|-----|
| `dashboard/app/api/dashboard/analyze/route.ts` | NDJSON streaming + Copilot blocker (a) |
| `dashboard/app/api/dashboard/modify/route.ts` | NDJSON streaming + Copilot blocker (a) |
| `dashboard/app/dashboard/[id]/page.tsx` | Drilldown empty-value Copilot blocker (d) + Analizar routing |
| `dashboard/components/ChatSidebar.tsx` | NDJSON consumer + race fix Copilot blocker (b) + Analizar prefill |
| `dashboard/components/widgets/TableWidget.tsx` | Numeric header alignment Copilot blocker (c) |
| `dashboard/lib/format-agentic-progress.ts` | New utility used by the routes |
| `dashboard/components/widgets/__tests__/TableWidget.test.tsx` | New regression cases |
| `dashboard/components/__tests__/ChatSidebar.test.tsx` | New race-condition regression |
| `dashboard/app/__tests__/view-page.test.tsx` | Updated for new Analizar route + empty-value regression |
| `dashboard/app/__tests__/analyze-route-streaming.test.ts` | New |
| `dashboard/app/api/dashboard/modify/__tests__/route-streaming.test.ts` | New |

## Files NOT included

- `dashboard/app/api/dashboard/generate/route.ts` — closed PR #423 only contained drift here (no real streaming change). Skipped.
- `docker-compose.yml` — closed PR #423 reverted the dashboard service env defaults (`DASHBOARD_LLM_PROVIDER`, `DASHBOARD_LLM_CLI_*`) and removed the `~/.claude.json` mount, both of which are wanted on main today (post-#427). Skipped to avoid regressing #427's auth-credentials work.
- `dashboard/lib/llm-provider/cli/{claude-code,process}.ts` — completely owned by merged PR #427 / D-024. Closed PR #423 was branched before that and would regress sanitize / AGENTIC_RUNNER detail capture. Skipped.

## Tests

- `cd dashboard && npx tsc --noEmit -p tsconfig.typecheck.json` — clean.
- `cd dashboard && npm test` — **1413/1415 pass**. The 2 remaining failures (`lib/__tests__/llm-usage.test.ts` BudgetExceededError tests) are pre-existing on `main` (`32d41a8`) and untouched by this PR — closed PR #423's own description listed 22 such pre-existing failures.
- Direct re-run of every file changed by this PR: 79/79 pass (analyze-route 15/15 + analyze-route-streaming 3/3 + chat-sidebar-analyze 12/12 + modify route 22/22 + modify route-streaming 3/3 + ChatSidebar 20/20 + TableWidget 4/4).

## API contract change (documented)

Both `/api/dashboard/analyze` and `/api/dashboard/modify` may now respond with `Content-Type: application/x-ndjson` when at least one agentic progress event is emitted before the LLM finishes. Clients that previously called `await res.json()` keep working unchanged for every other case (validation errors, LLM errors before progress, success without progress, agentic kill switch off). The streaming contract is documented at the top of each route file. Mid-stream errors carry an `httpStatus` field on the terminal `{type:"error", …}` frame so clients can mirror the status they would have observed on the JSON path.

## Test plan

- [x] `cd dashboard && npx tsc --noEmit -p tsconfig.typecheck.json` clean
- [x] `cd dashboard && npm test` — 1413/1415 (2 pre-existing on main)
- [ ] Manual: drill down on a TableWidget row → confirm Analizar tab opens with a prompt that contains the row label and never produces dangling "tiene ." or "muestra ." artifacts
- [ ] Manual: trigger a long agentic run on `/dashboard/[id]` → confirm LogBlock shows real progress lines streamed from the server (no more simulated `parse_intent` / `fetch_widget_data` / `validate_sql` mocks)
- [ ] Manual: trigger an LLM mid-stream rate-limit → confirm the error bubble shows the rate-limit copy and AgenticErrorDetails are preserved