### PR TITLE
fix(dashboard): force /api/data-health to be dynamic

### DIFF
--- a/dashboard/app/api/data-health/route.ts
+++ b/dashboard/app/api/data-health/route.ts
@@ -18,6 +18,11 @@
 import { NextResponse } from "next/server";
 import { query, ConnectionError } from "@/lib/db";
 
+// Always evaluate per-request — without this, Next.js 14 renders the route
+// statically at build time (when Postgres is unreachable) and serves the empty
+// fallback forever.
+export const dynamic = "force-dynamic";
+
 const STALE_THRESHOLD_HOURS = 36;
 
 export interface TableFreshness {


### PR DESCRIPTION
## Summary

After PR #452 landed, the freshness tooltip in the TopBar was still empty in production. Root cause: Next.js 14 App Router statically pre-renders GET routes that don't opt out, so `/api/data-health` was being captured at Docker build time (when Postgres is unreachable) and returning the `{tables: [], overallStale: false, stalestTable: null}` fallback forever. Verified locally:

- DB has 22 watermark rows.
- Direct `pg` query from inside the dashboard container returns all 22 rows.
- `curl /api/data-health` returns the empty fallback.
- `/api/dashboards` works because it implicitly opts into dynamic rendering through other request features.

Fix: `export const dynamic = "force-dynamic"` in the route.

## Test plan
- [ ] Rebuild dashboard image, hit `/api/data-health` — verify it returns the real watermark rows.
- [ ] Open any page, hover the live-data dot — tooltip shows the real last-sync timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)