### PR TITLE
feat(admin/slow-queries): SQL formatting, sortable+filterable table, origin matcher, guidance panel

### DIFF
--- a/dashboard/app/__tests__/slow-queries-page.test.tsx
+++ b/dashboard/app/__tests__/slow-queries-page.test.tsx
@@ -1,0 +1,347 @@
+// @vitest-environment jsdom
+/**
+ * Component tests for /admin/slow-queries page.
+ * Covers: SQL formatting (task 2), sort (task 3), filter (task 4).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import AdminSlowQueriesPage from "../admin/slow-queries/page";
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("prismjs", () => ({
+  default: {
+    highlight: (code: string) => code, // no-op for tests
+    languages: { sql: {} },
+  },
+}));
+
+vi.mock("prismjs/components/prism-sql", () => ({}));
+
+// sql-formatter: use real implementation so we can test that formatted SQL
+// has spaces around keywords.
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const MOCK_QUERIES = [
+  {
+    query: "SELECT COUNT(*) AS cnt FROM ps_ventas WHERE entrada = $1",
+    calls: 10,
+    mean_exec_time_ms: 500,
+    max_exec_time_ms: 800,
+    total_exec_time_ms: 5000,
+    rows: 1,
+    cache_hit_ratio: 99.5,
+    origin: { source: "Template: Responsable de Ventas", locationHint: "dashboard/lib/templates/ventas.ts" },
+  },
+  {
+    query: "SELECT tienda, SUM(stock) AS total FROM ps_stock_tienda GROUP BY tienda ORDER BY total DESC",
+    calls: 5,
+    mean_exec_time_ms: 2500,
+    max_exec_time_ms: 3000,
+    total_exec_time_ms: 12500,
+    rows: 50,
+    cache_hit_ratio: 85.2,
+  },
+  {
+    query: "SELECT lv.codigo, SUM(lv.unidades) AS u FROM ps_lineas_ventas lv WHERE lv.tienda = $1 GROUP BY lv.codigo",
+    calls: 100,
+    mean_exec_time_ms: 120,
+    max_exec_time_ms: 300,
+    total_exec_time_ms: 12000,
+    rows: 500,
+    cache_hit_ratio: null,
+  },
+];
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    json: async () => ({ queries: MOCK_QUERIES }),
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("AdminSlowQueriesPage — render", () => {
+  it("shows loading state before fetch resolves", () => {
+    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {}))); // never resolves
+    render(<AdminSlowQueriesPage />);
+    expect(screen.getByText(/Cargando/i)).toBeInTheDocument();
+  });
+
+  it("renders three rows after fetch", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => {
+      expect(screen.getAllByRole("row").length).toBeGreaterThan(1); // header + data rows
+    });
+    // 3 data rows + 1 header
+    const rows = screen.getAllByRole("row");
+    expect(rows.length).toBe(4);
+  });
+
+  it("displays error message when fetch returns error field", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      json: async () => ({ queries: [], error: "pg_stat_statements not enabled" }),
+    }));
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/pg_stat_statements not enabled/i)).toBeInTheDocument();
+    });
+  });
+});
+
+describe("AdminSlowQueriesPage — SQL formatting (task 2)", () => {
+  it("formats fused keywords before display", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      json: async () => ({
+        queries: [
+          {
+            query: "SELECTCOUNT(*)AS cnt FROM ps_ventas",
+            calls: 1,
+            mean_exec_time_ms: 10,
+            max_exec_time_ms: 20,
+            total_exec_time_ms: 10,
+            rows: 1,
+            cache_hit_ratio: 90,
+          },
+        ],
+      }),
+    }));
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => {
+      // After formatting, SELECT and COUNT should appear separately
+      const cells = screen.getAllByRole("cell");
+      const sqlCell = cells[0];
+      // The rendered text should not contain "SELECTCOUNT" fused together
+      expect(sqlCell.textContent).not.toMatch(/SELECTCOUNT/);
+    });
+  });
+});
+
+describe("AdminSlowQueriesPage — sort (task 3)", () => {
+  it("default sort is mean_exec_time_ms descending", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => screen.getAllByRole("row").length > 1);
+
+    // The sort arrow should appear on "Media ms" header (active, descending)
+    const headers = screen.getAllByRole("columnheader");
+    const mediaHeader = headers.find((h) => h.textContent?.includes("Media ms"));
+    expect(mediaHeader).toBeDefined();
+    // Active sort indicator: the arrow is ↓ for descending
+    expect(mediaHeader!.textContent).toContain("↓");
+  });
+
+  it("clicking a column header sorts by that column descending", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => screen.getAllByRole("row").length > 1);
+
+    const headers = screen.getAllByRole("columnheader");
+    const llamadasHeader = headers.find((h) => h.textContent?.includes("Llamadas"));
+    expect(llamadasHeader).toBeDefined();
+
+    act(() => {
+      fireEvent.click(llamadasHeader!);
+    });
+
+    // After click, Llamadas header should show ↓ (now the active sort)
+    await waitFor(() => {
+      const updatedHeaders = screen.getAllByRole("columnheader");
+      const updatedLlamadas = updatedHeaders.find((h) => h.textContent?.includes("Llamadas"));
+      expect(updatedLlamadas!.textContent).toContain("↓");
+    });
+  });
+
+  it("clicking same column twice reverses direction", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => screen.getAllByRole("row").length > 1);
+
+    const headers = screen.getAllByRole("columnheader");
+    const mediaHeader = headers.find((h) => h.textContent?.includes("Media ms"));
+
+    // First click: already sorted desc, should flip to asc
+    act(() => {
+      fireEvent.click(mediaHeader!);
+    });
+
+    await waitFor(() => {
+      const updatedHeaders = screen.getAllByRole("columnheader");
+      const updatedMedia = updatedHeaders.find((h) => h.textContent?.includes("Media ms"));
+      expect(updatedMedia!.textContent).toContain("↑");
+    });
+  });
+
+  it("rows are displayed in correct sort order (calls desc)", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => screen.getAllByRole("row").length > 1);
+
+    const headers = screen.getAllByRole("columnheader");
+    const llamadasHeader = headers.find((h) => h.textContent?.includes("Llamadas"));
+
+    act(() => {
+      fireEvent.click(llamadasHeader!);
+    });
+
+    await waitFor(() => {
+      // calls: [10, 5, 100] → sorted desc → [100, 10, 5]
+      const rows = screen.getAllByRole("row").slice(1); // skip header
+      const callValues = rows.map((row) => {
+        const cells = row.querySelectorAll("td");
+        return cells[1]?.textContent ?? "";
+      });
+      // 100 should come first, then 10, then 5
+      const nums = callValues.map((v) => parseInt(v.replace(/\./g, "").replace(/,/g, ""), 10));
+      expect(nums[0]).toBeGreaterThan(nums[1]);
+      expect(nums[1]).toBeGreaterThan(nums[2]);
+    });
+  });
+});
+
+describe("AdminSlowQueriesPage — filter (task 4)", () => {
+  it("filter input is rendered", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => screen.getAllByRole("row").length > 1);
+    const filterInput = screen.getByPlaceholderText(/Filtrar/i);
+    expect(filterInput).toBeInTheDocument();
+  });
+
+  it("typing in filter narrows rows", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => screen.getAllByRole("row").length > 1);
+
+    const filterInput = screen.getByPlaceholderText(/Filtrar/i);
+
+    // Filter to only queries mentioning ps_stock_tienda
+    act(() => {
+      fireEvent.change(filterInput, { target: { value: "ps_stock_tienda" } });
+    });
+
+    // Wait for debounce
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      const rows = screen.getAllByRole("row").slice(1);
+      // Should have only 1 row (the stock query)
+      expect(rows.length).toBe(1);
+    });
+  });
+
+  it("filter is case-insensitive", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => screen.getAllByRole("row").length > 1);
+
+    const filterInput = screen.getByPlaceholderText(/Filtrar/i);
+
+    act(() => {
+      fireEvent.change(filterInput, { target: { value: "PS_STOCK_TIENDA" } });
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      const rows = screen.getAllByRole("row").slice(1);
+      expect(rows.length).toBe(1);
+    });
+  });
+
+  it("shows '0 de N consultas' indicator when filter has no matches", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => screen.getAllByRole("row").length > 1);
+
+    const filterInput = screen.getByPlaceholderText(/Filtrar/i);
+
+    act(() => {
+      fireEvent.change(filterInput, { target: { value: "zzznomatch" } });
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/0 de 3 consultas/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows total count when no filter is active", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/3 consultas/i)).toBeInTheDocument();
+    });
+  });
+});
+
+describe("AdminSlowQueriesPage — origin (task 5)", () => {
+  it("shows origin badge when query has an origin", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Posible origen/i)).toBeInTheDocument();
+      expect(screen.getByText(/Responsable de Ventas/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows location hint as a code element", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => {
+      const codeEl = screen.getByText("dashboard/lib/templates/ventas.ts");
+      expect(codeEl.tagName.toLowerCase()).toBe("code");
+    });
+  });
+});
+
+describe("AdminSlowQueriesPage — guidance panel (task 6)", () => {
+  it("renders the guidance panel toggle button", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Cómo actuar/i)).toBeInTheDocument();
+    });
+  });
+
+  it("guidance panel is collapsed by default", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => {
+      // The guidance content should not be visible initially
+      expect(screen.queryByText(/Mide primero/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it("clicking toggle opens the guidance panel", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => screen.getByText(/Cómo actuar/i));
+
+    act(() => {
+      fireEvent.click(screen.getByText(/Cómo actuar/i));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Mide primero/i)).toBeInTheDocument();
+      expect(screen.getByText(/etl\/schema\/init\.sql/i)).toBeInTheDocument();
+    });
+  });
+
+  it("clicking toggle again closes the guidance panel", async () => {
+    render(<AdminSlowQueriesPage />);
+    await waitFor(() => screen.getByText(/Cómo actuar/i));
+
+    const toggle = screen.getByText(/Cómo actuar/i);
+
+    act(() => { fireEvent.click(toggle); });
+    await waitFor(() => screen.getByText(/Mide primero/i));
+
+    act(() => { fireEvent.click(toggle); });
+    await waitFor(() => {
+      expect(screen.queryByText(/Mide primero/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/dashboard/app/__tests__/slow-queries-page.test.tsx
+++ b/dashboard/app/__tests__/slow-queries-page.test.tsx
@@ -131,30 +131,30 @@ describe("AdminSlowQueriesPage — sort (task 3)", () => {
     render(<AdminSlowQueriesPage />);
     await waitFor(() => screen.getAllByRole("row").length > 1);
 
-    // The sort arrow should appear on "Media ms" header (active, descending)
-    const headers = screen.getAllByRole("columnheader");
-    const mediaHeader = headers.find((h) => h.textContent?.includes("Media ms"));
-    expect(mediaHeader).toBeDefined();
+    // The sort arrow should appear on the "Media ms" sort button (active, descending)
+    const buttons = screen.getAllByRole("button");
+    const mediaBtn = buttons.find((b) => b.textContent?.includes("Media ms"));
+    expect(mediaBtn).toBeDefined();
     // Active sort indicator: the arrow is ↓ for descending
-    expect(mediaHeader!.textContent).toContain("↓");
+    expect(mediaBtn!.textContent).toContain("↓");
   });
 
   it("clicking a column header sorts by that column descending", async () => {
     render(<AdminSlowQueriesPage />);
     await waitFor(() => screen.getAllByRole("row").length > 1);
 
-    const headers = screen.getAllByRole("columnheader");
-    const llamadasHeader = headers.find((h) => h.textContent?.includes("Llamadas"));
-    expect(llamadasHeader).toBeDefined();
+    const buttons = screen.getAllByRole("button");
+    const llamadasBtn = buttons.find((b) => b.textContent?.includes("Llamadas"));
+    expect(llamadasBtn).toBeDefined();
 
     act(() => {
-      fireEvent.click(llamadasHeader!);
+      fireEvent.click(llamadasBtn!);
     });
 
-    // After click, Llamadas header should show ↓ (now the active sort)
+    // After click, Llamadas button should show ↓ (now the active sort)
     await waitFor(() => {
-      const updatedHeaders = screen.getAllByRole("columnheader");
-      const updatedLlamadas = updatedHeaders.find((h) => h.textContent?.includes("Llamadas"));
+      const updatedButtons = screen.getAllByRole("button");
+      const updatedLlamadas = updatedButtons.find((b) => b.textContent?.includes("Llamadas"));
       expect(updatedLlamadas!.textContent).toContain("↓");
     });
   });
@@ -163,17 +163,17 @@ describe("AdminSlowQueriesPage — sort (task 3)", () => {
     render(<AdminSlowQueriesPage />);
     await waitFor(() => screen.getAllByRole("row").length > 1);
 
-    const headers = screen.getAllByRole("columnheader");
-    const mediaHeader = headers.find((h) => h.textContent?.includes("Media ms"));
+    const buttons = screen.getAllByRole("button");
+    const mediaBtn = buttons.find((b) => b.textContent?.includes("Media ms"));
 
     // First click: already sorted desc, should flip to asc
     act(() => {
-      fireEvent.click(mediaHeader!);
+      fireEvent.click(mediaBtn!);
     });
 
     await waitFor(() => {
-      const updatedHeaders = screen.getAllByRole("columnheader");
-      const updatedMedia = updatedHeaders.find((h) => h.textContent?.includes("Media ms"));
+      const updatedButtons = screen.getAllByRole("button");
+      const updatedMedia = updatedButtons.find((b) => b.textContent?.includes("Media ms"));
       expect(updatedMedia!.textContent).toContain("↑");
     });
   });
@@ -182,11 +182,11 @@ describe("AdminSlowQueriesPage — sort (task 3)", () => {
     render(<AdminSlowQueriesPage />);
     await waitFor(() => screen.getAllByRole("row").length > 1);
 
-    const headers = screen.getAllByRole("columnheader");
-    const llamadasHeader = headers.find((h) => h.textContent?.includes("Llamadas"));
+    const buttons = screen.getAllByRole("button");
+    const llamadasBtn = buttons.find((b) => b.textContent?.includes("Llamadas"));
 
     act(() => {
-      fireEvent.click(llamadasHeader!);
+      fireEvent.click(llamadasBtn!);
     });
 
     await waitFor(() => {

--- a/dashboard/app/admin/slow-queries/page.tsx
+++ b/dashboard/app/admin/slow-queries/page.tsx
@@ -35,12 +35,26 @@ const fmtMs = (v: number) =>
 const fmtInt = (v: number) =>
   new Intl.NumberFormat("es-ES", { maximumFractionDigits: 0 }).format(v);
 
-/** Highlight SQL with Prism after formatting. */
+/** Escape HTML special characters to prevent XSS in fallback paths. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/**
+ * Highlight SQL with Prism after formatting.
+ * Returns HTML-escaped plain text on Prism error so dangerouslySetInnerHTML
+ * remains safe even if the grammar is not loaded.
+ */
 function highlightSql(formatted: string): string {
   try {
     return Prism.highlight(formatted, Prism.languages.sql, "sql");
   } catch {
-    return formatted;
+    return escapeHtml(formatted);
   }
 }
 
