### PR TITLE
feat(dashboard/ux): wren link in topbar, freshness tooltip, ETL auto-refresh

### DIFF
--- a/dashboard/app/etl/page.tsx
+++ b/dashboard/app/etl/page.tsx
@@ -97,7 +97,12 @@ export default function EtlMonitorPage() {
   const [triggering, setTriggering] = useState(false);
   const [triggerError, setTriggerError] = useState<string | null>(null);
   const [forceDialogOpen, setForceDialogOpen] = useState(false);
+  // Biases the polling cadence to "fast" for ~15 s after a trigger so the new
+  // run surfaces as soon as the ETL scheduler creates it (its trigger poll is
+  // every 10 s, so we cover that window).
+  const [awaitingTrigger, setAwaitingTrigger] = useState(false);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const awaitingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchRuns = useCallback(async (p: number, silent = false) => {
     if (!silent) setRunsLoading(true);
@@ -157,22 +162,53 @@ export default function EtlMonitorPage() {
   };
 
   const isRunning = runs.some((r) => r.status === "running");
+  const wasRunningRef = useRef(false);
 
-  // Poll every 5 s while a run is active; stop when none are running
+  // Always poll the runs table so newly created or scheduler-triggered runs
+  // surface without a manual refresh. Cadence: 2 s briefly after a trigger,
+  // 3 s while a run is active, 8 s when idle.
   useEffect(() => {
     if (pollingRef.current) {
       clearInterval(pollingRef.current);
       pollingRef.current = null;
     }
-    if (isRunning) {
-      pollingRef.current = setInterval(() => {
-        void fetchRuns(page, true);
-      }, 5_000);
-    }
+    const intervalMs = awaitingTrigger ? 2_000 : isRunning ? 3_000 : 8_000;
+    pollingRef.current = setInterval(() => {
+      void fetchRuns(page, true);
+    }, intervalMs);
     return () => {
       if (pollingRef.current) clearInterval(pollingRef.current);
     };
-  }, [isRunning, fetchRuns, page]);
+  }, [awaitingTrigger, isRunning, fetchRuns, page]);
+
+  // Clear the awaiting flag as soon as a running run shows up
+  useEffect(() => {
+    if (awaitingTrigger && isRunning) {
+      setAwaitingTrigger(false);
+      if (awaitingTimeoutRef.current) {
+        clearTimeout(awaitingTimeoutRef.current);
+        awaitingTimeoutRef.current = null;
+      }
+    }
+  }, [awaitingTrigger, isRunning]);
+
+  // Clean up the awaiting safety timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (awaitingTimeoutRef.current) {
+        clearTimeout(awaitingTimeoutRef.current);
+        awaitingTimeoutRef.current = null;
+      }
+    };
+  }, []);
+
+  // When a run finishes (running → not running), refresh the stats KPIs too
+  useEffect(() => {
+    if (wasRunningRef.current && !isRunning) {
+      void fetchStats();
+    }
+    wasRunningRef.current = isRunning;
+  }, [isRunning, fetchStats]);
 
   const triggerSync = useCallback(
     async (opts?: ForceResyncOptions) => {
@@ -200,6 +236,15 @@ export default function EtlMonitorPage() {
         } else if (!res.ok) {
           setTriggerError("Error al iniciar la sincronización");
         }
+        // Bias polling to fast cadence until the new run is visible (covers the
+        // ETL scheduler's 10 s trigger-poll). Cleared either by the effect that
+        // detects isRunning or by this safety timeout.
+        setAwaitingTrigger(true);
+        if (awaitingTimeoutRef.current) clearTimeout(awaitingTimeoutRef.current);
+        awaitingTimeoutRef.current = setTimeout(() => {
+          setAwaitingTrigger(false);
+          awaitingTimeoutRef.current = null;
+        }, 15_000);
         await fetchRuns(page, true);
       } catch {
         setTriggerError("Error al iniciar la sincronización");

--- a/dashboard/components/DataFreshnessBanner.tsx
+++ b/dashboard/components/DataFreshnessBanner.tsx
@@ -26,7 +26,7 @@ export function DataFreshnessBanner() {
   const [dismissed, setDismissed] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
   const [loaded, setLoaded] = useState(false);
-  const { setFreshnessText, setFreshnessStale } = useFreshness();
+  const { setFreshnessText, setFreshnessStale, setFreshnessTooltip } = useFreshness();
 
   useEffect(() => {
     // Check session-scoped dismiss — short-circuit fetch if already dismissed
@@ -82,8 +82,11 @@ export function DataFreshnessBanner() {
         setFreshnessText(`Datos al día · ${age}`);
         setFreshnessStale(false);
       }
+      setFreshnessTooltip(
+        `Última sincronización (${health.stalestTable.name}): ${formatDate(health.stalestTable.lastSync)}`,
+      );
     }
-  }, [health, setFreshnessText, setFreshnessStale]);
+  }, [health, setFreshnessText, setFreshnessStale, setFreshnessTooltip]);
 
   const handleDismiss = () => {
     setDismissed(true);

--- a/dashboard/components/FreshnessContext.tsx
+++ b/dashboard/components/FreshnessContext.tsx
@@ -5,23 +5,37 @@ import { createContext, useContext, useState, type ReactNode } from "react";
 interface FreshnessState {
   freshnessText: string;
   freshnessStale: boolean;
+  freshnessTooltip: string | null;
   setFreshnessText: (text: string) => void;
   setFreshnessStale: (stale: boolean) => void;
+  setFreshnessTooltip: (tooltip: string | null) => void;
 }
 
 const FreshnessContext = createContext<FreshnessState>({
   freshnessText: "Datos al día",
   freshnessStale: false,
+  freshnessTooltip: null,
   setFreshnessText: () => {},
   setFreshnessStale: () => {},
+  setFreshnessTooltip: () => {},
 });
 
 export function FreshnessProvider({ children }: { children: ReactNode }) {
   const [freshnessText, setFreshnessText] = useState("Datos al día");
   const [freshnessStale, setFreshnessStale] = useState(false);
+  const [freshnessTooltip, setFreshnessTooltip] = useState<string | null>(null);
 
   return (
-    <FreshnessContext.Provider value={{ freshnessText, freshnessStale, setFreshnessText, setFreshnessStale }}>
+    <FreshnessContext.Provider
+      value={{
+        freshnessText,
+        freshnessStale,
+        freshnessTooltip,
+        setFreshnessText,
+        setFreshnessStale,
+        setFreshnessTooltip,
+      }}
+    >
       {children}
     </FreshnessContext.Provider>
   );

--- a/dashboard/components/TopBar.tsx
+++ b/dashboard/components/TopBar.tsx
@@ -10,18 +10,27 @@ interface TopBarProps {
   freshnessText?: string;
   /** Override freshness stale flag — falls back to context value */
   freshnessStale?: boolean;
+  /** Override freshness tooltip (last-sync timestamp) — falls back to context value */
+  freshnessTooltip?: string | null;
 }
 
-export function TopBar({ onCogClick, freshnessText: propFreshnessText, freshnessStale: propFreshnessStale }: TopBarProps) {
+export function TopBar({
+  onCogClick,
+  freshnessText: propFreshnessText,
+  freshnessStale: propFreshnessStale,
+  freshnessTooltip: propFreshnessTooltip,
+}: TopBarProps) {
   const pathname = usePathname();
   const ctx = useFreshness();
   const freshnessText = propFreshnessText ?? ctx.freshnessText;
   const freshnessStale = propFreshnessStale ?? ctx.freshnessStale;
+  const freshnessTooltip = propFreshnessTooltip ?? ctx.freshnessTooltip;
 
   const navLinks = [
     { href: "/", label: "Paneles" },
     { href: "/review", label: "Revisión" },
-  ];
+    { href: "http://localhost:3000", label: "Wren", external: true },
+  ] as const;
 
   return (
     <header
@@ -61,22 +70,34 @@ export function TopBar({ onCogClick, freshnessText: propFreshnessText, freshness
         {/* Primary nav */}
         <nav className="flex items-center gap-1">
           {navLinks.map((link) => {
+            const isExternal = "external" in link && link.external;
             const isActive =
-              link.href === "/" ? pathname === "/" : pathname.startsWith(link.href);
+              !isExternal &&
+              (link.href === "/" ? pathname === "/" : pathname.startsWith(link.href));
+            const style = {
+              padding: "6px 12px",
+              borderRadius: 6,
+              fontSize: 13,
+              fontWeight: isActive ? 500 : 400,
+              color: isActive ? "var(--fg)" : "var(--fg-muted)",
+              background: isActive ? "var(--bg-2)" : "transparent",
+              textDecoration: "none",
+            } as const;
+            if (isExternal) {
+              return (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={style}
+                >
+                  {link.label}
+                </a>
+              );
+            }
             return (
-              <Link
-                key={link.href}
-                href={link.href}
-                style={{
-                  padding: "6px 12px",
-                  borderRadius: 6,
-                  fontSize: 13,
-                  fontWeight: isActive ? 500 : 400,
-                  color: isActive ? "var(--fg)" : "var(--fg-muted)",
-                  background: isActive ? "var(--bg-2)" : "transparent",
-                  textDecoration: "none",
-                }}
-              >
+              <Link key={link.href} href={link.href} style={style}>
                 {link.label}
               </Link>
             );
@@ -87,7 +108,10 @@ export function TopBar({ onCogClick, freshnessText: propFreshnessText, freshness
       {/* Right: status + cog + admin + avatar */}
       <div className="flex items-center gap-3 px-5">
         {/* Live status */}
-        <div className="flex items-center gap-1.5">
+        <div
+          className="flex items-center gap-1.5"
+          title={freshnessTooltip ?? undefined}
+        >
           <span
             style={{
               width: 6,
@@ -104,6 +128,7 @@ export function TopBar({ onCogClick, freshnessText: propFreshnessText, freshness
               fontSize: 11,
               color: "var(--fg-muted)",
               fontFamily: "var(--font-jetbrains), monospace",
+              cursor: freshnessTooltip ? "help" : "default",
             }}
           >
             {freshnessText || "Datos al día"}


### PR DESCRIPTION
## Summary
- **Wren link** in the TopBar between *Revisión* and the cog — opens \`http://localhost:3000\` in a new tab so the operator can jump to the ad-hoc text-to-SQL UI without leaving the dashboard.
- **"Datos al día" tooltip** — hovering the live-status pill in the TopBar now reveals the actual last-sync timestamp (e.g. *"Última sincronización (ps_ventas): 27/04/2026 a las 02:14"*). Plumbed via a new \`freshnessTooltip\` field on \`FreshnessContext\`, set by \`DataFreshnessBanner\` when it loads \`/api/data-health\`.
- **ETL Monitor auto-refresh** — \`/etl\` page now polls the runs table on a cadence that adapts to state: 2 s burst for ~15 s after *Sincronizar ahora* (covers the ETL scheduler's 10 s trigger-poll window), 3 s while a run is active, 8 s when idle. KPI stats refetch on running→completed transitions. No more manual reload to see a new run.

## Test plan
- [x] \`npx tsc --noEmit\` clean for the touched files
- [ ] Smoke: load \`/\` → click *Wren* link → opens Wren UI in a new tab
- [ ] Smoke: hover the green/amber dot in the TopBar → tooltip shows last-sync timestamp
- [ ] Smoke: navigate to \`/etl\` → click *Sincronizar ahora* → run appears in the table within ≤5 s without refreshing the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)