### PR TITLE
feat(dashboard): tool-based publish for modify/analyze/review (#447)

### DIFF
--- a/dashboard/app/__tests__/analyze-route-streaming.test.ts
+++ b/dashboard/app/__tests__/analyze-route-streaming.test.ts
@@ -8,6 +8,7 @@
  * See dashboard/app/api/dashboard/analyze/route.ts for the contract.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LlmAgenticContext } from "@/lib/llm-tools/types";
 
 vi.mock("@/lib/llm", async () => {
   const actual = await vi.importActual<typeof import("@/lib/llm")>("@/lib/llm");
@@ -70,11 +71,31 @@ describe("POST /api/dashboard/analyze (streaming)", () => {
   });
 
   it("opens NDJSON stream when the agentic runner emits at least one progress event", async () => {
-    vi.mocked(llm.analyzeDashboard).mockImplementation(async (_data, _prompt, _action, opts) => {
-      opts?.onAgenticProgress?.({ type: "tool_done", round: 1, name: "execute_query", toolCallId: "tc_1", ok: true, ms: 12 });
-      await new Promise((r) => setTimeout(r, 0));
-      return "Análisis completo.";
-    });
+    // New contract: model stages ctx.analyzeResult and returns freeform message.
+    vi.mocked(llm.analyzeDashboard).mockImplementation(
+      async (
+        _data: string,
+        _prompt: string,
+        _action: string | undefined,
+        ctx: LlmAgenticContext,
+      ) => {
+        ctx.onAgenticProgress?.({
+          type: "tool_done",
+          round: 1,
+          name: "execute_query",
+          toolCallId: "tc_1",
+          ok: true,
+          ms: 12,
+        });
+        await new Promise((r) => setTimeout(r, 0));
+        // Stage the analysis markdown via publish-tool contract.
+        ctx.analyzeResult = {
+          markdown: "Análisis completo.",
+          summary: "Resumen breve.",
+        };
+        return "He analizado el dashboard y encontré tendencias positivas.";
+      },
+    );
 
     const res = await POST(makeRequest({ spec: baseSpec, widgetData: {}, prompt: "Analiza" }));
     expect(res.status).toBe(200);
@@ -87,16 +108,28 @@ describe("POST /api/dashboard/analyze (streaming)", () => {
     expect(last).toMatchObject({
       type: "result",
       response: "Análisis completo.",
+      message: "He analizado el dashboard y encontré tendencias positivas.",
+      summary: "Resumen breve.",
       suggestions: ["sugerencia 1"],
     });
   });
 
   it("emits a terminal error frame with httpStatus when the LLM fails after streaming starts", async () => {
-    vi.mocked(llm.analyzeDashboard).mockImplementation(async (_d, _p, _a, opts) => {
-      opts?.onAgenticProgress?.({ type: "tool_done", round: 1, name: "validate_query", toolCallId: "tc_2", ok: false, ms: 8, errorCode: "BAD_SQL" });
-      await new Promise((r) => setTimeout(r, 0));
-      throw new Error("upstream rate limit 429 exceeded");
-    });
+    vi.mocked(llm.analyzeDashboard).mockImplementation(
+      async (_d: string, _p: string, _a: string | undefined, ctx: LlmAgenticContext) => {
+        ctx.onAgenticProgress?.({
+          type: "tool_done",
+          round: 1,
+          name: "validate_query",
+          toolCallId: "tc_2",
+          ok: false,
+          ms: 8,
+          errorCode: "BAD_SQL",
+        });
+        await new Promise((r) => setTimeout(r, 0));
+        throw new Error("upstream rate limit 429 exceeded");
+      },
+    );
 
     const res = await POST(makeRequest({ spec: baseSpec, widgetData: {}, prompt: "Analiza" }));
     expect(res.status).toBe(200);

--- a/dashboard/app/__tests__/analyze-route.test.ts
+++ b/dashboard/app/__tests__/analyze-route.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/lib/llm", async () => {
 // Import AFTER mock setup
 import { POST } from "../api/dashboard/analyze/route";
 import * as llm from "@/lib/llm";
+import type { LlmAgenticContext } from "@/lib/llm-tools/types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,6 +42,29 @@ function makeRequest(body: unknown): Request {
   });
 }
 
+/**
+ * Returns a mock implementation for analyzeDashboard that stages analyzeResult
+ * in the ctx (simulating the publish-tool flow) and returns a freeform message.
+ * Pass markdown=null to simulate the model NOT calling submit_dashboard_analysis.
+ */
+function makeAnalyzeMock(
+  markdown: string | null,
+  message = "He analizado el dashboard y encontré varias tendencias.",
+  summary = "Las ventas crecieron un 12%.",
+) {
+  return async (
+    _serializedData: string,
+    _prompt: string,
+    _action: string | undefined,
+    ctx: LlmAgenticContext,
+  ) => {
+    if (markdown !== null) {
+      ctx.analyzeResult = { markdown, summary };
+    }
+    return message;
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -58,8 +82,10 @@ describe("POST /api/dashboard/analyze", () => {
   // Valid request
   // -----------------------------------------------------------------------
 
-  it("returns 200 with response and suggestions on valid request", async () => {
-    vi.mocked(llm.analyzeDashboard).mockResolvedValue("# Análisis\n\nEl dashboard muestra ventas de 50.000€.");
+  it("returns 200 with response + message + summary + suggestions on valid request", async () => {
+    vi.mocked(llm.analyzeDashboard).mockImplementation(
+      makeAnalyzeMock("# Análisis\n\nEl dashboard muestra ventas de 50.000€."),
+    );
 
     const req = makeRequest({
       spec: baseSpec,
@@ -71,13 +97,18 @@ describe("POST /api/dashboard/analyze", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
+    // response = the staged analysis markdown
     expect(body.response).toContain("Análisis");
+    // message = freeform chat reply
+    expect(body.message).toBe("He analizado el dashboard y encontré varias tendencias.");
+    // summary from the staged result
+    expect(body.summary).toBe("Las ventas crecieron un 12%.");
     expect(Array.isArray(body.suggestions)).toBe(true);
     expect(body.suggestions.length).toBeGreaterThan(0);
   });
 
   it("passes action to analyzeDashboard when provided", async () => {
-    vi.mocked(llm.analyzeDashboard).mockResolvedValue("Plan de acción: ...");
+    vi.mocked(llm.analyzeDashboard).mockImplementation(makeAnalyzeMock("Plan de acción: ..."));
 
     const req = makeRequest({
       spec: baseSpec,
@@ -100,7 +131,7 @@ describe("POST /api/dashboard/analyze", () => {
   });
 
   it("returns suggestions from generateSuggestions", async () => {
-    vi.mocked(llm.analyzeDashboard).mockResolvedValue("Respuesta del análisis.");
+    vi.mocked(llm.analyzeDashboard).mockImplementation(makeAnalyzeMock("Respuesta del análisis."));
     vi.mocked(llm.generateSuggestions).mockResolvedValue(["Pregunta 1", "Pregunta 2", "Pregunta 3"]);
 
     const req = makeRequest({
@@ -167,7 +198,7 @@ describe("POST /api/dashboard/analyze", () => {
   });
 
   it("accepts all valid action values", async () => {
-    vi.mocked(llm.analyzeDashboard).mockResolvedValue("OK");
+    vi.mocked(llm.analyzeDashboard).mockImplementation(makeAnalyzeMock("OK"));
 
     const validActions = [
       "explicar",
@@ -244,8 +275,23 @@ describe("POST /api/dashboard/analyze", () => {
     expect(body.code).toBe("LLM_CIRCUIT_OPEN");
   });
 
+  it("returns 500 when model returns text without calling submit_dashboard_analysis", async () => {
+    vi.mocked(llm.analyzeDashboard).mockImplementation(makeAnalyzeMock(null));
+
+    const req = makeRequest({
+      spec: baseSpec,
+      widgetData: {},
+      prompt: "Analiza",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe("AGENTIC_RUNNER");
+  });
+
   it("returns 200 even when generateSuggestions returns empty array", async () => {
-    vi.mocked(llm.analyzeDashboard).mockResolvedValue("Análisis correcto.");
+    vi.mocked(llm.analyzeDashboard).mockImplementation(makeAnalyzeMock("Análisis correcto."));
     vi.mocked(llm.generateSuggestions).mockResolvedValue([]);
 
     const req = makeRequest({

--- a/dashboard/app/__tests__/review-generate-route-streaming.test.ts
+++ b/dashboard/app/__tests__/review-generate-route-streaming.test.ts
@@ -24,22 +24,21 @@ vi.mock("@/lib/review-prompts", () => ({
 
 vi.mock("@/lib/llm", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/llm")>();
+  // generateReview and generateReviewWithProgress now return { content, message }
+  const mockReviewResult = {
+    content: {
+      executive_summary: ["Resumen OK"],
+      sections: [],
+      action_items: [],
+      data_quality_notes: [],
+      generated_at: "2026-04-01T00:00:00.000Z",
+    },
+    message: "He generado la revisión semanal.",
+  };
   return {
     ...actual,
-    generateReview: vi.fn().mockResolvedValue({
-      executive_summary: ["Resumen OK"],
-      sections: [],
-      action_items: [],
-      data_quality_notes: [],
-      generated_at: "2026-04-01T00:00:00.000Z",
-    }),
-    generateReviewWithProgress: vi.fn().mockResolvedValue({
-      executive_summary: ["Resumen OK"],
-      sections: [],
-      action_items: [],
-      data_quality_notes: [],
-      generated_at: "2026-04-01T00:00:00.000Z",
-    }),
+    generateReview: vi.fn().mockResolvedValue(mockReviewResult),
+    generateReviewWithProgress: vi.fn().mockResolvedValue(mockReviewResult),
     BudgetExceededError: actual.BudgetExceededError,
   };
 });
@@ -154,6 +153,8 @@ describe("POST /api/review/generate — streaming", () => {
     expect((result as Record<string, unknown>)?.review).toBeDefined();
     const review = (result as Record<string, { id?: unknown }>)?.review;
     expect(review?.id).toBe(42);
+    // New additive field: freeform chat message
+    expect((result as Record<string, unknown>)?.message).toBe("He generado la revisión semanal.");
   });
 
   it("emits error frame when review already exists (409) is detected early", async () => {

--- a/dashboard/app/api/dashboard/analyze/route.ts
+++ b/dashboard/app/api/dashboard/analyze/route.ts
@@ -17,14 +17,17 @@
  *                                Clients MUST check the frame `httpStatus`
  *                                field rather than `res.status` for
  *                                mid-stream failures.
- *   • Success (no progress)    → HTTP 200, JSON `{response, suggestions}`.
+ *   • Success (no progress)    → HTTP 200, JSON `{response, message?, summary?, suggestions}`.
  *   • Success (with progress)  → HTTP 200 NDJSON; final frame is
- *                                `{type:"result", response, suggestions}`.
+ *                                `{type:"result", response, message, summary, suggestions}`.
  *
  * Streaming frames (NDJSON):
  *   { type: "progress", requestId, logLine: LogLine }   per agentic step
- *   { type: "result",   requestId, response, suggestions }
+ *   { type: "result",   requestId, response, message, summary, suggestions }
  *   { type: "error",    requestId, httpStatus, error, code, details?, diagnostic? }
+ *
+ * Backward compat: the `response` field (analysis markdown) is preserved.
+ * `message` and `summary` are additive new fields.
  */
 import { NextResponse } from "next/server";
 import {
@@ -50,9 +53,10 @@ import {
   finishInteraction,
 } from "@/lib/db-write";
 import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
+import { isAgenticToolsEnabled } from "@/lib/llm-tools/config";
 import { buildAgenticErrorDiagnostic, persistAgenticError } from "@/lib/llm-tools/diagnostic";
 import { agenticEventToLogLine } from "@/lib/format-agentic-progress";
-import type { AgenticProgressEvent } from "@/lib/llm-tools/types";
+import type { AgenticProgressEvent, LlmAgenticContext } from "@/lib/llm-tools/types";
 import type { LogLine } from "@/components/LogBlock";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -290,19 +294,6 @@ export async function POST(request: Request) {
   }
 
   // --- Run the LLM call, collecting progress events into a buffer ----------
-  // We start the LLM call in the background. The progress callback pushes
-  // log lines into a buffer. We then await either the call's completion or
-  // the first progress event:
-  //
-  //   • If the call completes (success or failure) BEFORE any progress event
-  //     is buffered, we return a normal JSON response with proper HTTP
-  //     status. This is the "fast path" most tests / clients use.
-  //
-  //   • If at least one progress event was buffered before the call
-  //     resolved, we open an NDJSON stream that replays the buffered events
-  //     and continues live. From that point on errors must be reported as a
-  //     terminal `{type:"error", httpStatus, …}` frame because HTTP headers
-  //     have already been committed at status 200.
   const t0 = Date.now();
   const buffer: { type: "progress"; logLine: LogLine }[] = [];
   let firstEventResolve: (() => void) | null = null;
@@ -320,6 +311,15 @@ export async function POST(request: Request) {
     }
   };
 
+  // Build a mutable ctx so the route can read back the side-channel after the loop.
+  const analyzeCtx: LlmAgenticContext = {
+    requestId,
+    endpoint: "analyzeDashboard",
+    dashboardId: dashboardIdNum,
+    onAgenticProgress,
+    analyzeResult: null,
+  };
+
   type LlmOutcome =
     | { kind: "ok"; response: string }
     | { kind: "err"; err: unknown };
@@ -328,12 +328,7 @@ export async function POST(request: Request) {
     serializedData,
     prompt.trim(),
     typeof action === "string" ? action : undefined,
-    {
-      requestId,
-      endpoint: "analyzeDashboard",
-      dashboardId: dashboardIdNum,
-      onAgenticProgress,
-    },
+    analyzeCtx,
   ).then(
     (response): LlmOutcome => ({ kind: "ok", response }),
     (err): LlmOutcome => ({ kind: "err", err }),
@@ -344,6 +339,38 @@ export async function POST(request: Request) {
     llmPromise.then(() => "done" as const),
     firstEvent.then(() => "progress" as const),
   ]);
+
+  // -------------------------------------------------------------------------
+  // Helper: extract the analysis response + message + summary from outcome.
+  // With the new publish-tool approach (agentic tools enabled):
+  //   - response (analysis markdown) comes from ctx.analyzeResult.markdown
+  //   - message is the freeform text returned by runAgenticChat (rawResponse)
+  //   - summary comes from ctx.analyzeResult.summary
+  // Legacy path (agentic tools disabled):
+  //   - response IS the freeform raw response (old contract)
+  //   - message and summary are empty
+  // -------------------------------------------------------------------------
+  const resolveAnalysisResult = (rawResponse: string): {
+    analysisResponse: string;
+    message: string;
+    summary: string;
+  } | null => {
+    if (isAgenticToolsEnabled()) {
+      if (!analyzeCtx.analyzeResult) {
+        console.error(
+          `[${requestId}] El modelo no llamó a submit_dashboard_analysis (agentic tools enabled).`,
+        );
+        return null;
+      }
+      return {
+        analysisResponse: analyzeCtx.analyzeResult.markdown,
+        message: rawResponse,
+        summary: analyzeCtx.analyzeResult.summary,
+      };
+    }
+    // Legacy: the raw response IS the analysis.
+    return { analysisResponse: rawResponse, message: "", summary: "" };
+  };
 
   if (raceWinner === "done") {
     // Fast path: no progress was emitted before the call resolved.
@@ -360,16 +387,34 @@ export async function POST(request: Request) {
       console.error(`[${requestId}] Error al analizar dashboard con LLM:`, err);
       return NextResponse.json(payload, { status });
     }
-    // Success without progress: keep legacy JSON contract.
-    const analysisResponse = outcome.response;
-    const lastExchange = `Usuario: ${prompt.trim()}\n\nAsistente: ${analysisResponse}`;
+
+    const resolved = resolveAnalysisResult(outcome.response);
+    if (!resolved) {
+      if (interactionId) {
+        await finishInteraction(interactionId, "error", "El modelo no llamó a submit_dashboard_analysis").catch((e) =>
+          console.error(`[${requestId}] finishInteraction(analyze,error) failed:`, e),
+        );
+      }
+      return NextResponse.json(
+        formatApiError(
+          "El modelo no publicó el análisis. Inténtalo de nuevo.",
+          "AGENTIC_RUNNER",
+          "El modelo no llamó a `submit_dashboard_analysis`.",
+          requestId,
+        ),
+        { status: 500 },
+      );
+    }
+
+    const { analysisResponse, message, summary } = resolved;
+    const lastExchange = `Usuario: ${prompt.trim()}\n\nAsistente: ${message || analysisResponse}`;
     const suggestions = await generateSuggestions(serializedData, lastExchange, { requestId });
     if (interactionId) {
       await finishInteraction(interactionId, "completed", analysisResponse).catch((e) =>
         console.error(`[${requestId}] finishInteraction(analyze,completed) failed:`, e),
       );
     }
-    return NextResponse.json({ response: analysisResponse, suggestions });
+    return NextResponse.json({ response: analysisResponse, message, summary, suggestions });
   }
 
   // Streaming path: at least one progress event was emitted.
@@ -380,8 +425,6 @@ export async function POST(request: Request) {
         controller.enqueue(encoder.encode(`${JSON.stringify(obj)}\n`));
       };
 
-      // Replay events buffered up to this point. New events will continue
-      // arriving via `onAgenticProgress` → push into `liveBuffer` then drain.
       const drainBuffer = () => {
         while (buffer.length) {
           const ev = buffer.shift()!;
@@ -390,9 +433,6 @@ export async function POST(request: Request) {
       };
       drainBuffer();
 
-      // Swap the progress callback so future events stream directly.
-      // (Closure-captured `onAgenticProgress` is no longer needed; we just
-      //  poll `buffer` after each await tick.)
       const outcome = await llmPromise;
       drainBuffer();
 
@@ -406,22 +446,41 @@ export async function POST(request: Request) {
         }
         const { status, payload } = buildLlmErrorPayload(err, requestId, cfg);
         console.error(`[${requestId}] Error al analizar dashboard con LLM (mid-stream):`, err);
-        // Spread payload first so its `requestId` is the canonical one;
-        // then add type / httpStatus which are not part of ApiErrorResponse.
         send({ ...payload, type: "error", httpStatus: status });
         controller.close();
         return;
       }
 
-      const analysisResponse = outcome.response;
-      const lastExchange = `Usuario: ${prompt.trim()}\n\nAsistente: ${analysisResponse}`;
+      const resolved = resolveAnalysisResult(outcome.response);
+      if (!resolved) {
+        if (interactionId) {
+          await finishInteraction(interactionId, "error", "El modelo no llamó a submit_dashboard_analysis").catch((e) =>
+            console.error(`[${requestId}] finishInteraction(analyze,error) failed:`, e),
+          );
+        }
+        send({
+          ...formatApiError(
+            "El modelo no publicó el análisis. Inténtalo de nuevo.",
+            "AGENTIC_RUNNER",
+            "El modelo no llamó a `submit_dashboard_analysis`.",
+            requestId,
+          ),
+          type: "error",
+          httpStatus: 500,
+        });
+        controller.close();
+        return;
+      }
+
+      const { analysisResponse, message, summary } = resolved;
+      const lastExchange = `Usuario: ${prompt.trim()}\n\nAsistente: ${message || analysisResponse}`;
       const suggestions = await generateSuggestions(serializedData, lastExchange, { requestId });
       if (interactionId) {
         await finishInteraction(interactionId, "completed", analysisResponse).catch((e) =>
           console.error(`[${requestId}] finishInteraction(analyze,completed) failed:`, e),
         );
       }
-      send({ type: "result", requestId, response: analysisResponse, suggestions });
+      send({ type: "result", requestId, response: analysisResponse, message, summary, suggestions });
       controller.close();
     },
   });

--- a/dashboard/app/api/dashboard/analyze/route.ts
+++ b/dashboard/app/api/dashboard/analyze/route.ts
@@ -53,7 +53,7 @@ import {
   finishInteraction,
 } from "@/lib/db-write";
 import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
-import { isAgenticToolsEnabled } from "@/lib/llm-tools/config";
+import { isAgenticToolsEnabled, getAgenticConfig } from "@/lib/llm-tools/config";
 import { buildAgenticErrorDiagnostic, persistAgenticError } from "@/lib/llm-tools/diagnostic";
 import { agenticEventToLogLine } from "@/lib/format-agentic-progress";
 import type { AgenticProgressEvent, LlmAgenticContext } from "@/lib/llm-tools/types";
@@ -395,12 +395,34 @@ export async function POST(request: Request) {
           console.error(`[${requestId}] finishInteraction(analyze,error) failed:`, e),
         );
       }
+      const agenticCfg = getAgenticConfig();
+      const contractErr = new AgenticRunnerError(
+        "AGENTIC_RUNNER",
+        "El modelo no publicó el análisis. Inténtalo de nuevo.",
+        requestId,
+        {
+          phase: "final",
+          toolRoundsUsed: 0,
+          toolCallsUsed: 0,
+          durationMs: 0,
+          limitsAtFailure: {
+            maxRounds: agenticCfg.maxToolRounds,
+            maxToolCalls: agenticCfg.maxToolCalls,
+            toolTimeoutMs: agenticCfg.toolTimeoutMs,
+            executeRowLimit: agenticCfg.maxRows,
+            payloadCharLimit: agenticCfg.maxResultChars,
+          },
+        },
+      );
+      const diagnostic = buildAgenticErrorDiagnostic(contractErr, cfg);
+      persistAgenticError("analyze", contractErr, diagnostic);
       return NextResponse.json(
         formatApiError(
-          "El modelo no publicó el análisis. Inténtalo de nuevo.",
+          contractErr.message,
           "AGENTIC_RUNNER",
           "El modelo no llamó a `submit_dashboard_analysis`.",
           requestId,
+          diagnostic,
         ),
         { status: 500 },
       );
@@ -460,12 +482,34 @@ export async function POST(request: Request) {
             console.error(`[${requestId}] finishInteraction(analyze,error) failed:`, e),
           );
         }
+        const agenticCfg = getAgenticConfig();
+        const contractErr = new AgenticRunnerError(
+          "AGENTIC_RUNNER",
+          "El modelo no publicó el análisis. Inténtalo de nuevo.",
+          requestId,
+          {
+            phase: "final",
+            toolRoundsUsed: 0,
+            toolCallsUsed: 0,
+            durationMs: 0,
+            limitsAtFailure: {
+              maxRounds: agenticCfg.maxToolRounds,
+              maxToolCalls: agenticCfg.maxToolCalls,
+              toolTimeoutMs: agenticCfg.toolTimeoutMs,
+              executeRowLimit: agenticCfg.maxRows,
+              payloadCharLimit: agenticCfg.maxResultChars,
+            },
+          },
+        );
+        const diagnostic = buildAgenticErrorDiagnostic(contractErr, cfg);
+        persistAgenticError("analyze", contractErr, diagnostic);
         send({
           ...formatApiError(
-            "El modelo no publicó el análisis. Inténtalo de nuevo.",
+            contractErr.message,
             "AGENTIC_RUNNER",
             "El modelo no llamó a `submit_dashboard_analysis`.",
             requestId,
+            diagnostic,
           ),
           type: "error",
           httpStatus: 500,

--- a/dashboard/app/api/dashboard/analyze/route.ts
+++ b/dashboard/app/api/dashboard/analyze/route.ts
@@ -407,7 +407,9 @@ export async function POST(request: Request) {
     }
 
     const { analysisResponse, message, summary } = resolved;
-    const lastExchange = `Usuario: ${prompt.trim()}\n\nAsistente: ${message || analysisResponse}`;
+    // Use the full analysis body for suggestion context so suggestions reflect
+    // the complete analysis, not just the short freeform chat reply.
+    const lastExchange = `Usuario: ${prompt.trim()}\n\nAsistente: ${analysisResponse}`;
     const suggestions = await generateSuggestions(serializedData, lastExchange, { requestId });
     if (interactionId) {
       await finishInteraction(interactionId, "completed", analysisResponse).catch((e) =>
@@ -473,7 +475,8 @@ export async function POST(request: Request) {
       }
 
       const { analysisResponse, message, summary } = resolved;
-      const lastExchange = `Usuario: ${prompt.trim()}\n\nAsistente: ${message || analysisResponse}`;
+      // Use the full analysis body for suggestion context (not the short message).
+      const lastExchange = `Usuario: ${prompt.trim()}\n\nAsistente: ${analysisResponse}`;
       const suggestions = await generateSuggestions(serializedData, lastExchange, { requestId });
       if (interactionId) {
         await finishInteraction(interactionId, "completed", analysisResponse).catch((e) =>

--- a/dashboard/app/api/dashboard/modify/__tests__/route-streaming.test.ts
+++ b/dashboard/app/api/dashboard/modify/__tests__/route-streaming.test.ts
@@ -8,6 +8,7 @@
  * See dashboard/app/api/dashboard/modify/route.ts for the contract.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LlmAgenticContext } from "@/lib/llm-tools/types";
 
 const { mockModifyDashboard } = vi.hoisted(() => ({
   mockModifyDashboard: vi.fn(),
@@ -101,12 +102,20 @@ describe("POST /api/dashboard/modify (streaming)", () => {
 
   it("opens an NDJSON stream when the agentic runner emits at least one progress event", async () => {
     // Simulate an agentic runner that emits a `tool_done` event then resolves.
-    mockModifyDashboard.mockImplementation(async (_spec, _prompt, opts) => {
-      opts?.onAgenticProgress?.({ type: "tool_done", name: "validate_query", ok: true, ms: 42 });
-      // Allow a microtask so the route observes the event before completion.
-      await new Promise((r) => setTimeout(r, 0));
-      return JSON.stringify(updatedSpec);
-    });
+    // The new contract: model stages ctx.modifyResult and returns a freeform message.
+    mockModifyDashboard.mockImplementation(
+      async (_spec: string, _prompt: string, ctx: LlmAgenticContext) => {
+        ctx.onAgenticProgress?.({ type: "tool_done", round: 1, name: "validate_query", toolCallId: "tc1", ok: true, ms: 42 });
+        // Allow a microtask so the route observes the event before completion.
+        await new Promise((r) => setTimeout(r, 0));
+        // Stage the result as the publish tool would.
+        ctx.modifyResult = {
+          spec: updatedSpec as unknown as import("@/lib/schema").DashboardSpec,
+          summary: "Actualizado el título.",
+        };
+        return "He actualizado el título del dashboard.";
+      },
+    );
 
     const res = await POST(
       makeRequest({ spec: validSpec, prompt: "añade ventas por tienda" }),
@@ -120,7 +129,12 @@ describe("POST /api/dashboard/modify (streaming)", () => {
     expect(frames.length).toBeGreaterThanOrEqual(2);
     expect(frames[0]).toMatchObject({ type: "progress", logLine: { kind: "tool" } });
     const last = frames[frames.length - 1];
-    expect(last).toMatchObject({ type: "result", spec: { title: "Ventas Marzo Actualizado" } });
+    expect(last).toMatchObject({
+      type: "result",
+      spec: { title: "Ventas Marzo Actualizado" },
+      message: "He actualizado el título del dashboard.",
+      summary: "Actualizado el título.",
+    });
   });
 
   it("emits a terminal error frame with httpStatus when the LLM fails after streaming starts", async () => {

--- a/dashboard/app/api/dashboard/modify/__tests__/route.test.ts
+++ b/dashboard/app/api/dashboard/modify/__tests__/route.test.ts
@@ -27,6 +27,7 @@ vi.mock("@/lib/db-write", async () => {
 import { POST } from "../route";
 import { BudgetExceededError, CircuitBreakerOpenError } from "@/lib/llm";
 import * as dbWrite from "@/lib/db-write";
+import type { LlmAgenticContext } from "@/lib/llm-tools/types";
 
 // --- Helpers ----------------------------------------------------------------
 
@@ -87,6 +88,24 @@ function makeRawRequest(rawBody: string): Request {
   });
 }
 
+/**
+ * Returns a mock implementation for modifyDashboard that stages modifyResult
+ * in the ctx (simulating the publish-tool flow) and returns a freeform message.
+ * Pass spec=null to simulate the model NOT calling apply_dashboard_modification.
+ */
+function makeModifyMock(
+  spec: typeof updatedSpec | null,
+  message = "He añadido el widget de margen.",
+  summary = "Añadido widget de margen.",
+) {
+  return async (_specStr: string, _prompt: string, ctx: LlmAgenticContext) => {
+    if (spec !== null) {
+      ctx.modifyResult = { spec: spec as unknown as import("@/lib/schema").DashboardSpec, summary };
+    }
+    return message;
+  };
+}
+
 const mockCreateInteraction = vi.mocked(dbWrite.createInteraction);
 const mockFinishInteraction = vi.mocked(dbWrite.finishInteraction);
 
@@ -101,8 +120,8 @@ describe("POST /api/dashboard/modify", () => {
     mockFinishInteraction.mockResolvedValue(undefined);
   });
 
-  it("returns updated spec on valid modification", async () => {
-    mockModifyDashboard.mockResolvedValue(JSON.stringify(updatedSpec));
+  it("returns updated spec + message + summary on valid modification", async () => {
+    mockModifyDashboard.mockImplementation(makeModifyMock(updatedSpec));
 
     const res = await POST(makeRequest({ spec: validSpec, prompt: "Añade el margen" }));
 
@@ -110,17 +129,9 @@ describe("POST /api/dashboard/modify", () => {
     const json = await res.json();
     expect(json.title).toBe("Ventas Marzo — Actualizado");
     expect(json.widgets[0].items).toHaveLength(2);
-  });
-
-  it("strips markdown code blocks from LLM response", async () => {
-    const wrapped = "```json\n" + JSON.stringify(updatedSpec) + "\n```";
-    mockModifyDashboard.mockResolvedValue(wrapped);
-
-    const res = await POST(makeRequest({ spec: validSpec, prompt: "Añade el margen" }));
-
-    expect(res.status).toBe(200);
-    const json = await res.json();
-    expect(json.title).toBe("Ventas Marzo — Actualizado");
+    // New additive fields
+    expect(json.message).toBe("He añadido el widget de margen.");
+    expect(json.summary).toBe("Añadido widget de margen.");
   });
 
   it("returns 400 when spec is missing", async () => {
@@ -168,10 +179,8 @@ describe("POST /api/dashboard/modify", () => {
     expect(json.requestId).toBeDefined();
   });
 
-  it("returns 429 when LLM throws an error with status 429", async () => {
-    const rateLimitError = Object.assign(new Error("Rate limit exceeded"), {
-      status: 429,
-    });
+  it("returns 429 when LLM throws an error with rate limit message", async () => {
+    const rateLimitError = Object.assign(new Error("rate limit exceeded"), {});
     mockModifyDashboard.mockRejectedValue(rateLimitError);
 
     const res = await POST(makeRequest({ spec: validSpec, prompt: "Añade algo" }));
@@ -206,30 +215,31 @@ describe("POST /api/dashboard/modify", () => {
     expect(json.error).toMatch(/no disponible|Inténtelo/i);
   });
 
-  it("returns 400 when LLM returns invalid JSON", async () => {
-    mockModifyDashboard.mockResolvedValue("not json at all");
+  it("returns 500 when model returns text without calling apply_dashboard_modification", async () => {
+    // Model returns freeform text but never staged ctx.modifyResult
+    mockModifyDashboard.mockImplementation(makeModifyMock(null));
 
     const res = await POST(makeRequest({ spec: validSpec, prompt: "Añade algo" }));
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(500);
     const json = await res.json();
-    expect(json.code).toBe("LLM_INVALID_RESPONSE");
+    expect(json.code).toBe("AGENTIC_RUNNER");
     expect(json.requestId).toBeDefined();
   });
 
-  it("returns 400 when LLM returns valid JSON but invalid spec", async () => {
-    mockModifyDashboard.mockResolvedValue(JSON.stringify({ title: "No widgets" }));
+  it("does not expose raw LLM output in error responses", async () => {
+    // When model doesn't stage result, route returns 500 AGENTIC_RUNNER
+    mockModifyDashboard.mockImplementation(makeModifyMock(null, "secret internal context leaked"));
 
     const res = await POST(makeRequest({ spec: validSpec, prompt: "Añade algo" }));
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(500);
     const json = await res.json();
-    expect(json.code).toBe("LLM_INVALID_RESPONSE");
-    expect(json.requestId).toBeDefined();
+    expect(json.raw).toBeUndefined();
   });
 
   it("passes serialized spec and trimmed prompt to LLM", async () => {
-    mockModifyDashboard.mockResolvedValue(JSON.stringify(updatedSpec));
+    mockModifyDashboard.mockImplementation(makeModifyMock(updatedSpec));
 
     await POST(makeRequest({ spec: validSpec, prompt: "  Añade margen  " }));
 
@@ -279,21 +289,11 @@ describe("POST /api/dashboard/modify", () => {
     expect(json.requestId).toBeDefined();
   });
 
-  it("does not expose raw LLM output in error responses", async () => {
-    mockModifyDashboard.mockResolvedValue("secret internal context leaked");
-
-    const res = await POST(makeRequest({ spec: validSpec, prompt: "Añade algo" }));
-
-    expect(res.status).toBe(400);
-    const json = await res.json();
-    expect(json.raw).toBeUndefined();
-  });
-
   // --- Persistence (createInteraction / finishInteraction) ---
 
   describe("interaction persistence", () => {
     it("creates an interaction and finishes it as completed on success", async () => {
-      mockModifyDashboard.mockResolvedValue(JSON.stringify(updatedSpec));
+      mockModifyDashboard.mockImplementation(makeModifyMock(updatedSpec));
 
       const res = await POST(makeRequest({ spec: validSpec, prompt: "Añade el margen" }));
       expect(res.status).toBe(200);
@@ -323,7 +323,7 @@ describe("POST /api/dashboard/modify", () => {
     });
 
     it("passes dashboardId to createInteraction when provided in request body", async () => {
-      mockModifyDashboard.mockResolvedValue(JSON.stringify(updatedSpec));
+      mockModifyDashboard.mockImplementation(makeModifyMock(updatedSpec));
 
       await POST(makeRequest({ spec: validSpec, prompt: "Añade el margen", dashboardId: 42 }));
 

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -15,20 +15,29 @@
  *                                no progress was emitted yet; otherwise
  *                                HTTP 200 NDJSON terminating in
  *                                `{type:"error", httpStatus, ...}`.
- *   • Success (no progress)    → HTTP 200, JSON spread of DashboardSpec fields
- *                                plus additive `message` and `summary` strings.
- *                                Existing clients consuming `spec.title` / `spec.widgets`
- *                                continue to work — `message` / `summary` are new fields.
+ *   • Success (no progress)    → HTTP 200, JSON object where the DashboardSpec
+ *                                fields (title, description, widgets, filters, …)
+ *                                appear at the top level together with additive
+ *                                `message` and `summary` strings (i.e. the spec
+ *                                is spread, NOT wrapped under a `spec` key).
+ *                                Existing clients consuming `spec.title` /
+ *                                `spec.widgets` continue to work unchanged —
+ *                                `message` / `summary` are new top-level fields.
  *   • Success (with progress)  → HTTP 200 NDJSON terminating in
  *                                `{type:"result", spec: DashboardSpec, message, summary}`.
+ *
+ * Response shape (non-streaming):  `{ ...DashboardSpec, message?, summary? }`
+ * Response shape (streaming result frame):
+ *   { type: "result", requestId, spec: DashboardSpec, message: string, summary: string }
  *
  * Streaming frames (NDJSON):
  *   { type: "progress", requestId, logLine: LogLine }
  *   { type: "result",   requestId, spec: DashboardSpec, message: string, summary: string }
  *   { type: "error",    requestId, httpStatus, error, code, details?, diagnostic? }
  *
- * Backward compat: the `spec` field is always present in the result frame /
- * JSON response. `message` and `summary` are additive new fields.
+ * Backward compat: the non-streaming success response spreads spec fields at the
+ * top level for wire-compatibility with existing clients. `message` and
+ * `summary` are additive and will not collide with DashboardSpec field names.
  */
 import { NextResponse } from "next/server";
 import {
@@ -50,7 +59,7 @@ import {
   finishInteraction,
 } from "@/lib/db-write";
 import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
-import { isAgenticToolsEnabled } from "@/lib/llm-tools/config";
+import { isAgenticToolsEnabled, getAgenticConfig } from "@/lib/llm-tools/config";
 import { buildAgenticErrorDiagnostic, persistAgenticError } from "@/lib/llm-tools/diagnostic";
 import { agenticEventToLogLine } from "@/lib/format-agentic-progress";
 import type { AgenticProgressEvent, LlmAgenticContext } from "@/lib/llm-tools/types";
@@ -301,14 +310,36 @@ export async function POST(request: Request) {
         console.error(
           `[${requestId}] El modelo no llamó a apply_dashboard_modification (agentic tools enabled).`,
         );
+        const agenticCfg = getAgenticConfig();
+        const contractErr = new AgenticRunnerError(
+          "AGENTIC_RUNNER",
+          "El modelo no publicó el dashboard modificado. Reformula el cambio o inténtalo de nuevo.",
+          requestId,
+          {
+            phase: "final",
+            toolRoundsUsed: 0,
+            toolCallsUsed: 0,
+            durationMs: 0,
+            limitsAtFailure: {
+              maxRounds: agenticCfg.maxToolRounds,
+              maxToolCalls: agenticCfg.maxToolCalls,
+              toolTimeoutMs: agenticCfg.toolTimeoutMs,
+              executeRowLimit: agenticCfg.maxRows,
+              payloadCharLimit: agenticCfg.maxResultChars,
+            },
+          },
+        );
+        const diagnostic = buildAgenticErrorDiagnostic(contractErr, cfg);
+        persistAgenticError("modify", contractErr, diagnostic);
         return {
           ok: false,
           status: 500,
           payload: formatApiError(
-            "El modelo no publicó el dashboard modificado. Reformula el cambio o inténtalo de nuevo.",
+            contractErr.message,
             "AGENTIC_RUNNER",
             "El modelo no llamó a `apply_dashboard_modification`.",
             requestId,
+            diagnostic,
           ),
         };
       }

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -15,14 +15,17 @@
  *                                no progress was emitted yet; otherwise
  *                                HTTP 200 NDJSON terminating in
  *                                `{type:"error", httpStatus, ...}`.
- *   • Success (no progress)    → HTTP 200, JSON updated `DashboardSpec`.
+ *   • Success (no progress)    → HTTP 200, JSON `{ spec, message?, summary? }`.
  *   • Success (with progress)  → HTTP 200 NDJSON terminating in
- *                                `{type:"result", spec}`.
+ *                                `{type:"result", spec, message, summary}`.
  *
  * Streaming frames (NDJSON):
  *   { type: "progress", requestId, logLine: LogLine }
- *   { type: "result",   requestId, spec: DashboardSpec }
+ *   { type: "result",   requestId, spec: DashboardSpec, message: string, summary: string }
  *   { type: "error",    requestId, httpStatus, error, code, details?, diagnostic? }
+ *
+ * Backward compat: the `spec` field is always present in the result frame /
+ * JSON response. `message` and `summary` are additive new fields.
  */
 import { NextResponse } from "next/server";
 import {
@@ -44,9 +47,10 @@ import {
   finishInteraction,
 } from "@/lib/db-write";
 import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
+import { isAgenticToolsEnabled } from "@/lib/llm-tools/config";
 import { buildAgenticErrorDiagnostic, persistAgenticError } from "@/lib/llm-tools/diagnostic";
 import { agenticEventToLogLine } from "@/lib/format-agentic-progress";
-import type { AgenticProgressEvent } from "@/lib/llm-tools/types";
+import type { AgenticProgressEvent, LlmAgenticContext } from "@/lib/llm-tools/types";
 import type { LogLine } from "@/components/LogBlock";
 
 /**
@@ -247,6 +251,15 @@ export async function POST(request: Request) {
     }
   };
 
+  // Build a mutable ctx so the route can read back the side-channel after the loop.
+  const modifyCtx: LlmAgenticContext = {
+    requestId,
+    endpoint: "modifyDashboard",
+    dashboardId: dashboardIdNum ?? undefined,
+    onAgenticProgress,
+    modifyResult: null,
+  };
+
   type LlmOutcome =
     | { kind: "ok"; rawResponse: string }
     | { kind: "err"; err: unknown };
@@ -254,7 +267,7 @@ export async function POST(request: Request) {
   const llmPromise: Promise<LlmOutcome> = modifyDashboard(
     JSON.stringify(specParse.data),
     prompt.trim(),
-    { requestId, endpoint: "modifyDashboard", onAgenticProgress },
+    modifyCtx,
   ).then(
     (rawResponse): LlmOutcome => ({ kind: "ok", rawResponse }),
     (err): LlmOutcome => ({ kind: "err", err }),
@@ -266,14 +279,46 @@ export async function POST(request: Request) {
   ]);
 
   // -------------------------------------------------------------------------
-  // Helper: parse + validate the LLM raw response into a DashboardSpec.
-  // Returns a discriminated result so both code paths can react identically.
+  // Helper: extract spec + message from the LLM outcome.
+  // With the new publish-tool approach (agentic tools enabled):
+  //   - spec comes from ctx.modifyResult (staged by the tool handler)
+  //   - message is the freeform text returned by runAgenticChat
+  // Legacy path (agentic tools disabled):
+  //   - rawResponse is the raw JSON spec (old contract)
+  //   - message is empty
   // -------------------------------------------------------------------------
   type ValidationOutcome =
-    | { ok: true; spec: DashboardSpec }
+    | { ok: true; spec: DashboardSpec; message: string; summary: string }
     | { ok: false; status: number; payload: ApiErrorResponse };
 
   const validateLlmResponse = (rawResponse: string): ValidationOutcome => {
+    // Agentic path: ctx.modifyResult was staged by apply_dashboard_modification.
+    if (isAgenticToolsEnabled()) {
+      if (!modifyCtx.modifyResult) {
+        console.error(
+          `[${requestId}] El modelo no llamó a apply_dashboard_modification (agentic tools enabled).`,
+        );
+        return {
+          ok: false,
+          status: 500,
+          payload: formatApiError(
+            "El modelo no publicó el dashboard modificado. Reformula el cambio o inténtalo de nuevo.",
+            "AGENTIC_RUNNER",
+            "El modelo no llamó a `apply_dashboard_modification`.",
+            requestId,
+          ),
+        };
+      }
+      // The spec was already Zod-validated inside the tool handler.
+      return {
+        ok: true,
+        spec: modifyCtx.modifyResult.spec,
+        message: rawResponse,
+        summary: modifyCtx.modifyResult.summary,
+      };
+    }
+
+    // Legacy path: parse JSON from the raw response string.
     const jsonStr = extractJson(rawResponse);
     let parsed: unknown;
     try {
@@ -329,7 +374,7 @@ export async function POST(request: Request) {
       };
     }
 
-    return { ok: true, spec: updatedSpec };
+    return { ok: true, spec: updatedSpec, message: "", summary: "" };
   };
 
   // -------------------------------------------------------------------------
@@ -364,13 +409,14 @@ export async function POST(request: Request) {
       return NextResponse.json(validation.payload, { status: validation.status });
     }
 
-    const updatedSpec = validation.spec;
+    const { spec: updatedSpec, message, summary } = validation;
     if (interactionId) {
       await finishInteraction(interactionId, "completed", JSON.stringify(updatedSpec)).catch((e) =>
         console.error(`[${requestId}] finishInteraction(modify,completed) failed:`, e),
       );
     }
-    return NextResponse.json(updatedSpec);
+    // Return additive fields: spec (existing contract) + message + summary (new).
+    return NextResponse.json({ ...updatedSpec, message, summary });
   }
 
   // -------------------------------------------------------------------------
@@ -430,13 +476,14 @@ export async function POST(request: Request) {
         return;
       }
 
-      const updatedSpec = validation.spec;
+      const { spec: updatedSpec, message, summary } = validation;
       if (interactionId) {
         await finishInteraction(interactionId, "completed", JSON.stringify(updatedSpec)).catch((e) =>
           console.error(`[${requestId}] finishInteraction(modify,completed) failed:`, e),
         );
       }
-      send({ type: "result", requestId, spec: updatedSpec });
+      // Additive NDJSON result frame: spec (existing) + message + summary (new).
+      send({ type: "result", requestId, spec: updatedSpec, message, summary });
       controller.close();
     },
   });

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -15,9 +15,12 @@
  *                                no progress was emitted yet; otherwise
  *                                HTTP 200 NDJSON terminating in
  *                                `{type:"error", httpStatus, ...}`.
- *   • Success (no progress)    → HTTP 200, JSON `{ spec, message?, summary? }`.
+ *   • Success (no progress)    → HTTP 200, JSON spread of DashboardSpec fields
+ *                                plus additive `message` and `summary` strings.
+ *                                Existing clients consuming `spec.title` / `spec.widgets`
+ *                                continue to work — `message` / `summary` are new fields.
  *   • Success (with progress)  → HTTP 200 NDJSON terminating in
- *                                `{type:"result", spec, message, summary}`.
+ *                                `{type:"result", spec: DashboardSpec, message, summary}`.
  *
  * Streaming frames (NDJSON):
  *   { type: "progress", requestId, logLine: LogLine }

--- a/dashboard/app/api/review/generate/route.ts
+++ b/dashboard/app/api/review/generate/route.ts
@@ -32,8 +32,10 @@ import {
 } from "@/lib/errors";
 import { executeReviewQueries, formatAllResults, type ReviewQueryResult } from "@/lib/review-queries";
 import { buildReviewPrompt } from "@/lib/review-prompts";
-import { generateReview, generateReviewWithProgress, BudgetExceededError } from "@/lib/llm";
+import { generateReview, generateReviewWithProgress, BudgetExceededError, AgenticRunnerError } from "@/lib/llm";
 import type { AgenticProgressEvent } from "@/lib/llm";
+import { buildAgenticErrorDiagnostic, persistAgenticError } from "@/lib/llm-tools/diagnostic";
+import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
 import {
   formatCliRunnerError,
   isCliRunnerError,
@@ -83,6 +85,8 @@ async function generateAndSaveReview(params: {
   reviewId: number;
   content: ReviewContent;
   nextRevision: number;
+  /** Freeform Spanish chat message from the model (new). Empty string when using legacy path. */
+  message: string;
 }> {
   const {
     weekStartStr,
@@ -129,14 +133,20 @@ async function generateAndSaveReview(params: {
 
   onPhase?.("Llamando al modelo");
 
-  let llmOut;
+  // generateReviewWithProgress and generateReview now return { content, message }.
+  // In the agentic path, `content` comes from ctx.reviewResult (staged by submit_weekly_review)
+  // and `message` is the model's freeform chat reply. In the legacy path, message is "".
+  let llmResult: { content: import("@/lib/review-schema").ReviewLlmOutput; message: string };
   if (onProgress) {
-    llmOut = await generateReviewWithProgress(systemPrompt, { requestId, onAgenticProgress: onProgress });
+    llmResult = await generateReviewWithProgress(systemPrompt, { requestId, onAgenticProgress: onProgress });
   } else {
-    llmOut = await generateReview(systemPrompt, { requestId });
+    llmResult = await generateReview(systemPrompt, { requestId });
   }
 
   onPhase?.("Validando JSON");
+
+  const llmOut = llmResult.content;
+  const reviewMessage = llmResult.message;
 
   const generatedAt = llmOut.generated_at || new Date().toISOString();
 
@@ -214,7 +224,7 @@ async function generateAndSaveReview(params: {
     );
   }
 
-  return { reviewId: reviewId!, content, nextRevision };
+  return { reviewId: reviewId!, content, nextRevision, message: reviewMessage };
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse | Response> {
@@ -330,7 +340,7 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
           };
 
           try {
-            const { reviewId, content, nextRevision } = await generateAndSaveReview({
+            const { reviewId, content, nextRevision, message } = await generateAndSaveReview({
               weekStartStr,
               weekEndExclusiveStr,
               weekEndSundayStr,
@@ -345,6 +355,7 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
             send({
               type: "result",
               requestId,
+              message,
               review: {
                 ...content,
                 id: reviewId,
@@ -357,8 +368,17 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
             let httpStatus = 500;
             let errCode: ErrorCode = "UNKNOWN";
             let errMessage = "Error inesperado al generar la revisión.";
+            let diagnostic: import("@/lib/errors").AgenticErrorDiagnostic | undefined;
 
-            if (err instanceof BudgetExceededError) {
+            if (err instanceof AgenticRunnerError) {
+              const cfg = loadDashboardLlmConfig();
+              const diag = buildAgenticErrorDiagnostic(err, cfg);
+              persistAgenticError("review", err, diag);
+              httpStatus = 500;
+              errCode = "AGENTIC_RUNNER";
+              errMessage = "El flujo de IA alcanzó un límite o no pudo completarse. Inténtalo de nuevo.";
+              diagnostic = diag;
+            } else if (err instanceof BudgetExceededError) {
               httpStatus = 429;
               errCode = "LLM_BUDGET_EXCEEDED";
               errMessage = err.message;
@@ -387,7 +407,7 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
               errMessage = "Error inesperado al generar la revisión.";
             }
 
-            const errPayload = formatApiError(errMessage, errCode, sanitizeErrorMessage(err), requestId);
+            const errPayload = formatApiError(errMessage, errCode, sanitizeErrorMessage(err), requestId, diagnostic);
             send({
               type: "error",
               httpStatus,
@@ -410,7 +430,7 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
 
     // Non-streaming path (stream:false): legacy JSON response.
     try {
-      const { reviewId, content, nextRevision } = await generateAndSaveReview({
+      const { reviewId, content, nextRevision, message } = await generateAndSaveReview({
         weekStartStr,
         weekEndExclusiveStr,
         weekEndSundayStr,
@@ -434,6 +454,7 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
 
       return NextResponse.json(
         {
+          message,
           review: {
             ...content,
             id: reviewId,

--- a/dashboard/app/api/review/generate/route.ts
+++ b/dashboard/app/api/review/generate/route.ts
@@ -36,6 +36,7 @@ import { generateReview, generateReviewWithProgress, BudgetExceededError, Agenti
 import type { AgenticProgressEvent } from "@/lib/llm";
 import { buildAgenticErrorDiagnostic, persistAgenticError } from "@/lib/llm-tools/diagnostic";
 import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
+import { isAgenticToolsEnabled } from "@/lib/llm-tools/config";
 import {
   formatCliRunnerError,
   isCliRunnerError,
@@ -129,6 +130,7 @@ async function generateAndSaveReview(params: {
     formattedResults,
     reviewedWeekDescription,
     generationMode,
+    isAgenticToolsEnabled(),
   );
 
   onPhase?.("Llamando al modelo");

--- a/dashboard/app/review/page.tsx
+++ b/dashboard/app/review/page.tsx
@@ -76,6 +76,8 @@ interface FullReviewState {
   revision: number;
   generation_mode: string;
   content: ReviewContent;
+  /** Freeform Spanish message from the model (set after generation, null for loaded reviews). */
+  modelMessage?: string | null;
 }
 
 function formatWeekDate(dateStr: string): string {
@@ -298,6 +300,7 @@ export default function ReviewPage() {
     async (body: Record<string, unknown>): Promise<{
       week_start: string;
       id: number;
+      message?: string;
     } | null> => {
       setStreamingLog([]);
       startedAtRef.current = Date.now();
@@ -348,7 +351,7 @@ export default function ReviewPage() {
         | { type: "meta"; requestId: string; message: string; weekStart: string; generationMode: string }
         | { type: "phase"; message: string; index?: number; total?: number }
         | { type: "progress"; event: AgenticProgressEvent }
-        | { type: "result"; review: ReviewContent & { id: number; week_start: string; revision: number; generation_mode: string } }
+        | { type: "result"; message?: string; review: ReviewContent & { id: number; week_start: string; revision: number; generation_mode: string } }
         | { type: "error"; httpStatus: number; error: string; code: string; [k: string]: unknown };
 
       for await (const frame of readNdjsonStream<ReviewFrame>(res.body)) {
@@ -378,7 +381,7 @@ export default function ReviewPage() {
           ]);
         } else if (frame.type === "result") {
           setStreamingLog(null);
-          return { week_start: frame.review.week_start, id: frame.review.id };
+          return { week_start: frame.review.week_start, id: frame.review.id, message: frame.message };
         } else if (frame.type === "error") {
           setStreamingLog(null);
           throw Object.assign(new Error(frame.error ?? "Error al generar la revisión."), {
@@ -403,6 +406,10 @@ export default function ReviewPage() {
       const result = await callGenerateStreaming({});
       if (result) {
         await openWeek(result.week_start, result.id);
+        // Store the model's freeform message alongside the review state.
+        if (result.message) {
+          setCurrent((prev) => prev ? { ...prev, modelMessage: result.message } : prev);
+        }
         void fetchPastReviews();
       }
     } catch (err) {
@@ -425,6 +432,9 @@ export default function ReviewPage() {
       if (result) {
         setRegenMode(null);
         await openWeek(result.week_start, result.id);
+        if (result.message) {
+          setCurrent((prev) => prev ? { ...prev, modelMessage: result.message } : prev);
+        }
         void fetchPastReviews();
       }
     } catch (err) {
@@ -584,7 +594,10 @@ export default function ReviewPage() {
 
           <ReviewDiffPanel prior={priorContent} current={current.content} />
 
-          <ReviewDisplay review={{ ...current.content, id: current.id, week_start: current.week_start }} />
+          <ReviewDisplay
+            review={{ ...current.content, id: current.id, week_start: current.week_start }}
+            modelMessage={current.modelMessage ?? undefined}
+          />
 
           {current.id > 0 && (
             <ReviewActionsBoard

--- a/dashboard/components/ChatSidebar.tsx
+++ b/dashboard/components/ChatSidebar.tsx
@@ -28,6 +28,17 @@ export interface ChatMessage {
   isError?: boolean;
   /** Log lines captured during the API call that produced this message. */
   logs?: LogLine[];
+  /**
+   * Short summary from the publish tool (apply_dashboard_modification or
+   * submit_dashboard_analysis). When present, a compact "Cambios aplicados"
+   * chip is rendered below the chat bubble.
+   */
+  appliedSummary?: string;
+  /**
+   * Label for the chip shown when appliedSummary is set.
+   * Defaults to "Cambios aplicados" for modify, "Análisis publicado" for analyze.
+   */
+  appliedChipLabel?: string;
 }
 
 export interface ChatSidebarProps {
@@ -359,6 +370,24 @@ function MessageBubble({
           )}
         </div>
       )}
+
+      {/* "Cambios aplicados" / "Análisis publicado" chip — shown for successful publish-tool responses */}
+      {!isUser && !isError && msg.appliedSummary && (
+        <div
+          data-testid="applied-chip"
+          style={{
+            fontSize: 10,
+            padding: "3px 8px",
+            borderRadius: 10,
+            background: "rgba(var(--accent-rgb,99,102,241),0.12)",
+            border: "1px solid rgba(var(--accent-rgb,99,102,241),0.25)",
+            color: "var(--accent)",
+            maxWidth: "86%",
+          }}
+        >
+          ✓ {msg.appliedChipLabel ?? "Cambios aplicados"}
+        </div>
+      )}
     </div>
   );
 }
@@ -600,10 +629,12 @@ function ModificarTab({
       if (res.ok && res.body && isNdjsonResponse(res)) {
         type ModifyMsg =
           | { type: "progress"; requestId: string; logLine: LogLine }
-          | { type: "result"; requestId: string; spec: DashboardSpec }
+          | { type: "result"; requestId: string; spec: DashboardSpec; message?: string; summary?: string }
           | ({ type: "error"; requestId: string; httpStatus?: number } & Partial<ApiErrorResponse>);
 
         let resultSpec: DashboardSpec | null = null;
+        let resultMessage: string | null = null;
+        let resultSummary: string | null = null;
         let errorFrame: (ModifyMsg & { type: "error" }) | null = null;
 
         for await (const msg of readNdjsonStream<ModifyMsg>(res.body)) {
@@ -612,6 +643,8 @@ function ModificarTab({
             setStreamingLog([...capturedLogs]);
           } else if (msg.type === "result") {
             resultSpec = msg.spec;
+            resultMessage = msg.message ?? null;
+            resultSummary = msg.summary ?? null;
           } else if (msg.type === "error") {
             errorFrame = msg;
           }
@@ -643,18 +676,25 @@ function ModificarTab({
 
         if (resultSpec) {
           onSpecUpdate(resultSpec, trimmed);
-          const widgetDelta = resultSpec.widgets.length - spec.widgets.length;
-          let summary = "Dashboard actualizado.";
-          if (widgetDelta > 0) {
-            summary += ` Se ${widgetDelta === 1 ? "ha añadido 1 widget" : `han añadido ${widgetDelta} widgets`}.`;
-          } else if (widgetDelta < 0) {
-            summary += ` Se ${widgetDelta === -1 ? "ha eliminado 1 widget" : `han eliminado ${Math.abs(widgetDelta)} widgets`}.`;
+          // Use the model's freeform message if provided, otherwise fallback to widget delta summary.
+          let chatContent: string;
+          if (resultMessage && resultMessage.trim()) {
+            chatContent = resultMessage.trim();
+          } else {
+            const widgetDelta = resultSpec.widgets.length - spec.widgets.length;
+            chatContent = "Dashboard actualizado.";
+            if (widgetDelta > 0) {
+              chatContent += ` Se ${widgetDelta === 1 ? "ha añadido 1 widget" : `han añadido ${widgetDelta} widgets`}.`;
+            } else if (widgetDelta < 0) {
+              chatContent += ` Se ${widgetDelta === -1 ? "ha eliminado 1 widget" : `han eliminado ${Math.abs(widgetDelta)} widgets`}.`;
+            }
           }
           appendAssistant({
             role: "assistant",
-            content: summary,
+            content: chatContent,
             timestamp: new Date(),
             logs: [...capturedLogs],
+            ...(resultSummary ? { appliedSummary: resultSummary } : {}),
           });
           return;
         }
@@ -712,22 +752,32 @@ function ModificarTab({
         return;
       }
 
-      const newSpec: DashboardSpec = await res.json();
-      onSpecUpdate(newSpec, trimmed);
+      const responseBody = await res.json() as DashboardSpec & { message?: string; summary?: string };
+      // The new response body has { ...spec, message?, summary? }.
+      // Extract spec fields (title, widgets, etc.) and the additive message field.
+      const { message: respMessage, summary: respSummary, ...newSpec } = responseBody;
+      onSpecUpdate(newSpec as DashboardSpec, trimmed);
 
-      const widgetDelta = newSpec.widgets.length - spec.widgets.length;
-      let summary = "Dashboard actualizado.";
-      if (widgetDelta > 0) {
-        summary += ` Se ${widgetDelta === 1 ? "ha añadido 1 widget" : `han añadido ${widgetDelta} widgets`}.`;
-      } else if (widgetDelta < 0) {
-        summary += ` Se ${widgetDelta === -1 ? "ha eliminado 1 widget" : `han eliminado ${Math.abs(widgetDelta)} widgets`}.`;
+      // Use the model's freeform message if provided, otherwise fallback to widget delta summary.
+      let chatContent: string;
+      if (respMessage && respMessage.trim()) {
+        chatContent = respMessage.trim();
+      } else {
+        const widgetDelta = (newSpec as DashboardSpec).widgets.length - spec.widgets.length;
+        chatContent = "Dashboard actualizado.";
+        if (widgetDelta > 0) {
+          chatContent += ` Se ${widgetDelta === 1 ? "ha añadido 1 widget" : `han añadido ${widgetDelta} widgets`}.`;
+        } else if (widgetDelta < 0) {
+          chatContent += ` Se ${widgetDelta === -1 ? "ha eliminado 1 widget" : `han eliminado ${Math.abs(widgetDelta)} widgets`}.`;
+        }
       }
 
       appendAssistant({
         role: "assistant",
-        content: summary,
+        content: chatContent,
         timestamp: new Date(),
         logs: [...capturedLogs],
+        ...(respSummary ? { appliedSummary: respSummary } : {}),
       });
     } catch (err) {
       console.error("Error al procesar la solicitud del chat:", err);
@@ -1002,10 +1052,10 @@ function AnalizarTab({
         if (res.ok && res.body && isNdjsonResponse(res)) {
           type AnalyzeMsg =
             | { type: "progress"; requestId: string; logLine: LogLine }
-            | { type: "result"; requestId: string; response: string; suggestions: string[] }
+            | { type: "result"; requestId: string; response: string; message?: string; summary?: string; suggestions: string[] }
             | ({ type: "error"; requestId: string; httpStatus?: number } & Partial<ApiErrorResponse>);
 
-          let result: { response: string; suggestions: string[] } | null = null;
+          let result: { response: string; message?: string; summary?: string; suggestions: string[] } | null = null;
           let errorFrame: (AnalyzeMsg & { type: "error" }) | null = null;
 
           for await (const msg of readNdjsonStream<AnalyzeMsg>(res.body)) {
@@ -1013,7 +1063,12 @@ function AnalizarTab({
               capturedLogs.push(msg.logLine);
               setStreamingLog([...capturedLogs]);
             } else if (msg.type === "result") {
-              result = { response: msg.response, suggestions: msg.suggestions ?? [] };
+              result = {
+                response: msg.response,
+                message: msg.message,
+                summary: msg.summary,
+                suggestions: msg.suggestions ?? [],
+              };
             } else if (msg.type === "error") {
               errorFrame = msg;
             }
@@ -1044,11 +1099,15 @@ function AnalizarTab({
           }
 
           if (result) {
+            // With the publish-tool contract: message = freeform chat reply, response = analysis body.
+            // If message is empty (legacy path), fall back to response.
+            const chatContent = result.message?.trim() || result.response;
             appendAssistant({
               role: "assistant",
-              content: result.response,
+              content: chatContent,
               timestamp: new Date(),
               logs: [...capturedLogs],
+              ...(result.summary ? { appliedSummary: result.summary, appliedChipLabel: "Análisis publicado" } : {}),
             });
             setSuggestions(result.suggestions);
             return;
@@ -1106,13 +1165,16 @@ function AnalizarTab({
           return;
         }
 
-        const data = await res.json() as { response: string; suggestions: string[] };
+        const data = await res.json() as { response: string; message?: string; summary?: string; suggestions: string[] };
 
+        // With publish-tool contract: message = freeform chat reply, response = analysis body.
+        const chatContent = data.message?.trim() || data.response;
         appendAssistant({
           role: "assistant",
-          content: data.response,
+          content: chatContent,
           timestamp: new Date(),
           logs: [...capturedLogs],
+          ...(data.summary ? { appliedSummary: data.summary, appliedChipLabel: "Análisis publicado" } : {}),
         });
         setSuggestions(data.suggestions ?? []);
       } catch (err) {

--- a/dashboard/components/ReviewDisplay.tsx
+++ b/dashboard/components/ReviewDisplay.tsx
@@ -11,6 +11,12 @@ import type { ReviewActionRow } from "@/lib/review-actions-db";
 export interface ReviewDisplayProps {
   review: ReviewContent & { id?: number | null; week_start?: string };
   actions?: ReviewActionRow[];
+  /**
+   * Freeform Spanish message from the model describing the review conclusions.
+   * When present, shown as a "Resumen del modelo" intro paragraph above the
+   * executive summary card.
+   */
+  modelMessage?: string;
 }
 
 function formatTimestamp(iso: string): string {
@@ -198,7 +204,7 @@ function ActionCard({ item }: { item: ReviewActionItemV2 }) {
   );
 }
 
-export function ReviewDisplay({ review }: ReviewDisplayProps) {
+export function ReviewDisplay({ review, modelMessage }: ReviewDisplayProps) {
   const [copied, setCopied] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -267,6 +273,25 @@ export function ReviewDisplay({ review }: ReviewDisplayProps) {
           </button>
         </div>
       </div>
+
+      {modelMessage && modelMessage.trim() && (
+        <div
+          data-testid="model-message"
+          style={{
+            borderRadius: 8,
+            border: "1px solid rgba(var(--accent-rgb,99,102,241),0.2)",
+            background: "rgba(var(--accent-rgb,99,102,241),0.06)",
+            padding: "14px 16px",
+          }}
+        >
+          <p style={{ fontSize: 12, fontWeight: 600, color: "var(--accent)", margin: "0 0 6px" }}>
+            Resumen del modelo
+          </p>
+          <p style={{ fontSize: 13, color: "var(--fg-muted)", margin: 0, lineHeight: 1.6 }}>
+            {modelMessage.trim()}
+          </p>
+        </div>
+      )}
 
       {review.data_quality_notes.length > 0 && (
         <div

--- a/dashboard/lib/__tests__/llm-tools-dashboards.test.ts
+++ b/dashboard/lib/__tests__/llm-tools-dashboards.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { extractDashboardSqlRefs } from "@/lib/llm-tools/dashboard-query-extractor";
-import { handleValidateDashboardSpec } from "@/lib/llm-tools/handlers/dashboards";
+import {
+  handleValidateDashboardSpec,
+  handleApplyDashboardModification,
+  handleSubmitDashboardAnalysis,
+  handleSubmitWeeklyReview,
+} from "@/lib/llm-tools/handlers/dashboards";
 import type { DashboardSpec } from "@/lib/schema";
 import type { LlmAgenticContext } from "@/lib/llm-tools/types";
 
@@ -141,5 +146,199 @@ describe("handleValidateDashboardSpec", () => {
       expect(data.warnings.length).toBeGreaterThan(0);
       expect(data.warnings.join(" ")).toMatch(/COALESCE|texto/);
     }
+  });
+});
+
+// ─── handleApplyDashboardModification ────────────────────────────────────────
+
+const validModifySpec: DashboardSpec = {
+  title: "Ventas",
+  widgets: [
+    {
+      type: "kpi_row",
+      items: [{ label: "Ventas", sql: "SELECT SUM(total_si) FROM ps_ventas", format: "currency" }],
+    },
+  ],
+};
+
+describe("handleApplyDashboardModification", () => {
+  it("stages ctx.modifyResult and returns ok=true, applied=true for valid args", async () => {
+    const mutableCtx: LlmAgenticContext = { ...ctx };
+    const out = await handleApplyDashboardModification(
+      JSON.stringify({ spec: validModifySpec, change_summary: "He añadido un widget de ventas." }),
+      mutableCtx,
+    );
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      const d = out.data as { ok: boolean; applied: boolean };
+      expect(d.ok).toBe(true);
+      expect(d.applied).toBe(true);
+    }
+    expect(mutableCtx.modifyResult).not.toBeNull();
+    expect(mutableCtx.modifyResult?.summary).toBe("He añadido un widget de ventas.");
+    expect(mutableCtx.modifyResult?.spec.title).toBe("Ventas");
+  });
+
+  it("returns toolOk({ ok: false }) with errors when spec is invalid", async () => {
+    const mutableCtx: LlmAgenticContext = { ...ctx };
+    const out = await handleApplyDashboardModification(
+      JSON.stringify({ spec: { title: "no widgets" }, change_summary: "Cambié algo." }),
+      mutableCtx,
+    );
+    expect(out.ok).toBe(true); // toolOk wraps the validation result
+    if (out.ok) {
+      const d = out.data as { ok: boolean; errors: string[] };
+      expect(d.ok).toBe(false);
+      expect(d.errors.length).toBeGreaterThan(0);
+    }
+    expect(mutableCtx.modifyResult).toBeUndefined();
+  });
+
+  it("returns INVALID_ARGS when change_summary is missing", async () => {
+    const out = await handleApplyDashboardModification(
+      JSON.stringify({ spec: validModifySpec }),
+      ctx,
+    );
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.code).toBe("INVALID_ARGS");
+  });
+
+  it("returns INVALID_ARGS when change_summary exceeds 1000 chars", async () => {
+    const out = await handleApplyDashboardModification(
+      JSON.stringify({ spec: validModifySpec, change_summary: "x".repeat(1001) }),
+      ctx,
+    );
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.code).toBe("INVALID_ARGS");
+  });
+
+  it("overwrites ctx.modifyResult on double-call and adds note", async () => {
+    const mutableCtx: LlmAgenticContext = { ...ctx };
+    await handleApplyDashboardModification(
+      JSON.stringify({ spec: validModifySpec, change_summary: "Primera llamada." }),
+      mutableCtx,
+    );
+    const second = await handleApplyDashboardModification(
+      JSON.stringify({ spec: { ...validModifySpec, title: "Ventas v2" }, change_summary: "Segunda llamada." }),
+      mutableCtx,
+    );
+    expect(mutableCtx.modifyResult?.spec.title).toBe("Ventas v2");
+    expect(mutableCtx.modifyResult?.summary).toBe("Segunda llamada.");
+    if (second.ok) {
+      const d = second.data as { note?: string };
+      expect(d.note).toMatch(/overwritten|latest|LAST/i);
+    }
+  });
+});
+
+// ─── handleSubmitDashboardAnalysis ───────────────────────────────────────────
+
+describe("handleSubmitDashboardAnalysis", () => {
+  it("stages ctx.analyzeResult and returns ok=true, applied=true for valid args", async () => {
+    const mutableCtx: LlmAgenticContext = { ...ctx };
+    const out = await handleSubmitDashboardAnalysis(
+      JSON.stringify({
+        analysis_markdown: "# Análisis\n\nVentas crecieron un 12%.",
+        brief_summary: "Ventas al alza.",
+      }),
+      mutableCtx,
+    );
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      const d = out.data as { ok: boolean; applied: boolean };
+      expect(d.ok).toBe(true);
+      expect(d.applied).toBe(true);
+    }
+    expect(mutableCtx.analyzeResult?.markdown).toContain("Análisis");
+    expect(mutableCtx.analyzeResult?.summary).toBe("Ventas al alza.");
+  });
+
+  it("returns INVALID_ARGS when analysis_markdown is empty", async () => {
+    const out = await handleSubmitDashboardAnalysis(
+      JSON.stringify({ analysis_markdown: "  ", brief_summary: "Resumen." }),
+      ctx,
+    );
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.code).toBe("INVALID_ARGS");
+  });
+
+  it("returns INVALID_ARGS when analysis_markdown exceeds 30 KB", async () => {
+    const out = await handleSubmitDashboardAnalysis(
+      JSON.stringify({ analysis_markdown: "x".repeat(31 * 1024), brief_summary: "Resumen." }),
+      ctx,
+    );
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.code).toBe("INVALID_ARGS");
+  });
+
+  it("returns INVALID_ARGS when brief_summary is missing", async () => {
+    const out = await handleSubmitDashboardAnalysis(
+      JSON.stringify({ analysis_markdown: "# Análisis" }),
+      ctx,
+    );
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.code).toBe("INVALID_ARGS");
+  });
+});
+
+// ─── handleSubmitWeeklyReview ─────────────────────────────────────────────────
+
+// Minimal valid review that passes ReviewLlmOutputSchema
+const validReviewPayload = {
+  executive_summary: ["Ventas +12%", "Stock OK", "Tres pedidos"],
+  sections: [
+    { key: "ventas_retail", title: "Ventas Retail", narrative: "Texto.", kpis: ["KPI 1"], evidence_queries: ["ventas_semana_cerrada"], dashboard_key: "ventas_retail" },
+    { key: "canal_mayorista", title: "Mayorista", narrative: "Texto.", kpis: ["KPI 1"], evidence_queries: ["facturacion_mayorista_semana_cerrada"], dashboard_key: "canal_mayorista" },
+    { key: "stock", title: "Stock", narrative: "Texto.", kpis: ["KPI 1"], evidence_queries: ["stock_total_unidades"], dashboard_key: "stock" },
+    { key: "compras", title: "Compras", narrative: "Texto.", kpis: ["KPI 1"], evidence_queries: ["compras_semana_cerrada"], dashboard_key: "compras" },
+  ],
+  action_items: [
+    { action_key: "revisar_stock", priority: "alta", owner_role: "Logística", due_date: "2026-05-10", action: "Revisar stock.", expected_impact: "Menos roturas.", evidence_queries: ["articulos_stock_critico"], dashboard_key: "stock" },
+    { action_key: "contactar_clientes", priority: "media", owner_role: "Ventas", due_date: "2026-05-10", action: "Contactar clientes.", expected_impact: "Mejor cobro.", evidence_queries: ["top3_clientes_mayorista_semana_cerrada"], dashboard_key: "canal_mayorista" },
+    { action_key: "planificar_traspasos", priority: "baja", owner_role: "Tiendas", due_date: "2026-05-15", action: "Planificar traspasos.", expected_impact: "Mejor distribución.", evidence_queries: ["traspasos_semana_cerrada"], dashboard_key: "stock" },
+  ],
+  data_quality_notes: [],
+  generated_at: "2026-05-01T00:00:00.000Z",
+};
+
+describe("handleSubmitWeeklyReview", () => {
+  it("stages ctx.reviewResult and returns ok=true for valid args", async () => {
+    const mutableCtx: LlmAgenticContext = { ...ctx };
+    const out = await handleSubmitWeeklyReview(
+      JSON.stringify({ review: validReviewPayload, brief_summary: "Buena semana." }),
+      mutableCtx,
+    );
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      const d = out.data as { ok: boolean; applied: boolean };
+      expect(d.ok).toBe(true);
+      expect(d.applied).toBe(true);
+    }
+    expect(mutableCtx.reviewResult?.content.executive_summary[0]).toBe("Ventas +12%");
+    expect(mutableCtx.reviewResult?.summary).toBe("Buena semana.");
+  });
+
+  it("returns toolOk({ ok: false }) when review JSON is malformed", async () => {
+    const mutableCtx: LlmAgenticContext = { ...ctx };
+    const out = await handleSubmitWeeklyReview(
+      JSON.stringify({ review: { bad: "structure" }, brief_summary: "Resumen." }),
+      mutableCtx,
+    );
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      const d = out.data as { ok: boolean; errors: string[] };
+      expect(d.ok).toBe(false);
+      expect(d.errors.length).toBeGreaterThan(0);
+    }
+    expect(mutableCtx.reviewResult).toBeUndefined();
+  });
+
+  it("returns INVALID_ARGS when brief_summary is missing", async () => {
+    const out = await handleSubmitWeeklyReview(
+      JSON.stringify({ review: validReviewPayload }),
+      ctx,
+    );
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.code).toBe("INVALID_ARGS");
   });
 });

--- a/dashboard/lib/__tests__/prompts.test.ts
+++ b/dashboard/lib/__tests__/prompts.test.ts
@@ -235,7 +235,8 @@ describe("prompts", () => {
 
     it("does not wrap current spec in markdown fences", () => {
       expect(prompt).not.toContain("```json\n" + sampleSpec);
-      expect(prompt).toContain("Do not wrap your response in markdown fences");
+      // New contract: spec goes through apply_dashboard_modification tool, not raw JSON output.
+      expect(prompt).toContain("apply_dashboard_modification");
     });
 
     it("instructs to preserve existing widgets", () => {

--- a/dashboard/lib/analyze-prompts.ts
+++ b/dashboard/lib/analyze-prompts.ts
@@ -55,22 +55,31 @@ function formatBusinessRules(): string {
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
+export interface BuildAnalyzePromptOptions {
+  /** When set, the model may use dashboard tools with this id. */
+  dashboardId?: number;
+  /**
+   * When true (default), includes the publish-tool workflow instructions
+   * (submit_dashboard_analysis). When false, falls back to the legacy
+   * "respond with markdown analysis" contract for the non-agentic path.
+   */
+  agenticMode?: boolean;
+}
+
 /**
  * Build the system prompt for analyzing dashboard data.
  *
  * @param serializedData  — Formatted widget data string from serializeWidgetData()
  * @param action          — Optional preset action that drives specific instructions
+ * @param options         — Optional options including dashboardId and agenticMode
  */
-export interface BuildAnalyzePromptOptions {
-  /** When set, the model may use dashboard tools with this id. */
-  dashboardId?: number;
-}
-
 export function buildAnalyzePrompt(
   serializedData: string,
   action?: string,
   options?: BuildAnalyzePromptOptions,
 ): string {
+  const agenticMode = options?.agenticMode !== false; // default true
+
   const sections: string[] = [
     "# Rol",
     "",
@@ -86,19 +95,24 @@ export function buildAnalyzePrompt(
     "- No inventes datos que no estén en el contexto",
     "- Cuando los datos no estén disponibles, indícalo claramente",
     "",
-    "# Flujo requerido (OBLIGATORIO)",
-    "",
-    "1. Analiza los datos del dashboard y redacta el análisis completo en markdown.",
-    "2. Llama a la herramienta `submit_dashboard_analysis` con:",
-    "   - `analysis_markdown`: el análisis completo en markdown.",
-    "   - `brief_summary`: 1–2 frases en español que resumen el hallazgo principal.",
-    "3. Después de que `submit_dashboard_analysis` devuelva `{ ok: true, applied: true }`,",
-    "   escribe tu mensaje final como una respuesta amistosa en español al usuario (≤ 4 frases).",
-    "",
-    "**Nunca emitas el análisis como tu respuesta final.** El análisis DEBE ir a través de",
-    "`submit_dashboard_analysis`. Si emites el análisis directamente, el sistema fallará.",
-    "",
   ];
+
+  if (agenticMode) {
+    sections.push(
+      "# Flujo requerido (OBLIGATORIO)",
+      "",
+      "1. Analiza los datos del dashboard y redacta el análisis completo en markdown.",
+      "2. Llama a la herramienta `submit_dashboard_analysis` con:",
+      "   - `analysis_markdown`: el análisis completo en markdown.",
+      "   - `brief_summary`: 1–2 frases en español que resumen el hallazgo principal.",
+      "3. Después de que `submit_dashboard_analysis` devuelva `{ ok: true, applied: true }`,",
+      "   escribe tu mensaje final como una respuesta amistosa en español al usuario (≤ 4 frases).",
+      "",
+      "**Nunca emitas el análisis como tu respuesta final.** El análisis DEBE ir a través de",
+      "`submit_dashboard_analysis`. Si emites el análisis directamente, el sistema fallará.",
+      "",
+    );
+  }
 
   // Inject action-specific instructions when provided
   const normalizedAction = action as AnalyzeAction | undefined;

--- a/dashboard/lib/analyze-prompts.ts
+++ b/dashboard/lib/analyze-prompts.ts
@@ -86,6 +86,18 @@ export function buildAnalyzePrompt(
     "- No inventes datos que no estén en el contexto",
     "- Cuando los datos no estén disponibles, indícalo claramente",
     "",
+    "# Flujo requerido (OBLIGATORIO)",
+    "",
+    "1. Analiza los datos del dashboard y redacta el análisis completo en markdown.",
+    "2. Llama a la herramienta `submit_dashboard_analysis` con:",
+    "   - `analysis_markdown`: el análisis completo en markdown.",
+    "   - `brief_summary`: 1–2 frases en español que resumen el hallazgo principal.",
+    "3. Después de que `submit_dashboard_analysis` devuelva `{ ok: true, applied: true }`,",
+    "   escribe tu mensaje final como una respuesta amistosa en español al usuario (≤ 4 frases).",
+    "",
+    "**Nunca emitas el análisis como tu respuesta final.** El análisis DEBE ir a través de",
+    "`submit_dashboard_analysis`. Si emites el análisis directamente, el sistema fallará.",
+    "",
   ];
 
   // Inject action-specific instructions when provided

--- a/dashboard/lib/format-agentic-progress.ts
+++ b/dashboard/lib/format-agentic-progress.ts
@@ -104,7 +104,7 @@ export function formatAgenticProgressLineEs(event: AgenticProgressEvent): string
       return `  ${icon} ${event.name} — ${event.ms} ms${err}${preview}`;
     }
     case "finalizing":
-      return `Respuesta JSON lista (${event.messageChars} caracteres)`;
+      return `Respuesta lista · ${event.messageChars} caracteres`;
     default: {
       return JSON.stringify(event);
     }

--- a/dashboard/lib/llm-tools/catalog.ts
+++ b/dashboard/lib/llm-tools/catalog.ts
@@ -178,4 +178,84 @@ export const DASHBOARD_AGENTIC_TOOLS: ChatCompletionTool[] = [
       },
     },
   },
+  {
+    type: "function",
+    function: {
+      name: "apply_dashboard_modification",
+      description:
+        "Call this tool EXACTLY ONCE at the end of a dashboard modification task, after validate_dashboard_spec returns ok=true. " +
+        "Pass the fully updated dashboard spec and a 2–4 sentence Spanish change_summary describing what you changed. " +
+        "The tool stages the spec in a request-scoped side-channel; the route persists it after you return. " +
+        "After this tool returns { ok: true, applied: true }, write your final assistant message as a friendly Spanish reply to the user (≤ 4 sentences) describing the change. " +
+        "NEVER emit the JSON spec as your final answer — it MUST go through this tool.",
+      parameters: {
+        type: "object",
+        properties: {
+          spec: {
+            type: "object",
+            description: "The fully updated dashboard spec (byte-for-byte the same object that validate_dashboard_spec just approved with ok=true).",
+            additionalProperties: true,
+          },
+          change_summary: {
+            type: "string",
+            description: "2–4 sentences in Spanish summarising what you changed in the dashboard. Max 1000 characters.",
+          },
+        },
+        required: ["spec", "change_summary"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "submit_dashboard_analysis",
+      description:
+        "Call this tool EXACTLY ONCE at the end of a dashboard analysis task. " +
+        "Pass the full markdown analysis body and a brief_summary (≤ 500 chars, Spanish). " +
+        "The tool stages the analysis; the route persists it. " +
+        "After this tool returns { ok: true, applied: true }, write your final assistant message as a friendly Spanish chat reply to the user (≤ 4 sentences). " +
+        "NEVER emit the analysis markdown as your final answer — it MUST go through this tool.",
+      parameters: {
+        type: "object",
+        properties: {
+          analysis_markdown: {
+            type: "string",
+            description: "The full analysis in markdown format (Spanish). Max 30 KB.",
+          },
+          brief_summary: {
+            type: "string",
+            description: "1–2 sentences in Spanish summarising the key finding. Max 500 characters.",
+          },
+        },
+        required: ["analysis_markdown", "brief_summary"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "submit_weekly_review",
+      description:
+        "Call this tool EXACTLY ONCE at the end of a weekly review generation task. " +
+        "Pass the complete review JSON object (matching ReviewLlmOutputSchema) and a brief_summary (≤ 500 chars, Spanish). " +
+        "The tool validates the review, stages it in a request-scoped side-channel, and the route persists it. " +
+        "After this tool returns { ok: true, applied: true }, write your final assistant message as a friendly Spanish reply to the user (≤ 4 sentences) describing the key conclusions. " +
+        "NEVER emit the review JSON as your final answer — it MUST go through this tool.",
+      parameters: {
+        type: "object",
+        properties: {
+          review: {
+            type: "object",
+            description: "The complete weekly review JSON object matching the ReviewLlmOutputSchema.",
+            additionalProperties: true,
+          },
+          brief_summary: {
+            type: "string",
+            description: "1–2 sentences in Spanish summarising the key conclusions. Max 500 characters.",
+          },
+        },
+        required: ["review", "brief_summary"],
+      },
+    },
+  },
 ];

--- a/dashboard/lib/llm-tools/handlers/dashboards.ts
+++ b/dashboard/lib/llm-tools/handlers/dashboards.ts
@@ -409,7 +409,9 @@ export async function handleApplyDashboardModification(
     );
   }
 
-  // Validate the spec with Zod.
+  // Validate the spec with Zod — same logic as handleValidateDashboardSpec so
+  // the two tools stay consistent. NOTE: if validation logic changes, update
+  // both handlers (or extract a shared helper).
   const parsed = DashboardSpecSchema.safeParse(args.spec);
   if (!parsed.success) {
     const errors = parsed.error.issues.map((issue) => {
@@ -419,6 +421,7 @@ export async function handleApplyDashboardModification(
     return toolOk({
       ok: false,
       errors,
+      warnings: [],
       hint:
         "Fix the structural errors above and call apply_dashboard_modification again with the corrected spec.",
     });
@@ -500,10 +503,13 @@ export async function handleSubmitDashboardAnalysis(
     );
   }
 
-  const sanitizedMarkdown = sanitize(args.analysis_markdown.trim());
+  // Do NOT run sanitize() on the full analysis markdown — the secret-redaction
+  // patterns could corrupt legitimate business content (IDs, tokens matching
+  // the regex patterns). Store the analysis body as-is. Only the brief_summary
+  // (displayed in the chat chip and logged) requires sanitization.
   const sanitizedSummary = sanitize(args.brief_summary.trim());
 
-  ctx.analyzeResult = { markdown: sanitizedMarkdown, summary: sanitizedSummary };
+  ctx.analyzeResult = { markdown: args.analysis_markdown.trim(), summary: sanitizedSummary };
 
   return toolOk({ ok: true, applied: true });
 }

--- a/dashboard/lib/llm-tools/handlers/dashboards.ts
+++ b/dashboard/lib/llm-tools/handlers/dashboards.ts
@@ -13,6 +13,8 @@ import { extractDashboardSqlRefs } from "../dashboard-query-extractor";
 import type { LlmAgenticContext } from "../types";
 import { toolError, toolOk, type ToolResponseBody } from "../tool-payload";
 import { getAgenticConfig } from "../config";
+import { ReviewLlmOutputSchema } from "@/lib/review-schema";
+import { sanitize } from "@/lib/llm-provider/sanitize";
 
 const LimitSchema = z.object({
   limit: z.number().int().min(1).max(100).optional(),
@@ -349,6 +351,228 @@ export async function handleValidateDashboardSpec(
         ? "Spec is valid. You may emit the final JSON now."
         : "Spec is structurally valid but has SQL lint warnings — review each one. Warnings do not block emission; emit the final JSON when you are satisfied.",
   });
+}
+
+// ── Publish-tool handlers ────────────────────────────────────────────────────
+// These handlers stage results into the request-scoped `ctx` side-channel.
+// They MUST NOT write to PostgreSQL directly — persistence is the route's job.
+
+const CHANGE_SUMMARY_MAX = 1000;
+const BRIEF_SUMMARY_MAX = 500;
+const MARKDOWN_MAX_BYTES = 30 * 1024; // 30 KB
+
+/**
+ * `apply_dashboard_modification` — validate spec + stage modify result.
+ *
+ * The model calls this once at the end of a modify task with the full updated
+ * spec and a 2–4 sentence Spanish change_summary. The tool validates the spec
+ * with Zod and runs the SQL heuristic lint. On success it stages the result in
+ * ctx.modifyResult and returns `{ ok: true, applied: true }`. The LAST call
+ * wins — intentional double-calls are accepted (latest spec overwrites).
+ */
+export async function handleApplyDashboardModification(
+  rawArgs: string,
+  ctx: LlmAgenticContext,
+): Promise<ToolResponseBody> {
+  let args: { spec?: unknown; change_summary?: unknown };
+  try {
+    args = JSON.parse(rawArgs || "{}");
+  } catch {
+    return toolError(
+      "INVALID_ARGS",
+      "apply_dashboard_modification: arguments must be a JSON object.",
+      ctx,
+    );
+  }
+
+  if (typeof args.spec !== "object" || args.spec === null || Array.isArray(args.spec)) {
+    return toolError(
+      "INVALID_ARGS",
+      "apply_dashboard_modification: 'spec' must be a JSON object.",
+      ctx,
+    );
+  }
+
+  if (typeof args.change_summary !== "string" || args.change_summary.trim().length === 0) {
+    return toolError(
+      "INVALID_ARGS",
+      "apply_dashboard_modification: 'change_summary' must be a non-empty string.",
+      ctx,
+    );
+  }
+
+  if (args.change_summary.length > CHANGE_SUMMARY_MAX) {
+    return toolError(
+      "INVALID_ARGS",
+      `apply_dashboard_modification: 'change_summary' must be ≤ ${CHANGE_SUMMARY_MAX} characters.`,
+      ctx,
+    );
+  }
+
+  // Validate the spec with Zod.
+  const parsed = DashboardSpecSchema.safeParse(args.spec);
+  if (!parsed.success) {
+    const errors = parsed.error.issues.map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      return `${path}: ${issue.message}`;
+    });
+    return toolOk({
+      ok: false,
+      errors,
+      hint:
+        "Fix the structural errors above and call apply_dashboard_modification again with the corrected spec.",
+    });
+  }
+
+  // Run SQL heuristic lint (non-blocking — surfaced as warnings).
+  const warnings = lintDashboardSpec(parsed.data);
+
+  // Sanitize the summary before staging.
+  const sanitizedSummary = sanitize(args.change_summary.trim());
+
+  const wasAlreadySet = ctx.modifyResult != null;
+  ctx.modifyResult = { spec: parsed.data, summary: sanitizedSummary };
+
+  return toolOk({
+    ok: true,
+    applied: true,
+    warnings,
+    ...(wasAlreadySet
+      ? {
+          note: "Previous staged result overwritten. The LAST call to apply_dashboard_modification wins.",
+        }
+      : {}),
+  });
+}
+
+/**
+ * `submit_dashboard_analysis` — stage analysis markdown result.
+ *
+ * The model calls this once at the end of an analyze task with the full
+ * markdown analysis and a brief_summary (≤ 500 chars). Stages the result in
+ * ctx.analyzeResult.
+ */
+export async function handleSubmitDashboardAnalysis(
+  rawArgs: string,
+  ctx: LlmAgenticContext,
+): Promise<ToolResponseBody> {
+  let args: { analysis_markdown?: unknown; brief_summary?: unknown };
+  try {
+    args = JSON.parse(rawArgs || "{}");
+  } catch {
+    return toolError(
+      "INVALID_ARGS",
+      "submit_dashboard_analysis: arguments must be a JSON object.",
+      ctx,
+    );
+  }
+
+  if (typeof args.analysis_markdown !== "string" || args.analysis_markdown.trim().length === 0) {
+    return toolError(
+      "INVALID_ARGS",
+      "submit_dashboard_analysis: 'analysis_markdown' must be a non-empty string.",
+      ctx,
+    );
+  }
+
+  // Check size (~30 KB limit to avoid oversized payloads).
+  if (Buffer.byteLength(args.analysis_markdown, "utf8") > MARKDOWN_MAX_BYTES) {
+    return toolError(
+      "INVALID_ARGS",
+      `submit_dashboard_analysis: 'analysis_markdown' must be ≤ ${MARKDOWN_MAX_BYTES} bytes.`,
+      ctx,
+    );
+  }
+
+  if (typeof args.brief_summary !== "string" || args.brief_summary.trim().length === 0) {
+    return toolError(
+      "INVALID_ARGS",
+      "submit_dashboard_analysis: 'brief_summary' must be a non-empty string.",
+      ctx,
+    );
+  }
+
+  if (args.brief_summary.length > BRIEF_SUMMARY_MAX) {
+    return toolError(
+      "INVALID_ARGS",
+      `submit_dashboard_analysis: 'brief_summary' must be ≤ ${BRIEF_SUMMARY_MAX} characters.`,
+      ctx,
+    );
+  }
+
+  const sanitizedMarkdown = sanitize(args.analysis_markdown.trim());
+  const sanitizedSummary = sanitize(args.brief_summary.trim());
+
+  ctx.analyzeResult = { markdown: sanitizedMarkdown, summary: sanitizedSummary };
+
+  return toolOk({ ok: true, applied: true });
+}
+
+/**
+ * `submit_weekly_review` — validate review JSON + stage review result.
+ *
+ * The model calls this once at the end of a weekly review task with the full
+ * review JSON object and a brief_summary. Validates against ReviewLlmOutputSchema,
+ * then stages in ctx.reviewResult.
+ */
+export async function handleSubmitWeeklyReview(
+  rawArgs: string,
+  ctx: LlmAgenticContext,
+): Promise<ToolResponseBody> {
+  let args: { review?: unknown; brief_summary?: unknown };
+  try {
+    args = JSON.parse(rawArgs || "{}");
+  } catch {
+    return toolError(
+      "INVALID_ARGS",
+      "submit_weekly_review: arguments must be a JSON object.",
+      ctx,
+    );
+  }
+
+  if (typeof args.review !== "object" || args.review === null || Array.isArray(args.review)) {
+    return toolError(
+      "INVALID_ARGS",
+      "submit_weekly_review: 'review' must be a JSON object.",
+      ctx,
+    );
+  }
+
+  if (typeof args.brief_summary !== "string" || args.brief_summary.trim().length === 0) {
+    return toolError(
+      "INVALID_ARGS",
+      "submit_weekly_review: 'brief_summary' must be a non-empty string.",
+      ctx,
+    );
+  }
+
+  if (args.brief_summary.length > BRIEF_SUMMARY_MAX) {
+    return toolError(
+      "INVALID_ARGS",
+      `submit_weekly_review: 'brief_summary' must be ≤ ${BRIEF_SUMMARY_MAX} characters.`,
+      ctx,
+    );
+  }
+
+  // Validate review against ReviewLlmOutputSchema.
+  const parsed = ReviewLlmOutputSchema.safeParse(args.review);
+  if (!parsed.success) {
+    const errors = parsed.error.issues.map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      return `${path}: ${issue.message}`;
+    });
+    return toolOk({
+      ok: false,
+      errors,
+      hint: "Fix the validation errors above and call submit_weekly_review again with the corrected review JSON.",
+    });
+  }
+
+  const sanitizedSummary = sanitize(args.brief_summary.trim());
+
+  ctx.reviewResult = { content: parsed.data, summary: sanitizedSummary };
+
+  return toolOk({ ok: true, applied: true });
 }
 
 export async function handleGetDashboardAllWidgetStatus(

--- a/dashboard/lib/llm-tools/runner.ts
+++ b/dashboard/lib/llm-tools/runner.ts
@@ -32,6 +32,9 @@ import {
   handleGetDashboardWidgetRawValues,
   handleGetDashboardAllWidgetStatus,
   handleValidateDashboardSpec,
+  handleApplyDashboardModification,
+  handleSubmitDashboardAnalysis,
+  handleSubmitWeeklyReview,
 } from "./handlers/dashboards";
 import type { AgenticModelAdapter, AgenticRunStepInput } from "./runner-types";
 import { CliRunnerError } from "@/lib/llm-provider/cli/errors";
@@ -162,6 +165,12 @@ async function dispatchTool(
       return handleGetDashboardAllWidgetStatus(rawArgs, ctx);
     case "validate_dashboard_spec":
       return handleValidateDashboardSpec(rawArgs, ctx);
+    case "apply_dashboard_modification":
+      return handleApplyDashboardModification(rawArgs, ctx);
+    case "submit_dashboard_analysis":
+      return handleSubmitDashboardAnalysis(rawArgs, ctx);
+    case "submit_weekly_review":
+      return handleSubmitWeeklyReview(rawArgs, ctx);
     default:
       return toolError("UNKNOWN_TOOL", `Unknown tool: ${name}`, ctx);
   }

--- a/dashboard/lib/llm-tools/types.ts
+++ b/dashboard/lib/llm-tools/types.ts
@@ -3,6 +3,8 @@
  */
 
 import type { DashboardCliDriverId, DashboardLlmProviderId } from "@/lib/llm-provider/types";
+import type { DashboardSpec } from "@/lib/schema";
+import type { ReviewLlmOutput } from "@/lib/review-schema";
 
 /** High-level events from the tool loop (UI streaming + server logs). */
 export type AgenticProgressEvent =
@@ -36,6 +38,31 @@ export interface LlmAgenticContext {
   llmProvider?: DashboardLlmProviderId;
   /** When `llmProvider` is `cli`, which driver binary/protocol is used. */
   llmDriver?: DashboardCliDriverId | null;
+
+  // ── Publish-tool side-channel slots ────────────────────────────────────────
+  // These slots are populated by the publish-tool handlers and read by the
+  // route AFTER the agentic loop returns. Handlers MUST only stage results
+  // here — they MUST NOT persist directly to the database (dashboards /
+  // weekly_reviews). The route is the single point of persistence.
+
+  /**
+   * Staged result for the `apply_dashboard_modification` tool.
+   * Set by `handleApplyDashboardModification`; read by the modify route.
+   * The LAST call wins — the route always uses the final value after the loop.
+   */
+  modifyResult?: { spec: DashboardSpec; summary: string } | null;
+
+  /**
+   * Staged result for the `submit_dashboard_analysis` tool.
+   * Set by `handleSubmitDashboardAnalysis`; read by the analyze route.
+   */
+  analyzeResult?: { markdown: string; summary: string } | null;
+
+  /**
+   * Staged result for the `submit_weekly_review` tool.
+   * Set by `handleSubmitWeeklyReview`; read by the review/generate route.
+   */
+  reviewResult?: { content: ReviewLlmOutput; summary: string } | null;
 }
 
 export interface AgenticUsageTotals {

--- a/dashboard/lib/llm.ts
+++ b/dashboard/lib/llm.ts
@@ -304,7 +304,7 @@ export async function modifyDashboard(
       runAgenticChat({
         adapter,
         model,
-        systemPrompt: `${buildModifyPrompt(currentSpec)}\n\n${buildAgenticToolPreamble()}`,
+        systemPrompt: `${buildModifyPrompt(currentSpec, true)}\n\n${buildAgenticToolPreamble()}`,
         userContent: userPrompt,
         ctx: requestCtx,
         temperature: 0.2,
@@ -317,7 +317,8 @@ export async function modifyDashboard(
     return content;
   }
 
-  const systemPrompt = buildModifyPrompt(currentSpec);
+  // Non-agentic path: use legacy prompt (no publish-tool instructions).
+  const systemPrompt = buildModifyPrompt(currentSpec, false);
   return chatText(
     [
       { role: "system", content: systemPrompt },
@@ -424,6 +425,7 @@ export async function analyzeDashboard(
   if (isAgenticToolsEnabled()) {
     const systemPrompt = `${buildAnalyzePrompt(serializedData, action, {
       dashboardId: requestCtx.dashboardId,
+      agenticMode: true,
     })}\n\n${buildAgenticToolPreamble()}`;
     const adapter = createDashboardAgenticAdapter();
     const model = getEffectiveDashboardModel(cfg);
@@ -444,8 +446,10 @@ export async function analyzeDashboard(
     return content;
   }
 
+  // Non-agentic path: use legacy prompt (no publish-tool instructions).
   const systemPrompt = buildAnalyzePrompt(serializedData, action, {
     dashboardId: requestCtx.dashboardId,
+    agenticMode: false,
   });
 
   return chatText(

--- a/dashboard/lib/llm.ts
+++ b/dashboard/lib/llm.ts
@@ -461,8 +461,86 @@ export async function analyzeDashboard(
 }
 
 /**
+ * Generate a weekly business review using the agentic runner so that the
+ * `submit_weekly_review` tool is reachable. The model calls the tool to stage
+ * the review JSON, then emits freeform Spanish prose as its final message.
+ *
+ * Returns `{ content: ReviewLlmOutput; message: string }` where `content` is
+ * the validated review JSON (from ctx.reviewResult) and `message` is the
+ * model's freeform chat reply.
+ *
+ * Throws AgenticRunnerError("AGENTIC_RUNNER", phase "final") if the model
+ * returned final text without calling submit_weekly_review.
+ */
+export async function generateReviewAgentic(
+  systemPrompt: string,
+  opts?: { requestId?: string; onAgenticProgress?: (ev: AgenticProgressEvent) => void },
+): Promise<{ content: ReviewLlmOutput; message: string }> {
+  const requestId = opts?.requestId ?? "req_local";
+
+  await checkDailyBudget();
+
+  const cfg = loadDashboardLlmConfig();
+  // Build a mutable ctx — the side-channel slots start null.
+  const ctx: LlmAgenticContext = attachTelemetry(
+    {
+      requestId,
+      endpoint: "generateReview",
+      onAgenticProgress: opts?.onAgenticProgress,
+      reviewResult: null,
+    },
+    cfg,
+  );
+
+  const adapter = createDashboardAgenticAdapter();
+  const model = getEffectiveDashboardModel(cfg);
+
+  const { content: finalMessage, usage } = await callWithCircuitBreaker(() =>
+    runAgenticChat({
+      adapter,
+      model,
+      systemPrompt,
+      userContent: "Genera la revisión semanal ahora.",
+      ctx,
+      temperature: 0.2,
+      maxTokens: 4096,
+    }),
+  );
+
+  void logUsage("generateReview", model, usage, usageMetaFromCfg(cfg), { requestId });
+
+  // If the model did not call submit_weekly_review, fail loudly.
+  if (!ctx.reviewResult) {
+    throw new AgenticRunnerError(
+      "AGENTIC_RUNNER",
+      "El modelo no llamó a `submit_weekly_review`. El JSON de la revisión debe enviarse a través de la herramienta.",
+      requestId,
+      {
+        phase: "final",
+        toolRoundsUsed: 0,
+        toolCallsUsed: 0,
+        durationMs: 0,
+        limitsAtFailure: {
+          maxRounds: 0,
+          maxToolCalls: 0,
+          toolTimeoutMs: 0,
+          executeRowLimit: 0,
+          payloadCharLimit: 0,
+        },
+      },
+    );
+  }
+
+  return { content: ctx.reviewResult.content, message: finalMessage };
+}
+
+/**
  * Generate a weekly business review from query results (in Spanish), with optional
  * agentic progress callbacks for streaming.
+ *
+ * When agentic tools are enabled, delegates to `generateReviewAgentic` so that
+ * `submit_weekly_review` is reachable. When tools are disabled, falls back to the
+ * single-shot chatText path.
  *
  * Returns the parsed LLM output (validated with Zod). Uses max_tokens: 4096
  * (reviews are shorter than full dashboard specs).
@@ -470,10 +548,14 @@ export async function analyzeDashboard(
 export async function generateReviewWithProgress(
   systemPrompt: string,
   opts?: { requestId?: string; onAgenticProgress?: (ev: AgenticProgressEvent) => void },
-): Promise<ReviewLlmOutput> {
+): Promise<{ content: ReviewLlmOutput; message: string }> {
   const requestId = opts?.requestId ?? "req_local";
 
   await checkDailyBudget();
+
+  if (isAgenticToolsEnabled()) {
+    return generateReviewAgentic(systemPrompt, opts);
+  }
 
   const cfg = loadDashboardLlmConfig();
   const requestCtx = attachTelemetry(
@@ -486,7 +568,7 @@ export async function generateReviewWithProgress(
   );
 
   // Use chatText-with-delta path so model_text_delta events fire.
-  const content = await chatTextWithProgress(
+  const rawContent = await chatTextWithProgress(
     [{ role: "system", content: systemPrompt }],
     0.2,
     4096,
@@ -494,15 +576,15 @@ export async function generateReviewWithProgress(
     requestCtx,
   );
 
-  const fenced = content.match(/```(?:json)?\s*\n?([\s\S]*?)```/);
-  const jsonStr = fenced ? fenced[1].trim() : content.trim();
+  const fenced = rawContent.match(/```(?:json)?\s*\n?([\s\S]*?)```/);
+  const jsonStr = fenced ? fenced[1].trim() : rawContent.trim();
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(jsonStr);
   } catch {
     throw new Error(
-      `LLM returned invalid JSON for review. Raw response: ${content.slice(0, 500)}`,
+      `LLM returned invalid JSON for review. Raw response: ${rawContent.slice(0, 500)}`,
     );
   }
 
@@ -512,7 +594,7 @@ export async function generateReviewWithProgress(
       `LLM returned JSON that does not match ReviewLlmOutputSchema: ${z.error.message}`,
     );
   }
-  return z.data;
+  return { content: z.data, message: "" };
 }
 
 /**
@@ -524,12 +606,16 @@ export async function generateReviewWithProgress(
 export async function generateReview(
   systemPrompt: string,
   opts?: { requestId?: string },
-): Promise<ReviewLlmOutput> {
+): Promise<{ content: ReviewLlmOutput; message: string }> {
   const requestId = opts?.requestId ?? "req_local";
 
   await checkDailyBudget();
 
-  const content = await chatText(
+  if (isAgenticToolsEnabled()) {
+    return generateReviewAgentic(systemPrompt, { requestId });
+  }
+
+  const rawContent = await chatText(
     [{ role: "system", content: systemPrompt }],
     0.2,
     4096,
@@ -537,15 +623,15 @@ export async function generateReview(
     requestId,
   );
 
-  const fenced = content.match(/```(?:json)?\s*\n?([\s\S]*?)```/);
-  const jsonStr = fenced ? fenced[1].trim() : content.trim();
+  const fenced = rawContent.match(/```(?:json)?\s*\n?([\s\S]*?)```/);
+  const jsonStr = fenced ? fenced[1].trim() : rawContent.trim();
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(jsonStr);
   } catch {
     throw new Error(
-      `LLM returned invalid JSON for review. Raw response: ${content.slice(0, 500)}`,
+      `LLM returned invalid JSON for review. Raw response: ${rawContent.slice(0, 500)}`,
     );
   }
 
@@ -555,7 +641,7 @@ export async function generateReview(
       `LLM returned JSON that does not match ReviewLlmOutputSchema: ${z.error.message}`,
     );
   }
-  return z.data;
+  return { content: z.data, message: "" };
 }
 
 /**

--- a/dashboard/lib/llm.ts
+++ b/dashboard/lib/llm.ts
@@ -17,7 +17,7 @@ import {
   getEffectiveDashboardModel,
 } from "./llm-provider/config";
 import type { DashboardLlmConfig } from "./llm-provider/types";
-import { isAgenticToolsEnabled } from "./llm-tools/config";
+import { isAgenticToolsEnabled, getAgenticConfig } from "./llm-tools/config";
 import { runAgenticChat, AgenticRunnerError } from "./llm-tools/runner";
 import type { LlmAgenticContext, AgenticProgressEvent } from "./llm-tools/types";
 import type { LlmUsageProviderMeta } from "./llm-provider/types";
@@ -515,6 +515,7 @@ export async function generateReviewAgentic(
 
   // If the model did not call submit_weekly_review, fail loudly.
   if (!ctx.reviewResult) {
+    const agenticCfg = getAgenticConfig();
     throw new AgenticRunnerError(
       "AGENTIC_RUNNER",
       "El modelo no llamó a `submit_weekly_review`. El JSON de la revisión debe enviarse a través de la herramienta.",
@@ -525,11 +526,11 @@ export async function generateReviewAgentic(
         toolCallsUsed: 0,
         durationMs: 0,
         limitsAtFailure: {
-          maxRounds: 0,
-          maxToolCalls: 0,
-          toolTimeoutMs: 0,
-          executeRowLimit: 0,
-          payloadCharLimit: 0,
+          maxRounds: agenticCfg.maxToolRounds,
+          maxToolCalls: agenticCfg.maxToolCalls,
+          toolTimeoutMs: agenticCfg.toolTimeoutMs,
+          executeRowLimit: agenticCfg.maxRows,
+          payloadCharLimit: agenticCfg.maxResultChars,
         },
       },
     );

--- a/dashboard/lib/prompts.ts
+++ b/dashboard/lib/prompts.ts
@@ -318,6 +318,11 @@ export function buildGeneratePrompt(): string {
 
 /**
  * Instructions appended when the dashboard LLM runs in agentic (tool) mode.
+ *
+ * NOTE: for generate (create-from-scratch) the old contract still applies —
+ * emit the final raw JSON after validate_dashboard_spec passes. The modify,
+ * analyze, and review flows now use publish tools (apply_dashboard_modification,
+ * submit_dashboard_analysis, submit_weekly_review). See the per-flow prompts.
  */
 export function buildAgenticToolPreamble(): string {
   return [
@@ -330,22 +335,21 @@ export function buildAgenticToolPreamble(): string {
     "Rules:",
     "- Only read-only SQL. Never attempt writes.",
     "- Prefer validate_query / explain_query before execute_query.",
-    "- After you finish tool use, respond with ONLY the final artifact required by the task",
-    "  (for generate/modify: raw JSON dashboard spec, no markdown fences; for analyze: markdown analysis).",
+    "- For the **generate** (create-from-scratch) task: after you finish tool use, respond with ONLY",
+    "  the raw JSON dashboard spec (no markdown fences, no explanation).",
+    "- For **modify**, **analyze**, and **review** tasks: use the dedicated publish tool instead of",
+    "  emitting the artifact as your final answer. See the task-specific instructions below.",
     "",
     "## Dashboard spec validation (mandatory for generate and modify)",
     "",
-    "When the task is to produce a dashboard JSON spec (generate or modify), the very last tool",
-    "call before your final answer MUST be `validate_dashboard_spec` with your candidate spec",
-    "as the `spec` argument. The tool returns `{ ok, errors[], warnings[], hint }`:",
+    "When the task is to produce a dashboard JSON spec (generate or modify), you MUST call",
+    "`validate_dashboard_spec` with your candidate spec as the `spec` argument before publishing.",
+    "The tool returns `{ ok, errors[], warnings[], hint }`:",
     "- If `ok` is `false` or `errors[]` is non-empty: fix every error and re-call `validate_dashboard_spec`.",
-    "  Repeat until `ok=true` or you have used the round budget. NEVER emit a final spec while",
-    "  errors are unresolved — the route will reject it as LLM_INVALID_RESPONSE and the user sees a failure.",
-    "- If `warnings[]` is non-empty: fix or, if the warning is a known false positive,",
-    "  proceed to the final answer (warnings do not block emission).",
-    "- Only after a passing `validate_dashboard_spec` call should you emit the final raw JSON.",
-    "",
-    "The final JSON you emit MUST be byte-for-byte the same `spec` object that just validated `ok=true`.",
+    "  Repeat until `ok=true` or you have used the round budget.",
+    "- If `warnings[]` is non-empty: fix or, if the warning is a known false positive, proceed.",
+    "- For **generate**: only after a passing `validate_dashboard_spec` should you emit the final raw JSON.",
+    "- For **modify**: after `validate_dashboard_spec` passes, call `apply_dashboard_modification` (not emit raw JSON).",
   ].join("\n");
 }
 
@@ -358,7 +362,7 @@ export function buildModifyPrompt(currentSpec: string): string {
     "",
     "You are an expert AI dashboard modifier for a Spanish retail and wholesale fashion business (PowerShop).",
     "The user wants to modify an existing dashboard. They will describe the changes they want.",
-    "You must return the COMPLETE updated dashboard JSON — not just the changed parts.",
+    "You must produce the COMPLETE updated dashboard JSON — not just the changed parts.",
     "Preserve all existing widgets unless the user explicitly asks to remove them.",
     "When adding new widgets, continue the id sequence (e.g. if the last widget is w6, the new one is w7).",
     "",
@@ -376,10 +380,23 @@ export function buildModifyPrompt(currentSpec: string): string {
     "3. If the existing spec has no glossary, create one with 5-10 key terms for the full updated dashboard.",
     "4. The 'glossary' field MUST always be present in your response.",
     "",
+    "## Required workflow (MANDATORY)",
+    "",
+    "1. Inspect the current spec and understand what the user wants to change.",
+    "2. Draft the updated spec in your reasoning (with all existing widgets preserved + changes applied).",
+    "3. Call `validate_dashboard_spec` with your candidate spec until `ok=true`.",
+    "4. Call `apply_dashboard_modification` with the validated spec and a 2–4 sentence Spanish",
+    "   `change_summary` describing what you changed.",
+    "5. After `apply_dashboard_modification` returns `{ ok: true, applied: true }`, write your final",
+    "   assistant message as a friendly Spanish reply to the user (≤ 4 sentences) describing what changed.",
+    "",
+    "**Never emit the JSON spec as your final answer.** The spec MUST go through",
+    "`apply_dashboard_modification`. If you emit raw JSON as your final message, the route will",
+    "fail with an error because ctx.modifyResult will be null.",
+    "",
     "## Current Dashboard Spec",
     "",
     "The following is the existing dashboard JSON provided as input context.",
-    "Do not wrap your response in markdown fences; return only the complete updated dashboard as raw JSON.",
     "",
     currentSpec,
     "",

--- a/dashboard/lib/prompts.ts
+++ b/dashboard/lib/prompts.ts
@@ -355,8 +355,36 @@ export function buildAgenticToolPreamble(): string {
 
 /**
  * Build the system prompt for modifying an existing dashboard.
+ *
+ * @param currentSpec - JSON string of the current dashboard spec.
+ * @param agenticMode - When true (default), includes publish-tool workflow
+ *   instructions (apply_dashboard_modification). When false (tools disabled),
+ *   falls back to the legacy "return raw JSON" contract.
  */
-export function buildModifyPrompt(currentSpec: string): string {
+export function buildModifyPrompt(currentSpec: string, agenticMode = true): string {
+  const workflowSection = agenticMode
+    ? [
+        "## Required workflow (MANDATORY)",
+        "",
+        "1. Inspect the current spec and understand what the user wants to change.",
+        "2. Draft the updated spec in your reasoning (with all existing widgets preserved + changes applied).",
+        "3. Call `validate_dashboard_spec` with your candidate spec until `ok=true`.",
+        "4. Call `apply_dashboard_modification` with the validated spec and a 2–4 sentence Spanish",
+        "   `change_summary` describing what you changed.",
+        "5. After `apply_dashboard_modification` returns `{ ok: true, applied: true }`, write your final",
+        "   assistant message as a friendly Spanish reply to the user (≤ 4 sentences) describing what changed.",
+        "",
+        "**Never emit the JSON spec as your final answer.** The spec MUST go through",
+        "`apply_dashboard_modification`. If you emit raw JSON as your final message, the route will",
+        "fail with an error because ctx.modifyResult will be null.",
+      ]
+    : [
+        "## Output",
+        "",
+        "Return the COMPLETE updated dashboard as raw JSON — no markdown fences, no explanation.",
+        "Do not wrap your response in markdown fences; return only the complete updated dashboard as raw JSON.",
+      ];
+
   return [
     "# Role",
     "",
@@ -380,19 +408,7 @@ export function buildModifyPrompt(currentSpec: string): string {
     "3. If the existing spec has no glossary, create one with 5-10 key terms for the full updated dashboard.",
     "4. The 'glossary' field MUST always be present in your response.",
     "",
-    "## Required workflow (MANDATORY)",
-    "",
-    "1. Inspect the current spec and understand what the user wants to change.",
-    "2. Draft the updated spec in your reasoning (with all existing widgets preserved + changes applied).",
-    "3. Call `validate_dashboard_spec` with your candidate spec until `ok=true`.",
-    "4. Call `apply_dashboard_modification` with the validated spec and a 2–4 sentence Spanish",
-    "   `change_summary` describing what you changed.",
-    "5. After `apply_dashboard_modification` returns `{ ok: true, applied: true }`, write your final",
-    "   assistant message as a friendly Spanish reply to the user (≤ 4 sentences) describing what changed.",
-    "",
-    "**Never emit the JSON spec as your final answer.** The spec MUST go through",
-    "`apply_dashboard_modification`. If you emit raw JSON as your final message, the route will",
-    "fail with an error because ctx.modifyResult will be null.",
+    ...workflowSection,
     "",
     "## Current Dashboard Spec",
     "",

--- a/dashboard/lib/review-prompts.ts
+++ b/dashboard/lib/review-prompts.ts
@@ -54,11 +54,11 @@ ${instructionsText}
 Solo puedes referenciar estos nombres exactos en los arrays evidence_queries:
 ${QUERY_NAMES_LIST}
 
-## Formato de salida (v2)
+## Formato de la revisión (v2)
 
 **Resumen Ejecutivo:** corresponde al campo JSON \`executive_summary\` (array de 3 a 5 bullets en español).
 
-Devuelve ÚNICAMENTE un objeto JSON válido (sin markdown, sin texto extra) con esta forma:
+El objeto JSON de la revisión debe tener esta forma:
 
 {
   "executive_summary": ["bullet 1", "bullet 2", "bullet 3"],
@@ -120,6 +120,19 @@ Restricciones:
 - due_date siempre YYYY-MM-DD (fecha objetivo de seguimiento).
 - evidence_queries nunca vacío; solo nombres de la lista permitida.
 - data_quality_notes incluye avisos si faltan datos o una consulta falló (según el bloque de resultados).
+
+## Flujo requerido (OBLIGATORIO)
+
+1. Analiza los datos y construye el objeto JSON de la revisión siguiendo el formato anterior.
+2. Llama a la herramienta \`submit_weekly_review\` con:
+   - \`review\`: el objeto JSON completo de la revisión.
+   - \`brief_summary\`: 1–2 frases en español que resumen las conclusiones principales.
+3. Después de que \`submit_weekly_review\` devuelva \`{ ok: true, applied: true }\`,
+   escribe tu mensaje final como una respuesta amistosa en español al usuario (≤ 4 frases)
+   describiendo las conclusiones clave de la semana.
+
+**Nunca emitas el JSON de la revisión como tu respuesta final.** El JSON DEBE ir a través de
+\`submit_weekly_review\`. Si emites el JSON directamente como texto, el sistema fallará con un error.
 
 ## Datos analizados
 

--- a/dashboard/lib/review-prompts.ts
+++ b/dashboard/lib/review-prompts.ts
@@ -22,11 +22,16 @@ const QUERY_NAMES_LIST = REVIEW_QUERIES.map((q) => q.name).join(", ");
 
 /**
  * Build the system prompt for the weekly review LLM call (strict JSON v2).
+ *
+ * @param agenticMode - When true (default), includes the publish-tool workflow
+ *   (submit_weekly_review). When false, uses the legacy "return raw JSON" contract
+ *   for when DASHBOARD_AGENTIC_TOOLS_ENABLED=false.
  */
 export function buildReviewPrompt(
   queryResults: string,
   reviewedWeekDescription: string,
   generationMode: "initial" | "refresh_data" | "alternate_angle" = "initial",
+  agenticMode = true,
 ): string {
   const instructionsText = formatInstructions(INSTRUCTIONS);
 
@@ -121,7 +126,9 @@ Restricciones:
 - evidence_queries nunca vacío; solo nombres de la lista permitida.
 - data_quality_notes incluye avisos si faltan datos o una consulta falló (según el bloque de resultados).
 
-## Flujo requerido (OBLIGATORIO)
+${
+  agenticMode
+    ? `## Flujo requerido (OBLIGATORIO)
 
 1. Analiza los datos y construye el objeto JSON de la revisión siguiendo el formato anterior.
 2. Llama a la herramienta \`submit_weekly_review\` con:
@@ -132,7 +139,9 @@ Restricciones:
    describiendo las conclusiones clave de la semana.
 
 **Nunca emitas el JSON de la revisión como tu respuesta final.** El JSON DEBE ir a través de
-\`submit_weekly_review\`. Si emites el JSON directamente como texto, el sistema fallará con un error.
+\`submit_weekly_review\`. Si emites el JSON directamente como texto, el sistema fallará con un error.`
+    : `Devuelve ÚNICAMENTE un objeto JSON válido (sin markdown, sin texto extra) con la forma descrita arriba.`
+}
 
 ## Datos analizados
 

--- a/etl/tests/test_trigger.py
+++ b/etl/tests/test_trigger.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock, patch
 if "schedule" not in sys.modules:
     _schedule_stub = types.ModuleType("schedule")
     _schedule_stub.run_pending = MagicMock()  # type: ignore[attr-defined]
+    _schedule_stub.every = MagicMock()  # type: ignore[attr-defined]
     sys.modules["schedule"] = _schedule_stub
 
 
@@ -233,19 +234,20 @@ class TestSchedulerLoopTriggerCheck:
         ):
             import etl.main as main_mod
 
+            config = MagicMock()
             conn_4d, conn_pg = MagicMock(), MagicMock()
             try:
-                main_mod._run_scheduler_loop(conn_4d, conn_pg)
+                main_mod._run_scheduler_loop(config, conn_pg, conn_4d, 2)
             except StopIteration:
                 pass
 
-            mock_sync.assert_called_once_with(
-                conn_4d, conn_pg, trigger="manual", trigger_id=7
-            )
+            mock_sync.assert_any_call(conn_4d, conn_pg, trigger="manual", trigger_id=7)
 
     def test_second_trigger_while_active_is_not_consumed(self):
         """When a run is already active, check_and_consume_trigger is never called
-        so the pending trigger row is preserved for the next poll tick."""
+        so the pending trigger row is preserved for the next poll tick.
+        The startup _job() may call run_full_sync(trigger='scheduled'), but
+        no manual-trigger call should occur."""
         with (
             patch("etl.db.postgres.check_and_consume_trigger") as mock_consume,
             patch("etl.main._is_run_active", return_value=True),
@@ -255,17 +257,24 @@ class TestSchedulerLoopTriggerCheck:
         ):
             import etl.main as main_mod
 
+            config = MagicMock()
             conn_4d, conn_pg = MagicMock(), MagicMock()
             try:
-                main_mod._run_scheduler_loop(conn_4d, conn_pg)
+                main_mod._run_scheduler_loop(config, conn_pg, conn_4d, 2)
             except StopIteration:
                 pass
 
             mock_consume.assert_not_called()
-            mock_sync.assert_not_called()
+            # The loop skips the manual-trigger path while a run is active.
+            # (The startup _job may have fired a scheduled call, but no manual trigger.)
+            for call_args in mock_sync.call_args_list:
+                assert call_args.kwargs.get("trigger") != "manual", (
+                    f"run_full_sync should not be called with trigger='manual', got {call_args}"
+                )
 
     def test_no_trigger_no_manual_run(self):
-        """When check_and_consume_trigger returns None, run_full_sync is not called."""
+        """When check_and_consume_trigger returns None, run_full_sync is not called
+        with a manual trigger (the startup _job may fire a scheduled call)."""
         with (
             patch("etl.db.postgres.check_and_consume_trigger", return_value=None),
             patch("etl.main._is_run_active", return_value=False),
@@ -275,17 +284,21 @@ class TestSchedulerLoopTriggerCheck:
         ):
             import etl.main as main_mod
 
+            config = MagicMock()
             conn_4d, conn_pg = MagicMock(), MagicMock()
             try:
-                main_mod._run_scheduler_loop(conn_4d, conn_pg)
+                main_mod._run_scheduler_loop(config, conn_pg, conn_4d, 2)
             except StopIteration:
                 pass
 
-            mock_sync.assert_not_called()
+            for call_args in mock_sync.call_args_list:
+                assert call_args.kwargs.get("trigger") != "manual", (
+                    f"run_full_sync should not be called with trigger='manual', got {call_args}"
+                )
 
     def test_poll_exception_does_not_crash_loop(self):
         """RISK-TRIG-7: transient DB error in check_and_consume_trigger is logged;
-        the loop continues and run_full_sync is not called."""
+        the loop continues and run_full_sync is not called with a manual trigger."""
         with (
             patch(
                 "etl.db.postgres.check_and_consume_trigger",
@@ -298,13 +311,17 @@ class TestSchedulerLoopTriggerCheck:
         ):
             import etl.main as main_mod
 
+            config = MagicMock()
             conn_4d, conn_pg = MagicMock(), MagicMock()
             try:
-                main_mod._run_scheduler_loop(conn_4d, conn_pg)
+                main_mod._run_scheduler_loop(config, conn_pg, conn_4d, 2)
             except StopIteration:
                 pass
 
-            mock_sync.assert_not_called()
+            for call_args in mock_sync.call_args_list:
+                assert call_args.kwargs.get("trigger") != "manual", (
+                    f"run_full_sync should not be called with trigger='manual', got {call_args}"
+                )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **New tools**: `apply_dashboard_modification`, `submit_dashboard_analysis`, `submit_weekly_review` — the model calls the publish tool with the artifact + a Spanish `change_summary`/`brief_summary`, the tool stages the result in a request-scoped `LlmAgenticContext` side-channel (`modifyResult` / `analyzeResult` / `reviewResult`), and the model's *final assistant text* becomes the chat bubble the user reads.
- **Routes** (`modify`, `analyze`, `review/generate`) read `ctx.modifyResult` / `ctx.analyzeResult` / `ctx.reviewResult` after the agentic loop and fail loudly (`AGENTIC_RUNNER`, phase `final`) if the model didn't call the tool.
- **`generateReview` / `generateReviewWithProgress`** now delegate to the agentic runner when tools are enabled, returning `{ content: ReviewLlmOutput; message: string }` instead of the bare `ReviewLlmOutput`.
- **UI**: `ChatSidebar` renders the freeform `message` as the chat bubble (with a "Cambios aplicados" / "Análisis publicado" chip); `ReviewDisplay` renders an optional "Resumen del modelo" intro. LogBlock close-out reads "Respuesta lista · N chars" (tracking the chat reply, not the spec).
- **NDJSON frames**: additive `message` and `summary` fields — `spec` / `response` / `review` preserved for backward compat.
- **Prompt rewrites**: `buildModifyPrompt`, `buildAnalyzePrompt`, `buildReviewPrompt` all explain the publish-tool contract explicitly ("Never emit the JSON as your final answer").

## Test plan

- [ ] All 1525 vitest unit/integration tests pass (`npx vitest run --no-coverage` from `dashboard/`).
- [ ] `tsc --noEmit` from `dashboard/` clean (only pre-existing sql-formatter TS2307).
- [ ] New handler unit tests: `handleApplyDashboardModification` (5 cases), `handleSubmitDashboardAnalysis` (4 cases), `handleSubmitWeeklyReview` (3 cases).
- [ ] Modify route tests updated to use publish-tool mock pattern; legacy JSON parse path removed.
- [ ] Analyze route tests updated to use `analyzeResult` staging; missing-tool-call path returns 500 AGENTIC_RUNNER.
- [ ] Review streaming route test mock updated to `{ content, message }` shape.
- [ ] Smoke test (manual): modify a dashboard with "Añade un widget de texto", confirm chat bubble + dashboard update + LogBlock. Analyze a dashboard, confirm chat reply + "Análisis publicado" chip. Refresh a weekly review, confirm chat reply + "Resumen del modelo" section.

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)