@@ -168,6 +182,13 @@ export default function AdminSlowQueriesPage() {
       .catch((e) =>
         setData({ queries: [], error: e instanceof Error ? e.message : "Error" }),
       );
+  }, []);
+
+  // Cleanup debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (filterTimerRef.current !== null) clearTimeout(filterTimerRef.current);
+    };
   }, []);
 
   // Debounce filter input — 150 ms
@@ -322,7 +343,7 @@ export default function AdminSlowQueriesPage() {
                     <th
                       key={col.label}
                       style={{
-                        padding: "9px 12px",
+                        padding: col.key ? "0" : "9px 12px",
                         fontWeight: 500,
                         fontFamily: "var(--font-inter, sans-serif)",
                         fontSize: 11,
@@ -331,10 +352,7 @@ export default function AdminSlowQueriesPage() {
                         textAlign: col.align,
                         whiteSpace: "nowrap",
                         borderBottom: "1px solid var(--border)",
-                        cursor: col.key ? "pointer" : "default",
-                        userSelect: "none",
                       }}
-                      onClick={col.key ? () => toggleSort(col.key!) : undefined}
                       aria-sort={
                         col.key
                           ? sortKey === col.key
@@ -345,26 +363,48 @@ export default function AdminSlowQueriesPage() {
                           : undefined
                       }
                     >
-                      {col.label}
-                      {col.key && (
-                        <SortArrow
-                          active={sortKey === col.key}
-                          dir={sortDir}
-                        />
+                      {col.key ? (
+                        /* Wrap sortable headers in a button for keyboard + screen-reader accessibility */
+                        <button
+                          type="button"
+                          onClick={() => toggleSort(col.key!)}
+                          style={{
+                            display: "block",
+                            width: "100%",
+                            padding: "9px 12px",
+                            background: "none",
+                            border: "none",
+                            cursor: "pointer",
+                            fontFamily: "inherit",
+                            fontSize: "inherit",
+                            fontWeight: "inherit",
+                            letterSpacing: "inherit",
+                            color: "inherit",
+                            textAlign: col.align,
+                            whiteSpace: "nowrap",
+                            userSelect: "none",
+                          }}
+                        >
+                          {col.label}
+                          <SortArrow active={sortKey === col.key} dir={sortDir} />
+                        </button>
+                      ) : (
+                        col.label
                       )}
                     </th>
                   ))}
                 </tr>
               </thead>
               <tbody>
-                {displayRows.map(({ q, i }) => {
+                {displayRows.map(({ q, i }, displayIndex) => {
                   const fq = formattedQueries[i];
                   const isExpanded = expanded.has(i);
                   return (
                     <tr
                       key={i}
                       style={{
-                        background: i % 2 === 1 ? "var(--bg-2)" : undefined,
+                        /* Use display index for correct stripe pattern after sort/filter */
+                        background: displayIndex % 2 === 1 ? "var(--bg-2)" : undefined,
                         borderTop: "1px solid var(--border)",
                       }}
                     >
@@ -415,14 +455,15 @@ export default function AdminSlowQueriesPage() {
                             wordBreak: "break-word",
                           }}
                         >
-                          {fq ? (
-                            <span
-                              // biome-ignore lint/security/noDangerouslySetInnerHtml
-                              dangerouslySetInnerHTML={{ __html: fq.highlighted }}
-                            />
-                          ) : (
-                            q.query
-                          )}
+                          {/* dangerouslySetInnerHTML is safe here: highlightSql HTML-escapes
+                              the fallback path and Prism only produces span elements with
+                              class attributes from its own grammar tokeniser. */}
+                          <span
+                            // biome-ignore lint/security/noDangerouslySetInnerHtml
+                            dangerouslySetInnerHTML={{
+                              __html: fq ? fq.highlighted : escapeHtml(q.query),
+                            }}
+                          />
                         </div>
                         <button
                           type="button"

--- a/dashboard/app/admin/slow-queries/page.tsx
+++ b/dashboard/app/admin/slow-queries/page.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import Prism from "prismjs";
+import "prismjs/components/prism-sql";
+import { formatPgQueryText } from "@/lib/format-pg-query";
+
+interface QueryOrigin {
+  source: string;
+  locationHint?: string;
+}
 
 interface SlowQuery {
   query: string;
@@ -10,6 +18,7 @@ interface SlowQuery {
   total_exec_time_ms: number;
   rows: number;
   cache_hit_ratio: number | null;
+  origin?: QueryOrigin;
 }
 
 interface SlowQueriesData {
@@ -17,15 +26,140 @@ interface SlowQueriesData {
   error?: string;
 }
 
+type SortKey = "mean_exec_time_ms" | "max_exec_time_ms" | "total_exec_time_ms" | "calls" | "rows" | "cache_hit_ratio";
+type SortDir = "asc" | "desc";
+
 const fmtMs = (v: number) =>
   new Intl.NumberFormat("es-ES", { maximumFractionDigits: 1 }).format(v);
 
 const fmtInt = (v: number) =>
   new Intl.NumberFormat("es-ES", { maximumFractionDigits: 0 }).format(v);
 
+/** Highlight SQL with Prism after formatting. */
+function highlightSql(formatted: string): string {
+  try {
+    return Prism.highlight(formatted, Prism.languages.sql, "sql");
+  } catch {
+    return formatted;
+  }
+}
+
+/** Arrow indicator for sort direction. */
+function SortArrow({ active, dir }: { active: boolean; dir: SortDir }) {
+  if (!active) {
+    return (
+      <span style={{ opacity: 0.3, marginLeft: 3, fontSize: 9 }}>⇅</span>
+    );
+  }
+  return (
+    <span style={{ marginLeft: 3, fontSize: 9, color: "var(--accent)" }}>
+      {dir === "desc" ? "↓" : "↑"}
+    </span>
+  );
+}
+
+/** Collapsible "¿Cómo actuar?" guidance panel. */
+function GuidancePanel() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div
+      style={{
+        borderRadius: 8,
+        border: "1px solid var(--border)",
+        overflow: "hidden",
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          width: "100%",
+          padding: "10px 14px",
+          background: "var(--bg-2)",
+          border: "none",
+          cursor: "pointer",
+          fontFamily: "var(--font-inter, sans-serif)",
+          fontSize: 12,
+          fontWeight: 600,
+          color: "var(--fg)",
+          textAlign: "left",
+        }}
+      >
+        <span style={{ fontSize: 11, opacity: 0.7 }}>{open ? "▼" : "▶"}</span>
+        ¿Cómo actuar ante consultas lentas?
+      </button>
+      {open && (
+        <div
+          style={{
+            padding: "12px 16px",
+            fontSize: 12,
+            color: "var(--fg)",
+            lineHeight: 1.7,
+            background: "var(--bg)",
+          }}
+        >
+          <ol style={{ margin: 0, paddingLeft: 18, display: "flex", flexDirection: "column", gap: 8 }}>
+            <li>
+              <strong>Mide primero.</strong> Abre la consulta en{" "}
+              <a
+                href="/admin"
+                style={{ color: "var(--accent)", textDecoration: "underline" }}
+              >
+                /admin
+              </a>{" "}
+              y usa el endpoint <code>/api/admin/explain</code> para obtener{" "}
+              <code>EXPLAIN (ANALYZE, BUFFERS)</code>. Busca{" "}
+              <em>Seq Scan</em> en tablas grandes (
+              <code>ps_stock_tienda</code> ~12 M filas,{" "}
+              <code>ps_lineas_ventas</code> ~1,7 M,{" "}
+              <code>ps_ventas</code> ~911 K).
+            </li>
+            <li>
+              <strong>Propón un índice</strong> cuando el filtro usa una columna
+              que no está en los índices existentes (ver{" "}
+              <code>etl/schema/init.sql</code>). Añádelo ahí para que se
+              aplique en cada ETL rebuild.
+            </li>
+            <li>
+              <strong>Refactoriza el widget.</strong> Si el origen apunta a un
+              template en <code>dashboard/lib/templates/</code>, revisa el SQL
+              del widget: reduce el rango temporal por defecto, añade más
+              filtros o agrupa con mayor granularidad.
+            </li>
+            <li>
+              <strong>Materializa la agregación.</strong> Para agregaciones
+              pesadas que se repiten (stock por tienda, totales de ventas por
+              semana), considera una{" "}
+              <code>CREATE MATERIALIZED VIEW</code> refrescada por el ETL. Ver
+              los módulos de sync en <code>etl/sync/</code> para añadir un paso
+              de refresco.
+            </li>
+            <li>
+              <strong>Ajusta el timeout.</strong> Las consultas del dashboard ya
+              usan <code>SET LOCAL statement_timeout</code> (ver{" "}
+              <code>dashboard/lib/db.ts</code>). Si una consulta siempre supera
+              el timeout, bien la consulta necesita optimización, bien el límite
+              puede ajustarse por widget.
+            </li>
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function AdminSlowQueriesPage() {
   const [data, setData] = useState<SlowQueriesData | null>(null);
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const [sortKey, setSortKey] = useState<SortKey>("mean_exec_time_ms");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [filter, setFilter] = useState("");
+  const filterTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [debouncedFilter, setDebouncedFilter] = useState("");
 
   useEffect(() => {
     void fetch("/api/admin/slow-queries")
@@ -36,6 +170,34 @@ export default function AdminSlowQueriesPage() {
       );
   }, []);
 
+  // Debounce filter input — 150 ms
+  const handleFilterChange = useCallback((value: string) => {
+    setFilter(value);
+    if (filterTimerRef.current !== null) clearTimeout(filterTimerRef.current);
+    filterTimerRef.current = setTimeout(() => setDebouncedFilter(value), 150);
+  }, []);
+
+  // Memoised formatted + highlighted SQL per query
+  const formattedQueries = useMemo(() => {
+    if (!data) return [];
+    return data.queries.map((q) => {
+      const formatted = formatPgQueryText(q.query);
+      return {
+        formatted,
+        highlighted: highlightSql(formatted),
+      };
+    });
+  }, [data]);
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "desc" ? "asc" : "desc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+  }
+
   function toggleExpand(i: number) {
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -44,6 +206,36 @@ export default function AdminSlowQueriesPage() {
       return next;
     });
   }
+
+  // Filter + sort (client-side)
+  const displayRows = useMemo(() => {
+    if (!data) return [];
+    const lf = debouncedFilter.toLowerCase();
+    const filtered = data.queries
+      .map((q, i) => ({ q, i }))
+      .filter(({ q }) => !lf || q.query.toLowerCase().includes(lf));
+
+    return filtered.sort((a, b) => {
+      const va = a.q[sortKey] ?? -Infinity;
+      const vb = b.q[sortKey] ?? -Infinity;
+      const numA = typeof va === "number" ? va : Number(va);
+      const numB = typeof vb === "number" ? vb : Number(vb);
+      return sortDir === "desc" ? numB - numA : numA - numB;
+    });
+  }, [data, debouncedFilter, sortKey, sortDir]);
+
+  const totalCount = data?.queries.length ?? 0;
+  const filteredCount = displayRows.length;
+
+  const columns: Array<{ label: string; key?: SortKey; align: "left" | "right" }> = [
+    { label: "Consulta", align: "left" },
+    { label: "Llamadas", key: "calls", align: "right" },
+    { label: "Media ms", key: "mean_exec_time_ms", align: "right" },
+    { label: "Máx ms", key: "max_exec_time_ms", align: "right" },
+    { label: "Total ms", key: "total_exec_time_ms", align: "right" },
+    { label: "Filas", key: "rows", align: "right" },
+    { label: "Cache %", key: "cache_hit_ratio", align: "right" },
+  ];
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
@@ -57,6 +249,9 @@ export default function AdminSlowQueriesPage() {
       >
         Consultas lentas (pg_stat_statements)
       </h1>
+
+      {/* Guidance panel */}
+      <GuidancePanel />
 
       {data?.error && (
         <p
@@ -78,110 +273,217 @@ export default function AdminSlowQueriesPage() {
       )}
 
       {data && (
-        <div
-          style={{
-            overflowX: "auto",
-            borderRadius: 8,
-            border: "1px solid var(--border)",
-          }}
-        >
-          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
-            <thead>
-              <tr style={{ background: "var(--bg-2)" }}>
-                {["Consulta", "Llamadas", "Media ms", "Máx ms", "Total ms", "Filas", "Cache %"].map(
-                  (h) => (
+        <>
+          {/* Filter row */}
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <input
+              type="search"
+              value={filter}
+              onChange={(e) => handleFilterChange(e.target.value)}
+              placeholder="Filtrar por tabla, columna o texto de consulta…"
+              aria-label="Filtrar consultas"
+              style={{
+                flex: 1,
+                padding: "7px 10px",
+                borderRadius: 6,
+                border: "1px solid var(--border)",
+                background: "var(--bg-2)",
+                color: "var(--fg)",
+                fontFamily: "var(--font-inter, sans-serif)",
+                fontSize: 12,
+                outline: "none",
+              }}
+            />
+            <span
+              style={{
+                fontSize: 11,
+                color: "var(--fg-muted)",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {filteredCount === totalCount
+                ? `${totalCount} consultas`
+                : `${filteredCount} de ${totalCount} consultas`}
+            </span>
+          </div>
+
+          {/* Table */}
+          <div
+            style={{
+              overflowX: "auto",
+              borderRadius: 8,
+              border: "1px solid var(--border)",
+            }}
+          >
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+              <thead>
+                <tr style={{ background: "var(--bg-2)" }}>
+                  {columns.map((col) => (
                     <th
-                      key={h}
+                      key={col.label}
                       style={{
                         padding: "9px 12px",
                         fontWeight: 500,
                         fontFamily: "var(--font-inter, sans-serif)",
                         fontSize: 11,
                         letterSpacing: "0.04em",
-                        color: "var(--fg-subtle)",
-                        textAlign: h === "Consulta" ? "left" : "right",
+                        color: col.key ? "var(--fg)" : "var(--fg-subtle)",
+                        textAlign: col.align,
                         whiteSpace: "nowrap",
                         borderBottom: "1px solid var(--border)",
+                        cursor: col.key ? "pointer" : "default",
+                        userSelect: "none",
                       }}
+                      onClick={col.key ? () => toggleSort(col.key!) : undefined}
+                      aria-sort={
+                        col.key
+                          ? sortKey === col.key
+                            ? sortDir === "desc"
+                              ? "descending"
+                              : "ascending"
+                            : "none"
+                          : undefined
+                      }
                     >
-                      {h}
+                      {col.label}
+                      {col.key && (
+                        <SortArrow
+                          active={sortKey === col.key}
+                          dir={sortDir}
+                        />
+                      )}
                     </th>
-                  ),
-                )}
-              </tr>
-            </thead>
-            <tbody>
-              {(data?.queries ?? []).map((q, i) => (
-                <tr
-                  key={i}
-                  style={{
-                    background: i % 2 === 1 ? "var(--bg-2)" : undefined,
-                    borderTop: "1px solid var(--border)",
-                  }}
-                >
-                  <td
-                    style={{
-                      padding: "9px 12px",
-                      maxWidth: 420,
-                      verticalAlign: "top",
-                    }}
-                  >
-                    <div
-                      style={{
-                        display: "-webkit-box",
-                        WebkitBoxOrient: "vertical" as React.CSSProperties["WebkitBoxOrient"],
-                        WebkitLineClamp: expanded.has(i) ? undefined : 2,
-                        overflow: expanded.has(i) ? "visible" : "hidden",
-                        fontFamily: "var(--font-jetbrains, monospace)",
-                        fontSize: 11,
-                        color: "var(--fg)",
-                        whiteSpace: "pre-wrap",
-                        wordBreak: "break-all",
-                      }}
-                    >
-                      {q.query}
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => toggleExpand(i)}
-                      style={{
-                        background: "none",
-                        border: "none",
-                        cursor: "pointer",
-                        fontSize: 11,
-                        color: "var(--accent)",
-                        padding: "2px 0",
-                        fontFamily: "inherit",
-                      }}
-                    >
-                      {expanded.has(i) ? "contraer" : "ver completa"}
-                    </button>
-                  </td>
-                  <td style={{ padding: "9px 12px", textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
-                    {fmtInt(q.calls)}
-                  </td>
-                  <td style={{ padding: "9px 12px", textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
-                    {fmtMs(q.mean_exec_time_ms)}
-                  </td>
-                  <td style={{ padding: "9px 12px", textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
-                    {fmtMs(q.max_exec_time_ms)}
-                  </td>
-                  <td style={{ padding: "9px 12px", textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
-                    {fmtMs(q.total_exec_time_ms)}
-                  </td>
-                  <td style={{ padding: "9px 12px", textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
-                    {fmtInt(q.rows)}
-                  </td>
-                  <td style={{ padding: "9px 12px", textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
-                    {q.cache_hit_ratio != null
-                      ? `${(q.cache_hit_ratio * 100).toFixed(1)}%`
-                      : "—"}
-                  </td>
+                  ))}
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {displayRows.map(({ q, i }) => {
+                  const fq = formattedQueries[i];
+                  const isExpanded = expanded.has(i);
+                  return (
+                    <tr
+                      key={i}
+                      style={{
+                        background: i % 2 === 1 ? "var(--bg-2)" : undefined,
+                        borderTop: "1px solid var(--border)",
+                      }}
+                    >
+                      <td
+                        style={{
+                          padding: "9px 12px",
+                          maxWidth: 460,
+                          verticalAlign: "top",
+                        }}
+                      >
+                        {/* Origin badge */}
+                        {q.origin && (
+                          <div
+                            style={{
+                              marginBottom: 4,
+                              fontSize: 10,
+                              color: "var(--accent)",
+                              fontFamily: "var(--font-inter, sans-serif)",
+                            }}
+                          >
+                            Posible origen:{" "}
+                            {q.origin.locationHint ? (
+                              <span title={q.origin.source}>
+                                <code style={{ fontSize: 10 }}>
+                                  {q.origin.locationHint}
+                                </code>
+                                {" — "}
+                                <span style={{ opacity: 0.8 }}>
+                                  {q.origin.source}
+                                </span>
+                              </span>
+                            ) : (
+                              <span>{q.origin.source}</span>
+                            )}
+                          </div>
+                        )}
+
+                        {/* SQL body */}
+                        <div
+                          style={{
+                            maxHeight: isExpanded ? "none" : "3.6em",
+                            overflow: isExpanded ? "visible" : "hidden",
+                            fontFamily: "var(--font-jetbrains, monospace)",
+                            fontSize: 11,
+                            lineHeight: 1.5,
+                            color: "var(--fg)",
+                            whiteSpace: "pre-wrap",
+                            wordBreak: "break-word",
+                          }}
+                        >
+                          {fq ? (
+                            <span
+                              // biome-ignore lint/security/noDangerouslySetInnerHtml
+                              dangerouslySetInnerHTML={{ __html: fq.highlighted }}
+                            />
+                          ) : (
+                            q.query
+                          )}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => toggleExpand(i)}
+                          style={{
+                            background: "none",
+                            border: "none",
+                            cursor: "pointer",
+                            fontSize: 11,
+                            color: "var(--accent)",
+                            padding: "2px 0",
+                            fontFamily: "inherit",
+                          }}
+                        >
+                          {isExpanded ? "contraer" : "ver completa"}
+                        </button>
+                      </td>
+                      <td style={{ padding: "9px 12px", textAlign: "right", fontVariantNumeric: "tabular-nums", whiteSpace: "nowrap" }}>
+                        {fmtInt(q.calls)}
+                      </td>
+                      <td style={{ padding: "9px 12px", textAlign: "right", fontVariantNumeric: "tabular-nums", whiteSpace: "nowrap" }}>
+                        {fmtMs(q.mean_exec_time_ms)}
+                      </td>
+                      <td style={{ padding: "9px 12px", textAlign: "right", fontVariantNumeric: "tabular-nums", whiteSpace: "nowrap" }}>
+                        {fmtMs(q.max_exec_time_ms)}
+                      </td>
+                      <td style={{ padding: "9px 12px", textAlign: "right", fontVariantNumeric: "tabular-nums", whiteSpace: "nowrap" }}>
+                        {fmtMs(q.total_exec_time_ms)}
+                      </td>
+                      <td style={{ padding: "9px 12px", textAlign: "right", fontVariantNumeric: "tabular-nums", whiteSpace: "nowrap" }}>
+                        {fmtInt(q.rows)}
+                      </td>
+                      <td style={{ padding: "9px 12px", textAlign: "right", fontVariantNumeric: "tabular-nums", whiteSpace: "nowrap" }}>
+                        {q.cache_hit_ratio != null
+                          ? `${q.cache_hit_ratio.toFixed(1)}%`
+                          : "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+                {displayRows.length === 0 && (
+                  <tr>
+                    <td
+                      colSpan={7}
+                      style={{
+                        padding: "24px 12px",
+                        textAlign: "center",
+                        color: "var(--fg-muted)",
+                        fontSize: 12,
+                      }}
+                    >
+                      {debouncedFilter
+                        ? `Sin resultados para "${debouncedFilter}"`
+                        : "Sin consultas lentas registradas."}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
     </div>
   );

--- a/dashboard/lib/__tests__/admin-query-origin.test.ts
+++ b/dashboard/lib/__tests__/admin-query-origin.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractSqlFingerprint,
+  jaccardSimilarity,
+  savedDashboardCandidates,
+  findQueryOrigin,
+} from "../admin-query-origin";
+
+describe("extractSqlFingerprint", () => {
+  it("extracts ps_* table names from a simple query", () => {
+    const sql = "SELECT * FROM ps_ventas WHERE fecha_creacion >= $1";
+    expect(extractSqlFingerprint(sql)).toEqual(["ps_ventas"]);
+  });
+
+  it("extracts multiple table names from a JOIN query", () => {
+    const sql = `
+      SELECT lv.codigo, v.tienda
+      FROM ps_lineas_ventas lv
+      JOIN ps_ventas v ON v.reg_ventas = lv.num_ventas
+      WHERE lv.tienda <> '99'
+    `;
+    expect(extractSqlFingerprint(sql)).toEqual(["ps_lineas_ventas", "ps_ventas"]);
+  });
+
+  it("deduplicates repeated table names", () => {
+    const sql =
+      "SELECT * FROM ps_ventas v JOIN ps_ventas v2 ON v.id = v2.id WHERE ps_ventas.tienda = '01'";
+    expect(extractSqlFingerprint(sql)).toEqual(["ps_ventas"]);
+  });
+
+  it("returns empty array when no ps_* tables", () => {
+    expect(extractSqlFingerprint("SELECT 1 AS x")).toEqual([]);
+    expect(extractSqlFingerprint("")).toEqual([]);
+  });
+
+  it("is case-insensitive", () => {
+    const sql = "SELECT * FROM PS_VENTAS";
+    expect(extractSqlFingerprint(sql)).toEqual(["ps_ventas"]);
+  });
+});
+
+describe("jaccardSimilarity", () => {
+  it("returns 1 for identical non-empty fingerprints", () => {
+    expect(jaccardSimilarity(["ps_ventas"], ["ps_ventas"])).toBe(1);
+  });
+
+  it("returns 0 for disjoint fingerprints", () => {
+    expect(jaccardSimilarity(["ps_ventas"], ["ps_stock_tienda"])).toBe(0);
+  });
+
+  it("returns 0 for two empty fingerprints", () => {
+    expect(jaccardSimilarity([], [])).toBe(0);
+  });
+
+  it("computes partial overlap correctly", () => {
+    const a = ["ps_ventas", "ps_lineas_ventas"];
+    const b = ["ps_ventas", "ps_articulos"];
+    // intersection = {ps_ventas}, union = {ps_ventas, ps_lineas_ventas, ps_articulos}
+    expect(jaccardSimilarity(a, b)).toBeCloseTo(1 / 3);
+  });
+});
+
+describe("savedDashboardCandidates", () => {
+  it("extracts candidates from a dashboard spec", () => {
+    const dashboards = [
+      {
+        id: "d1",
+        title: "Mi Dashboard",
+        spec: {
+          title: "Mi Dashboard",
+          widgets: [
+            {
+              id: "w1",
+              type: "bar_chart",
+              title: "Ventas por tienda",
+              sql: "SELECT tienda, SUM(total_si) FROM ps_ventas GROUP BY tienda",
+            },
+          ],
+        },
+      },
+    ];
+    const candidates = savedDashboardCandidates(dashboards);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].source).toContain("Mi Dashboard");
+    expect(candidates[0].fingerprint).toEqual(["ps_ventas"]);
+  });
+
+  it("extracts candidates from kpi_row items", () => {
+    const dashboards = [
+      {
+        id: "d2",
+        title: "KPIs",
+        spec: {
+          title: "KPIs",
+          widgets: [
+            {
+              id: "w1",
+              type: "kpi_row",
+              items: [
+                {
+                  label: "Ventas",
+                  sql: "SELECT SUM(total_si) AS value FROM ps_ventas WHERE entrada = true",
+                },
+                {
+                  label: "Stock",
+                  sql: "SELECT SUM(stock) AS value FROM ps_stock_tienda",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ];
+    const candidates = savedDashboardCandidates(dashboards);
+    expect(candidates).toHaveLength(2);
+    const tables = candidates.flatMap((c) => c.fingerprint);
+    expect(tables).toContain("ps_ventas");
+    expect(tables).toContain("ps_stock_tienda");
+  });
+
+  it("returns empty when dashboards list is empty", () => {
+    expect(savedDashboardCandidates([])).toHaveLength(0);
+  });
+});
+
+describe("findQueryOrigin — template matching", () => {
+  it("matches a ps_ventas query to the Ventas template", () => {
+    const rawSql =
+      "SELECT SUM(total_si) AS value FROM ps_ventas v WHERE v.entrada = true AND v.tienda <> '99' AND v.fecha_creacion >= $1 AND v.fecha_creacion <= $2";
+    const origin = findQueryOrigin(rawSql);
+    expect(origin).not.toBeNull();
+    expect(origin!.source).toMatch(/Template.*Ventas/i);
+    expect(origin!.locationHint).toContain("dashboard/lib/templates/ventas.ts");
+  });
+
+  it("matches a ps_stock_tienda query to the Stock template", () => {
+    const rawSql =
+      "SELECT tienda, SUM(stock) AS total_stock FROM ps_stock_tienda WHERE tienda <> '99' GROUP BY tienda ORDER BY total_stock DESC";
+    const origin = findQueryOrigin(rawSql);
+    expect(origin).not.toBeNull();
+    // Should match the stock template since it primarily references ps_stock_tienda
+    expect(origin!.locationHint).toContain("dashboard/lib/templates/stock.ts");
+  });
+
+  it("returns null for a non-ps_* query", () => {
+    const rawSql = "SELECT 1 AS health_check";
+    expect(findQueryOrigin(rawSql)).toBeNull();
+  });
+
+  it("returns null when similarity is below threshold", () => {
+    // A query with a table not in any template
+    const rawSql =
+      "SELECT * FROM ps_completely_made_up_table_xyz WHERE id = $1";
+    // ps_completely_made_up_table_xyz won't match any source
+    expect(findQueryOrigin(rawSql)).toBeNull();
+  });
+});
+
+describe("findQueryOrigin — saved dashboard matching", () => {
+  it("matches a query against a saved dashboard", () => {
+    const rawSql =
+      "SELECT tienda, SUM(total_si) AS ventas FROM ps_gc_lin_albarane GROUP BY tienda";
+    const savedDashboards = [
+      {
+        id: "d1",
+        title: "Dashboard Mayorista",
+        spec: {
+          title: "Dashboard Mayorista",
+          widgets: [
+            {
+              id: "w1",
+              type: "bar_chart",
+              title: "Ventas mayorista por tienda",
+              sql: "SELECT tienda, SUM(base1 + base2) AS ventas FROM ps_gc_lin_albarane GROUP BY tienda",
+            },
+          ],
+        },
+      },
+    ];
+    const origin = findQueryOrigin(rawSql, { savedDashboards });
+    expect(origin).not.toBeNull();
+    expect(origin!.source).toContain("Dashboard Mayorista");
+  });
+});

--- a/dashboard/lib/__tests__/admin-query-origin.test.ts
+++ b/dashboard/lib/__tests__/admin-query-origin.test.ts
@@ -177,7 +177,9 @@ describe("findQueryOrigin — saved dashboard matching", () => {
         },
       },
     ];
-    const origin = findQueryOrigin(rawSql, { savedDashboards });
+    // Build candidates once, pass as savedDashboardCandidateList (new API)
+    const candidateList = savedDashboardCandidates(savedDashboards);
+    const origin = findQueryOrigin(rawSql, { savedDashboardCandidateList: candidateList });
     expect(origin).not.toBeNull();
     expect(origin!.source).toContain("Dashboard Mayorista");
   });

--- a/dashboard/lib/__tests__/format-pg-query.test.ts
+++ b/dashboard/lib/__tests__/format-pg-query.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { formatPgQueryText } from "../format-pg-query";
+
+/**
+ * Tests for formatPgQueryText.
+ *
+ * Bug examples are taken verbatim from the Additional Context section of
+ * GitHub issue #443.  Each test asserts that the output contains the expected
+ * token spacing (case-insensitive, tolerating line-breaks added by the
+ * formatter).
+ */
+
+/** Normalise whitespace to a single space so we can match across line-breaks. */
+function normalise(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+describe("formatPgQueryText — issue #443 bug examples", () => {
+  it('fixes SELECTCOUNT(*)AS → SELECT COUNT(*) AS', () => {
+    const input = "SELECTCOUNT(*)AS skus_with_inconsistent_cc FROM ps_ventas";
+    const out = normalise(formatPgQueryText(input));
+    expect(out).toMatch(/SELECT\s+COUNT\s*\(\s*\*\s*\)\s+AS\s+skus_with_inconsistent_cc/i);
+  });
+
+  it('fixes ISNOTNULLGROUPBY → IS NOT NULL … GROUP BY', () => {
+    const input =
+      "SELECT cc_stock FROM ps_stock_tienda WHERE cc_stock ISNOTNULLGROUPBY codigo, talla";
+    const out = normalise(formatPgQueryText(input));
+    expect(out).toMatch(/IS\s+NOT\s+NULL/i);
+    expect(out).toMatch(/GROUP\s+BY/i);
+  });
+
+  it('fixes SELECTDATE $1AS → SELECT DATE $1 AS', () => {
+    const input = "SELECTDATE $1AS curr_from, DATE $2AS curr_to";
+    const out = normalise(formatPgQueryText(input));
+    expect(out).toMatch(/SELECT/i);
+    expect(out).toMatch(/AS\s+curr_from/i);
+    expect(out).toMatch(/AS\s+curr_to/i);
+  });
+
+  it('fixes "ccrefejofacm"AS"Referencia" → ... AS "Referencia"', () => {
+    const input =
+      'SELECT p."ccrefejofacm"AS"Referencia" FROM ps_articulos p';
+    const out = formatPgQueryText(input);
+    // The formatter must insert whitespace between the alias and the keyword
+    expect(out).toMatch(/AS\s+"Referencia"/i);
+  });
+});
+
+describe("formatPgQueryText — idempotency", () => {
+  it("is idempotent: formatting twice produces the same result", () => {
+    const input =
+      'SELECT v."total_si" AS ventas, COUNT(*) AS tickets FROM ps_ventas v WHERE v."entrada" = true GROUP BY v."tienda" ORDER BY ventas DESC';
+    const once = formatPgQueryText(input);
+    const twice = formatPgQueryText(once);
+    expect(normalise(twice)).toBe(normalise(once));
+  });
+});
+
+describe("formatPgQueryText — edge cases", () => {
+  it("returns empty string unchanged", () => {
+    expect(formatPgQueryText("")).toBe("");
+  });
+
+  it("returns whitespace-only string unchanged", () => {
+    expect(formatPgQueryText("   ")).toBe("   ");
+  });
+
+  it("handles $N placeholders without throwing", () => {
+    const input =
+      "SELECT * FROM ps_ventas WHERE fecha_creacion >= $1 AND fecha_creacion <= $2 AND tienda = $3";
+    expect(() => formatPgQueryText(input)).not.toThrow();
+    const out = normalise(formatPgQueryText(input));
+    expect(out).toMatch(/WHERE/i);
+    expect(out).toMatch(/\$1/);
+    expect(out).toMatch(/\$2/);
+    expect(out).toMatch(/\$3/);
+  });
+
+  it("handles CTE (WITH ... AS (...)) without throwing", () => {
+    const input = `WITH params AS (SELECT $1::date AS curr_from, $2::date AS curr_to) SELECT * FROM ps_ventas v, params p WHERE v.fecha_creacion >= p.curr_from`;
+    expect(() => formatPgQueryText(input)).not.toThrow();
+    const out = normalise(formatPgQueryText(input));
+    expect(out).toMatch(/WITH/i);
+    expect(out).toMatch(/params/i);
+  });
+
+  it("handles FILTER (WHERE ...) aggregate syntax without throwing", () => {
+    const input =
+      "SELECT COUNT(*) FILTER (WHERE entrada = true) AS ventas, COUNT(*) FILTER (WHERE entrada = false) AS devol FROM ps_ventas";
+    expect(() => formatPgQueryText(input)).not.toThrow();
+    const out = normalise(formatPgQueryText(input));
+    expect(out).toMatch(/FILTER/i);
+  });
+
+  it("handles SELECT DISTINCT without throwing", () => {
+    const input =
+      "SELECT DISTINCT tienda FROM ps_ventas WHERE fecha_creacion >= $1";
+    expect(() => formatPgQueryText(input)).not.toThrow();
+    const out = normalise(formatPgQueryText(input));
+    expect(out).toMatch(/SELECT\s+DISTINCT/i);
+  });
+
+  it("handles JSON operators without throwing", () => {
+    const input =
+      "SELECT spec->'widgets' AS widgets FROM dashboards WHERE id = $1";
+    expect(() => formatPgQueryText(input)).not.toThrow();
+  });
+
+  it("does not throw on malformed SQL — returns a non-empty string", () => {
+    const input = "SELECTNONSENSE;;;garbage$$";
+    let result: string | undefined;
+    expect(() => {
+      result = formatPgQueryText(input);
+    }).not.toThrow();
+    expect(typeof result).toBe("string");
+    expect((result ?? "").length).toBeGreaterThan(0);
+  });
+});
+
+describe("formatPgQueryText — real pg_stat_statements patterns", () => {
+  it("formats a typical ps_ventas aggregation query", () => {
+    const input =
+      "SELECT tienda, SUM(total_si) AS ventas, COUNT(DISTINCT reg_ventas) AS tickets FROM ps_ventas WHERE entrada = $1 AND tienda <> $2 AND fecha_creacion >= $3 AND fecha_creacion <= $4 GROUP BY tienda ORDER BY ventas DESC";
+    const out = formatPgQueryText(input);
+    expect(out).toMatch(/SELECT/i);
+    expect(out).toMatch(/GROUP BY/i);
+    expect(out).toMatch(/ORDER BY/i);
+  });
+
+  it("formats a stock query with CASE / IS NOT NULL", () => {
+    const input =
+      "SELECT codigo, talla, stock FROM ps_stock_tienda WHERE stock IS NOT NULL AND tienda = $1 ORDER BY codigo";
+    const out = normalise(formatPgQueryText(input));
+    expect(out).toMatch(/IS\s+NOT\s+NULL/i);
+    expect(out).toMatch(/ORDER\s+BY/i);
+  });
+});

--- a/dashboard/lib/admin-query-origin.ts
+++ b/dashboard/lib/admin-query-origin.ts
@@ -1,0 +1,243 @@
+/**
+ * Origin matcher for pg_stat_statements slow queries.
+ *
+ * Given the raw SQL text from pg_stat_statements, attempts to identify
+ * where in the codebase the query was generated.  Matching is done by
+ * extracting a "fingerprint" (set of ps_* table names referenced) from
+ * both the candidate and the source SQL, then finding the best match.
+ *
+ * Priority order:
+ *   1. dashboard/lib/templates/*.ts  (template widget SQL)
+ *   2. Saved dashboards from the database (widget SQL in the spec JSON)
+ *   3. dashboard/lib/review-queries.ts (REVIEW_QUERIES array)
+ *   4. scripts/wren-push-metadata.py  (SQL_PAIRS list)
+ *
+ * Returns null when no source reaches the minimum similarity threshold.
+ */
+
+import { readFileSync } from "fs";
+import path from "path";
+import { TEMPLATES } from "@/lib/templates";
+import { REVIEW_QUERIES } from "@/lib/review-queries";
+import type { DashboardSpec } from "@/lib/schema";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface QueryOrigin {
+  /** Human-readable source label, e.g. "Template: Responsable de Ventas > Ventas Netas" */
+  source: string;
+  /** Relative file path hint when deterministic, e.g. "dashboard/lib/templates/ventas.ts" */
+  locationHint?: string;
+}
+
+// ─── Fingerprinting ───────────────────────────────────────────────────────────
+
+/**
+ * Extract a normalised fingerprint from a SQL string:
+ *   - lowercase the query
+ *   - extract all ps_* table names referenced in FROM / JOIN clauses
+ *   - return a sorted, deduplicated array of table names
+ *
+ * The fingerprint must be non-empty and contain at least one ps_* name;
+ * otherwise we cannot make a reliable match.
+ */
+export function extractSqlFingerprint(sql: string): string[] {
+  if (!sql) return [];
+  // Match ps_<word> references (table names or aliases)
+  const matches = sql.toLowerCase().match(/\bps_[a-z_]+/g) ?? [];
+  return [...new Set(matches)].sort();
+}
+
+/**
+ * Jaccard similarity between two fingerprint arrays.
+ * Returns a number in [0, 1].  Returns 0 when both are empty.
+ */
+export function jaccardSimilarity(a: string[], b: string[]): number {
+  if (a.length === 0 && b.length === 0) return 0;
+  const setA = new Set(a);
+  const setB = new Set(b);
+  const intersection = [...setA].filter((x) => setB.has(x)).length;
+  const union = new Set([...setA, ...setB]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/** Minimum Jaccard similarity to claim a match. */
+const MIN_SIMILARITY = 0.5;
+
+// ─── Source scanners ──────────────────────────────────────────────────────────
+
+interface Candidate {
+  source: string;
+  locationHint?: string;
+  fingerprint: string[];
+}
+
+/** Build candidates from templates. */
+function templateCandidates(): Candidate[] {
+  const results: Candidate[] = [];
+  for (const tmpl of TEMPLATES) {
+    const spec = tmpl.spec;
+    const locationHint = `dashboard/lib/templates/${tmpl.slug}.ts`;
+    for (const widget of spec.widgets) {
+      const sqls: string[] = [];
+      if ("sql" in widget && typeof widget.sql === "string") {
+        sqls.push(widget.sql);
+      }
+      if ("items" in widget && Array.isArray(widget.items)) {
+        for (const item of widget.items) {
+          if (item && typeof item === "object" && "sql" in item && typeof item.sql === "string") {
+            sqls.push(item.sql);
+          }
+        }
+      }
+      for (const sql of sqls) {
+        const fp = extractSqlFingerprint(sql);
+        if (fp.length > 0) {
+          const widgetLabel =
+            "title" in widget && widget.title
+              ? String(widget.title)
+              : "items" in widget
+              ? "kpi_row"
+              : widget.type ?? "widget";
+          results.push({
+            source: `Template: ${tmpl.name} > ${widgetLabel}`,
+            locationHint,
+            fingerprint: fp,
+          });
+        }
+      }
+    }
+  }
+  return results;
+}
+
+/** Build candidates from review queries. */
+function reviewQueryCandidates(): Candidate[] {
+  return REVIEW_QUERIES.filter((q) => extractSqlFingerprint(q.sql).length > 0).map((q) => ({
+    source: `Review: ${q.name} (${q.domain})`,
+    locationHint: "dashboard/lib/review-queries.ts",
+    fingerprint: extractSqlFingerprint(q.sql),
+  }));
+}
+
+/** Extract SQL strings from a raw dashboard spec JSON. */
+function extractSpecSqls(specJson: unknown): string[] {
+  const sqls: string[] = [];
+  if (!specJson || typeof specJson !== "object") return sqls;
+  const spec = specJson as DashboardSpec;
+  if (!Array.isArray(spec.widgets)) return sqls;
+  for (const widget of spec.widgets) {
+    if ("sql" in widget && typeof widget.sql === "string") sqls.push(widget.sql);
+    if ("items" in widget && Array.isArray(widget.items)) {
+      for (const item of widget.items) {
+        if (item && typeof item === "object" && "sql" in item && typeof item.sql === "string") {
+          sqls.push(item.sql);
+        }
+      }
+    }
+  }
+  return sqls;
+}
+
+/** Build candidates from saved dashboards (injected to avoid DB coupling in tests). */
+export function savedDashboardCandidates(
+  dashboards: Array<{ id: string; title?: string; spec: unknown }>,
+): Candidate[] {
+  const results: Candidate[] = [];
+  for (const db of dashboards) {
+    const sqls = extractSpecSqls(db.spec);
+    for (const sql of sqls) {
+      const fp = extractSqlFingerprint(sql);
+      if (fp.length > 0) {
+        results.push({
+          source: `Dashboard guardado: ${db.title ?? db.id}`,
+          fingerprint: fp,
+        });
+      }
+    }
+  }
+  return results;
+}
+
+/** Parse SQL_PAIRS from wren-push-metadata.py using a simple regex (no AST). */
+export function wrenPairCandidates(repoRoot: string): Candidate[] {
+  const filePath = path.join(repoRoot, "scripts", "wren-push-metadata.py");
+  let src: string;
+  try {
+    src = readFileSync(filePath, "utf8");
+  } catch {
+    return []; // file not available in this environment
+  }
+
+  const candidates: Candidate[] = [];
+
+  // Match SQL strings inside SQL_PAIRS — look for multi-line strings after "sql": """..."""
+  // or "sql": "..." patterns in the Python tuple/dict structure.
+  // Use a simple approach: find all triple-quoted strings that reference ps_* tables.
+  const tripleQuoteRe = /"""([\s\S]*?)"""/g;
+  let m: RegExpExecArray | null;
+  while ((m = tripleQuoteRe.exec(src)) !== null) {
+    const content = m[1];
+    if (/\bps_[a-z_]+/i.test(content)) {
+      const fp = extractSqlFingerprint(content);
+      if (fp.length > 0) {
+        candidates.push({
+          source: "WrenAI SQL pair",
+          locationHint: "scripts/wren-push-metadata.py",
+          fingerprint: fp,
+        });
+      }
+    }
+  }
+
+  return candidates;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export interface FindQueryOriginOptions {
+  /** Pre-loaded saved dashboards (avoids DB call in tests). */
+  savedDashboards?: Array<{ id: string; title?: string; spec: unknown }>;
+  /** Absolute path to the repo root (for reading wren-push-metadata.py). */
+  repoRoot?: string;
+}
+
+/**
+ * Find the most likely origin of a pg_stat_statements SQL string.
+ *
+ * Returns null when no source reaches MIN_SIMILARITY threshold or when the
+ * query fingerprint is empty (e.g. a DDL or a non-ps_* query).
+ */
+export function findQueryOrigin(
+  rawSql: string,
+  options: FindQueryOriginOptions = {},
+): QueryOrigin | null {
+  const target = extractSqlFingerprint(rawSql);
+  if (target.length === 0) return null;
+
+  // Collect all candidates in priority order
+  const candidates: Candidate[] = [
+    ...templateCandidates(),
+    ...(options.savedDashboards ? savedDashboardCandidates(options.savedDashboards) : []),
+    ...reviewQueryCandidates(),
+    ...(options.repoRoot ? wrenPairCandidates(options.repoRoot) : []),
+  ];
+
+  let bestSim = 0;
+  let bestCandidate: Candidate | null = null;
+
+  for (const candidate of candidates) {
+    const sim = jaccardSimilarity(target, candidate.fingerprint);
+    if (sim > bestSim) {
+      bestSim = sim;
+      bestCandidate = candidate;
+    }
+  }
+
+  if (bestSim < MIN_SIMILARITY || bestCandidate === null) return null;
+
+  return {
+    source: bestCandidate.source,
+    locationHint: bestCandidate.locationHint,
+  };
+}

--- a/dashboard/lib/admin-query-origin.ts
+++ b/dashboard/lib/admin-query-origin.ts
@@ -3,22 +3,21 @@
  *
  * Given the raw SQL text from pg_stat_statements, attempts to identify
  * where in the codebase the query was generated.  Matching is done by
- * extracting a "fingerprint" (set of ps_* table names referenced) from
- * both the candidate and the source SQL, then finding the best match.
+ * extracting a "fingerprint" (set of ps_* tokens) from both the candidate
+ * and the source SQL, then finding the best match by Jaccard similarity.
  *
  * Priority order:
  *   1. dashboard/lib/templates/*.ts  (template widget SQL)
  *   2. Saved dashboards from the database (widget SQL in the spec JSON)
  *   3. dashboard/lib/review-queries.ts (REVIEW_QUERIES array)
- *   4. scripts/wren-push-metadata.py  (SQL_PAIRS list)
+ *   4. dashboard/lib/knowledge.ts     (SQL_PAIRS — typed copy of wren SQL pairs)
  *
  * Returns null when no source reaches the minimum similarity threshold.
  */
 
-import { readFileSync } from "fs";
-import path from "path";
 import { TEMPLATES } from "@/lib/templates";
 import { REVIEW_QUERIES } from "@/lib/review-queries";
+import { SQL_PAIRS } from "@/lib/knowledge";
 import type { DashboardSpec } from "@/lib/schema";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -33,17 +32,18 @@ export interface QueryOrigin {
 // ─── Fingerprinting ───────────────────────────────────────────────────────────
 
 /**
- * Extract a normalised fingerprint from a SQL string:
- *   - lowercase the query
- *   - extract all ps_* table names referenced in FROM / JOIN clauses
- *   - return a sorted, deduplicated array of table names
+ * Extract a normalised fingerprint from a SQL string.
  *
- * The fingerprint must be non-empty and contain at least one ps_* name;
- * otherwise we cannot make a reliable match.
+ * Matches all `ps_*` tokens anywhere in the SQL (table names as well as
+ * references in SELECT lists, aliases, etc.).  While this can include some
+ * false positives, it is intentionally broad so that joined tables captured
+ * in `pg_stat_statements` output still produce a useful overlap signal.
+ *
+ * Returns a sorted, deduplicated array.  An empty array means "no ps_* tokens
+ * found" — origin matching should be skipped for such queries.
  */
 export function extractSqlFingerprint(sql: string): string[] {
   if (!sql) return [];
-  // Match ps_<word> references (table names or aliases)
   const matches = sql.toLowerCase().match(/\bps_[a-z_]+/g) ?? [];
   return [...new Set(matches)].sort();
 }
@@ -64,7 +64,7 @@ export function jaccardSimilarity(a: string[], b: string[]): number {
 /** Minimum Jaccard similarity to claim a match. */
 const MIN_SIMILARITY = 0.5;
 
-// ─── Source scanners ──────────────────────────────────────────────────────────
+// ─── Source candidates ────────────────────────────────────────────────────────
 
 interface Candidate {
   source: string;
@@ -72,9 +72,17 @@ interface Candidate {
   fingerprint: string[];
 }
 
-/** Build candidates from templates. */
-function templateCandidates(): Candidate[] {
+/**
+ * Lazily-built candidate list from static sources (templates + review queries +
+ * knowledge SQL pairs).  Built once and cached at module scope — these never
+ * change at runtime.
+ */
+let _staticCandidates: Candidate[] | null = null;
+
+function buildStaticCandidates(): Candidate[] {
   const results: Candidate[] = [];
+
+  // ── Templates ──────────────────────────────────────────────────────────────
   for (const tmpl of TEMPLATES) {
     const spec = tmpl.spec;
     const locationHint = `dashboard/lib/templates/${tmpl.slug}.ts`;
@@ -108,16 +116,39 @@ function templateCandidates(): Candidate[] {
       }
     }
   }
+
+  // ── Review queries ─────────────────────────────────────────────────────────
+  for (const q of REVIEW_QUERIES) {
+    const fp = extractSqlFingerprint(q.sql);
+    if (fp.length > 0) {
+      results.push({
+        source: `Review: ${q.name} (${q.domain})`,
+        locationHint: "dashboard/lib/review-queries.ts",
+        fingerprint: fp,
+      });
+    }
+  }
+
+  // ── Knowledge SQL pairs (typed copy of wren-push-metadata.py SQL_PAIRS) ───
+  for (const pair of SQL_PAIRS) {
+    const fp = extractSqlFingerprint(pair.sql);
+    if (fp.length > 0) {
+      results.push({
+        source: `WrenAI SQL pair: ${pair.question.slice(0, 60)}`,
+        locationHint: "dashboard/lib/knowledge.ts",
+        fingerprint: fp,
+      });
+    }
+  }
+
   return results;
 }
 
-/** Build candidates from review queries. */
-function reviewQueryCandidates(): Candidate[] {
-  return REVIEW_QUERIES.filter((q) => extractSqlFingerprint(q.sql).length > 0).map((q) => ({
-    source: `Review: ${q.name} (${q.domain})`,
-    locationHint: "dashboard/lib/review-queries.ts",
-    fingerprint: extractSqlFingerprint(q.sql),
-  }));
+function getStaticCandidates(): Candidate[] {
+  if (_staticCandidates === null) {
+    _staticCandidates = buildStaticCandidates();
+  }
+  return _staticCandidates;
 }
 
 /** Extract SQL strings from a raw dashboard spec JSON. */
@@ -159,51 +190,19 @@ export function savedDashboardCandidates(
   return results;
 }
 
-/** Parse SQL_PAIRS from wren-push-metadata.py using a simple regex (no AST). */
-export function wrenPairCandidates(repoRoot: string): Candidate[] {
-  const filePath = path.join(repoRoot, "scripts", "wren-push-metadata.py");
-  let src: string;
-  try {
-    src = readFileSync(filePath, "utf8");
-  } catch {
-    return []; // file not available in this environment
-  }
-
-  const candidates: Candidate[] = [];
-
-  // Match SQL strings inside SQL_PAIRS — look for multi-line strings after "sql": """..."""
-  // or "sql": "..." patterns in the Python tuple/dict structure.
-  // Use a simple approach: find all triple-quoted strings that reference ps_* tables.
-  const tripleQuoteRe = /"""([\s\S]*?)"""/g;
-  let m: RegExpExecArray | null;
-  while ((m = tripleQuoteRe.exec(src)) !== null) {
-    const content = m[1];
-    if (/\bps_[a-z_]+/i.test(content)) {
-      const fp = extractSqlFingerprint(content);
-      if (fp.length > 0) {
-        candidates.push({
-          source: "WrenAI SQL pair",
-          locationHint: "scripts/wren-push-metadata.py",
-          fingerprint: fp,
-        });
-      }
-    }
-  }
-
-  return candidates;
-}
-
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 export interface FindQueryOriginOptions {
-  /** Pre-loaded saved dashboards (avoids DB call in tests). */
-  savedDashboards?: Array<{ id: string; title?: string; spec: unknown }>;
-  /** Absolute path to the repo root (for reading wren-push-metadata.py). */
-  repoRoot?: string;
+  /** Pre-built saved dashboard candidates (compute once per request, pass per row). */
+  savedDashboardCandidateList?: Candidate[];
 }
 
 /**
  * Find the most likely origin of a pg_stat_statements SQL string.
+ *
+ * Uses pre-cached static candidates (templates + review queries + knowledge SQL pairs)
+ * for O(1) per-request candidate building, plus optional per-request dashboard
+ * candidates passed in from the call site.
  *
  * Returns null when no source reaches MIN_SIMILARITY threshold or when the
  * query fingerprint is empty (e.g. a DDL or a non-ps_* query).
@@ -215,18 +214,23 @@ export function findQueryOrigin(
   const target = extractSqlFingerprint(rawSql);
   if (target.length === 0) return null;
 
-  // Collect all candidates in priority order
-  const candidates: Candidate[] = [
-    ...templateCandidates(),
-    ...(options.savedDashboards ? savedDashboardCandidates(options.savedDashboards) : []),
-    ...reviewQueryCandidates(),
-    ...(options.repoRoot ? wrenPairCandidates(options.repoRoot) : []),
-  ];
+  // Static candidates are cached at module scope (built once)
+  const staticCandidates = getStaticCandidates();
+  const dashboardCandidates = options.savedDashboardCandidateList ?? [];
 
   let bestSim = 0;
   let bestCandidate: Candidate | null = null;
 
-  for (const candidate of candidates) {
+  for (const candidate of staticCandidates) {
+    const sim = jaccardSimilarity(target, candidate.fingerprint);
+    if (sim > bestSim) {
+      bestSim = sim;
+      bestCandidate = candidate;
+    }
+  }
+
+  // Dashboard candidates come after static ones (lower priority)
+  for (const candidate of dashboardCandidates) {
     const sim = jaccardSimilarity(target, candidate.fingerprint);
     if (sim > bestSim) {
       bestSim = sim;
@@ -241,3 +245,6 @@ export function findQueryOrigin(
     locationHint: bestCandidate.locationHint,
   };
 }
+
+// Re-export for test use
+export type { Candidate };

--- a/dashboard/lib/admin-slow-queries.ts
+++ b/dashboard/lib/admin-slow-queries.ts
@@ -1,4 +1,5 @@
 import { query } from "@/lib/db";
+import { findQueryOrigin } from "@/lib/admin-query-origin";
 
 export const SLOW_QUERIES_SQL = `
   SELECT
@@ -18,6 +19,11 @@ export const SLOW_QUERIES_SQL = `
   LIMIT 20
 `;
 
+export interface QueryOrigin {
+  source: string;
+  locationHint?: string;
+}
+
 export interface SlowQuery {
   query: string;
   calls: number;
@@ -26,6 +32,8 @@ export interface SlowQuery {
   total_exec_time_ms: number;
   rows: number;
   cache_hit_ratio: number | null;
+  /** Best-effort origin guess from codebase fingerprinting. */
+  origin?: QueryOrigin;
 }
 
 export interface SlowQueriesResponse {
@@ -38,15 +46,37 @@ export async function fetchSlowQueries(): Promise<SlowQueriesResponse> {
   try {
     const result = await query(SLOW_QUERIES_SQL);
 
-    const queries: SlowQuery[] = result.rows.map((row) => ({
-      query: String(row[0]),
-      calls: Number(row[1]),
-      mean_exec_time_ms: Number(row[2]),
-      max_exec_time_ms: Number(row[3]),
-      total_exec_time_ms: Number(row[4]),
-      rows: Number(row[5]),
-      cache_hit_ratio: row[6] != null ? Number(row[6]) : null,
-    }));
+    // Try to load saved dashboards for origin matching — non-fatal if unavailable.
+    let savedDashboards: Array<{ id: string; title?: string; spec: unknown }> = [];
+    try {
+      const dbResult = await query(
+        `SELECT id, spec->>'title' AS title, spec FROM dashboards LIMIT 50`,
+      );
+      savedDashboards = dbResult.rows.map((row) => ({
+        id: String(row[0]),
+        title: row[1] ? String(row[1]) : undefined,
+        spec: row[2] as unknown,
+      }));
+    } catch {
+      // dashboards table may not exist or spec column structure may differ;
+      // origin matching still works with templates + review queries.
+    }
+
+    const queries: SlowQuery[] = result.rows.map((row) => {
+      const rawQuery = String(row[0]);
+      const origin =
+        findQueryOrigin(rawQuery, { savedDashboards }) ?? undefined;
+      return {
+        query: rawQuery,
+        calls: Number(row[1]),
+        mean_exec_time_ms: Number(row[2]),
+        max_exec_time_ms: Number(row[3]),
+        total_exec_time_ms: Number(row[4]),
+        rows: Number(row[5]),
+        cache_hit_ratio: row[6] != null ? Number(row[6]) : null,
+        ...(origin ? { origin } : {}),
+      };
+    });
 
     return { queries };
   } catch (err) {

--- a/dashboard/lib/admin-slow-queries.ts
+++ b/dashboard/lib/admin-slow-queries.ts
@@ -1,5 +1,5 @@
 import { query } from "@/lib/db";
-import { findQueryOrigin } from "@/lib/admin-query-origin";
+import { findQueryOrigin, savedDashboardCandidates } from "@/lib/admin-query-origin";
 
 export const SLOW_QUERIES_SQL = `
   SELECT
@@ -46,26 +46,29 @@ export async function fetchSlowQueries(): Promise<SlowQueriesResponse> {
   try {
     const result = await query(SLOW_QUERIES_SQL);
 
-    // Try to load saved dashboards for origin matching — non-fatal if unavailable.
-    let savedDashboards: Array<{ id: string; title?: string; spec: unknown }> = [];
+    // Build saved-dashboard candidates once per request (not per row) to keep
+    // origin matching O(candidates + rows) rather than O(candidates × rows).
+    // Non-fatal: origin matching still works from templates + review queries if
+    // the dashboards table is unavailable.
+    let dbCandidates: ReturnType<typeof savedDashboardCandidates> = [];
     try {
       const dbResult = await query(
         `SELECT id, spec->>'title' AS title, spec FROM dashboards LIMIT 50`,
       );
-      savedDashboards = dbResult.rows.map((row) => ({
+      const dashboards = dbResult.rows.map((row) => ({
         id: String(row[0]),
         title: row[1] ? String(row[1]) : undefined,
         spec: row[2] as unknown,
       }));
+      dbCandidates = savedDashboardCandidates(dashboards);
     } catch {
-      // dashboards table may not exist or spec column structure may differ;
-      // origin matching still works with templates + review queries.
+      // dashboards table may not exist or spec column structure may differ
     }
 
     const queries: SlowQuery[] = result.rows.map((row) => {
       const rawQuery = String(row[0]);
       const origin =
-        findQueryOrigin(rawQuery, { savedDashboards }) ?? undefined;
+        findQueryOrigin(rawQuery, { savedDashboardCandidateList: dbCandidates }) ?? undefined;
       return {
         query: rawQuery,
         calls: Number(row[1]),

--- a/dashboard/lib/format-pg-query.ts
+++ b/dashboard/lib/format-pg-query.ts
@@ -1,0 +1,150 @@
+/**
+ * SQL formatter for pg_stat_statements output.
+ *
+ * pg_stat_statements collapses whitespace and replaces literals with $N, so
+ * adjacent keywords merge: `SELECTCOUNT(*)AS`, `ISNOTNULLGROUPBY`, etc.
+ *
+ * Strategy:
+ *   1. Pre-process: insert spaces between fused keyword tokens so that
+ *      sql-formatter can tokenise the query correctly.
+ *   2. Format with sql-formatter (postgresql dialect).
+ *   3. On failure fall back to the pre-processed string (already more readable
+ *      than the raw pg_stat_statements output).
+ */
+
+import { format } from "sql-formatter";
+
+const SQL_FORMATTER_OPTIONS = {
+  language: "postgresql" as const,
+  keywordCase: "upper" as const,
+  linesBetweenQueries: 1,
+  tabWidth: 2,
+} satisfies Parameters<typeof format>[1];
+
+// ─── Pre-processor ─────────────────────────────────────────────────────────
+
+/**
+ * Multi-word fused keyword patterns (longest / most-specific first).
+ *
+ * Uses \b (word boundary) to match the keyword regardless of whether it is
+ * preceded by a word character, a closing quote, or whitespace.  This handles
+ * both "cc_stockISNOTNULL" (word char before) and "cc_stock ISNOTNULL"
+ * (space before, still a valid match at the word boundary).
+ */
+const MULTIWORD_FUSIONS: Array<[RegExp, string]> = [
+  // Three-word fusions
+  [/\bISNOTNULLGROUPBY\b/gi, "IS NOT NULL GROUP BY"],
+  [/\bISNOTNULLORDERBY\b/gi, "IS NOT NULL ORDER BY"],
+  [/\bISNOTNULL\b/gi, "IS NOT NULL"],
+  // Two-word fusions
+  [/\bGROUPBY\b/gi, "GROUP BY"],
+  [/\bORDERBY\b/gi, "ORDER BY"],
+  [/\bPARTITIONBY\b/gi, "PARTITION BY"],
+  [/\bLEFTJOIN\b/gi, "LEFT JOIN"],
+  [/\bRIGHTJOIN\b/gi, "RIGHT JOIN"],
+  [/\bINNERJOIN\b/gi, "INNER JOIN"],
+  [/\bFULLJOIN\b/gi, "FULL JOIN"],
+  // ISNOT (without NULL following) — must come after ISNOTNULL patterns
+  [/\bISNOT(?!NULL)\b/gi, "IS NOT"],
+];
+
+/**
+ * Single-keyword list for the adjacency pass.
+ * Each keyword will get a space inserted before it when directly preceded by
+ * a non-whitespace, non-open-paren, non-comma character.
+ * Deliberately excludes NULL (handled in multi-word pass) and names that are
+ * common identifier substrings (IN, AT, BY, OF, etc.) to avoid false positives.
+ */
+const SINGLE_KEYWORDS = [
+  "SELECT",
+  "DISTINCT",
+  "FROM",
+  "WHERE",
+  "HAVING",
+  "LIMIT",
+  "OFFSET",
+  "WITH",
+  "CASE",
+  "WHEN",
+  "THEN",
+  "ELSE",
+  "END",
+  "JOIN",
+  "ON",
+  "USING",
+  "UNION",
+  "INTERSECT",
+  "EXCEPT",
+  "FILTER",
+  "OVER",
+  "RETURNING",
+  "DATE",
+  "INTERVAL",
+  "NOT",
+  "AND",
+  "OR",
+  "AS",
+  "IS",
+  "COUNT",
+  "SUM",
+  "AVG",
+  "MAX",
+  "MIN",
+  "COALESCE",
+  "NULLIF",
+  "ROUND",
+  "CAST",
+  "EXTRACT",
+];
+
+/**
+ * Insert spaces between fused SQL keyword tokens so that sql-formatter can
+ * parse the query correctly.
+ *
+ * Examples:
+ *   "SELECTCOUNT(*)AS skus" → "SELECT COUNT(*) AS skus"
+ *   "cc_stock ISNOTNULLGROUPBY" → "cc_stock IS NOT NULL GROUP BY"
+ *   'p."ccrefejofacm"AS"Ref"' → 'p."ccrefejofacm" AS "Ref"'
+ */
+function preProcessFusedKeywords(sql: string): string {
+  let result = sql;
+
+  // Pass 1: multi-word fusions (longest patterns first)
+  for (const [pat, repl] of MULTIWORD_FUSIONS) {
+    result = result.replace(pat, repl);
+  }
+
+  // Pass 2: single keywords directly preceded by non-whitespace/paren/comma
+  for (const kw of SINGLE_KEYWORDS) {
+    const re = new RegExp(`(?<=[^\\s(,])(${kw})\\b`, "g");
+    result = result.replace(re, ` $1`);
+  }
+
+  // Pass 3: AS followed directly by a double-quoted identifier (e.g. AS"Col")
+  result = result.replace(/\bAS"/g, 'AS "');
+
+  return result;
+}
+
+/**
+ * Format a raw pg_stat_statements query string for human readability.
+ *
+ * - Pre-processes fused keyword tokens.
+ * - Formats with sql-formatter (postgresql dialect) for proper line-breaks and
+ *   indentation.
+ * - Falls back to the pre-processed string on formatter error.
+ * - Always returns a string; never throws.
+ */
+export function formatPgQueryText(raw: string): string {
+  if (!raw || !raw.trim()) return raw;
+
+  const preprocessed = preProcessFusedKeywords(raw);
+
+  try {
+    return format(preprocessed, SQL_FORMATTER_OPTIONS);
+  } catch {
+    // sql-formatter can balk on some pg-specific syntax. Return the
+    // pre-processed string — it is already more readable than the raw output.
+    return preprocessed;
+  }
+}

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -20,6 +20,7 @@
         "react-markdown": "^10.1.0",
         "react-simple-code-editor": "^0.14.1",
         "remark-gfm": "^4.0.1",
+        "sql-formatter": "^15.7.3",
         "yaml": "^2.8.3",
         "zod": "^4.3.6"
       },
@@ -2587,7 +2588,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
@@ -3672,6 +3672,12 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -7236,6 +7242,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
+      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7293,6 +7305,34 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
     "node_modules/next": {
@@ -8253,6 +8293,25 @@
       ],
       "license": "MIT"
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -8613,6 +8672,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/reusify": {
@@ -9007,6 +9075,19 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/sql-formatter": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.7.3.tgz",
+      "integrity": "sha512-5+zl9Nqg5aNjss0tb1G+StpC4dJKbjv3+g8CL/+V+00PfZop+2RKGyi53ScFl0dr+Dkx1LjmUO54Q3N7K3EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "nearley": "^2.20.1"
+      },
+      "bin": {
+        "sql-formatter": "bin/sql-formatter-cli.cjs"
       }
     },
     "node_modules/stable-hash": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -28,6 +28,7 @@
     "react-markdown": "^10.1.0",
     "react-simple-code-editor": "^0.14.1",
     "remark-gfm": "^4.0.1",
+    "sql-formatter": "^15.7.3",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## Summary

- **SQL formatting**: adds `formatPgQueryText()` that pre-processes fused `pg_stat_statements` tokens (`SELECTCOUNT` → `SELECT COUNT`, `ISNOTNULLGROUPBY` → `IS NOT NULL GROUP BY`) then formats with `sql-formatter` (postgresql dialect) for proper line-breaks and indentation. Falls back gracefully on formatter error.
- **Prism SQL highlighting**: formatted SQL is now rendered through Prism's SQL grammar for color-coded syntax.
- **Sortable columns**: all numeric columns (Llamadas, Media ms, Máx ms, Total ms, Filas, Cache %) have clickable headers with ↑/↓ direction indicators. Default sort = worst mean exec time first.
- **Free-text filter**: debounced (150 ms) text input filters by raw query text (table names, column names). Shows "N de M consultas" counter.
- **Origin matcher**: fingerprints each slow query against templates (`lib/templates/`), saved dashboards, `review-queries.ts`, and `wren-push-metadata.py` SQL pairs. Shows "Posible origen" badge with `locationHint` when a match is found.
- **"¿Cómo actuar?" guidance panel**: collapsible, covering EXPLAIN analysis, index recommendations (`etl/schema/init.sql`), widget refactoring (`lib/templates/`), materialised views (`etl/sync/`), and statement_timeout (`lib/db.ts`).

## Test plan

- [ ] `npx vitest run` in `dashboard/` — 109 test files, 1507 tests pass
- [ ] `npx tsc --noEmit` — no new type errors (36 pre-existing unchanged)
- [ ] Manual smoke test: navigate to `/admin/slow-queries` after `ps stack up`, confirm SQL bodies have spaces and line-breaks, sort/filter work, guidance panel opens/closes
- [ ] Verify 51 new tests: 15 formatter unit tests, 17 origin matcher unit tests, 19 component tests

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)