### PR TITLE
ETL: hourly delta + nightly full, Tipo column, rows_total_after

### DIFF
--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -404,7 +404,17 @@
   sensitive: false
   default: 2
   section: "ETL"
-  description: "Hora UTC a la que se ejecuta la sincronización ETL nocturna. Solo env var; los cambios en config.yaml se ignoran (etl/main.py lee únicamente ETL_CRON_HOUR del entorno). Requiere reiniciar el contenedor ETL."
+  description: "Hora UTC a la que se ejecuta la sincronización completa nocturna (truncate + insert; refleja borrados duros del 4D). Solo env var; los cambios en config.yaml se ignoran (etl/main.py lee únicamente ETL_CRON_HOUR del entorno). Requiere reiniciar el contenedor ETL."
+  requires_restart: [etl]
+  components: [etl, docker]
+
+- key: etl.delta_cron_minute
+  env: ETL_DELTA_CRON_MINUTE
+  type: int
+  sensitive: false
+  default: 0
+  section: "ETL"
+  description: "Minuto de cada hora en que arranca la sincronización delta (0-59). La completa nocturna también arranca a este minuto en la hora ETL_CRON_HOUR; el firing de delta a esa hora se salta automáticamente al detectar que ya hay run activa. Solo env var. Requiere reiniciar el contenedor ETL."
   requires_restart: [etl]
   components: [etl, docker]
 

--- a/dashboard/app/api/etl/run/route.ts
+++ b/dashboard/app/api/etl/run/route.ts
@@ -34,6 +34,10 @@ const STALE_RUN_HOURS = 4;
 // the dashboard cannot import from Python; add a CI check if these ever
 // drift (see issue #398 for the registry).
 const ALLOWED_FORCE_TABLES: ReadonlySet<string> = new Set([
+  "articulos",
+  "clientes",
+  "ccstock",
+  "facturas",
   "ventas",
   "lineas_ventas",
   "pagos_ventas",

--- a/dashboard/app/api/etl/runs/[id]/route.ts
+++ b/dashboard/app/api/etl/runs/[id]/route.ts
@@ -74,7 +74,8 @@ export async function GET(
   try {
     const runResult = await query(
       `SELECT id, started_at, finished_at, duration_ms, status,
-              total_tables, tables_ok, tables_failed, total_rows_synced, trigger
+              total_tables, tables_ok, tables_failed, total_rows_synced, trigger,
+              kind
        FROM etl_sync_runs
        WHERE id = $1`,
       [id],
@@ -104,6 +105,7 @@ export async function GET(
       tables_failed: r[7] != null ? Number(r[7]) : null,
       total_rows_synced: r[8] != null ? Number(r[8]) : null,
       trigger: String(r[9]),
+      kind: r[10] === "delta" ? "delta" : "full",
     };
 
     const tablesResult = await query(

--- a/dashboard/app/api/etl/runs/route.ts
+++ b/dashboard/app/api/etl/runs/route.ts
@@ -103,7 +103,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     // Get paginated rows
     const runsResult = await query(
       `SELECT id, started_at, finished_at, duration_ms, status,
-              total_tables, tables_ok, tables_failed, total_rows_synced, trigger
+              total_tables, tables_ok, tables_failed, total_rows_synced, trigger,
+              kind
        FROM etl_sync_runs
        ORDER BY started_at DESC
        LIMIT $1 OFFSET $2`,
@@ -121,6 +122,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       tables_failed: row[7] != null ? Number(row[7]) : null,
       total_rows_synced: row[8] != null ? Number(row[8]) : null,
       trigger: String(row[9]),
+      kind: row[10] === "delta" ? "delta" : "full",
     }));
 
     const response: EtlRunsResponse = { runs, total, page, per_page: perPage };

--- a/dashboard/app/api/etl/types.ts
+++ b/dashboard/app/api/etl/types.ts
@@ -1,9 +1,13 @@
+export type EtlRunKind = "delta" | "full";
+
 export interface EtlSyncRun {
   id: number;
   started_at: string;
   finished_at: string | null;
   duration_ms: number | null;
   status: string;
+  /** 'delta' for the hourly watermark sweep, 'full' for the nightly truncate-and-reinsert pass. */
+  kind: EtlRunKind;
   total_tables: number | null;
   tables_ok: number | null;
   tables_failed: number | null;

--- a/dashboard/components/etl/ForceResyncDialog.tsx
+++ b/dashboard/components/etl/ForceResyncDialog.tsx
@@ -17,6 +17,10 @@ export interface ForceResyncOptions {
 // ALLOWED_FORCE_TABLES in /api/etl/run/route.ts.
 export const RESYNCABLE_TABLES: ReadonlyArray<{ name: string; label: string }> =
   [
+    { name: "articulos", label: "Artículos" },
+    { name: "clientes", label: "Clientes" },
+    { name: "ccstock", label: "Stock central (CCStock)" },
+    { name: "facturas", label: "Facturas" },
     { name: "stock", label: "Stock (Exportaciones)" },
     { name: "ventas", label: "Ventas" },
     { name: "lineas_ventas", label: "Líneas de ventas" },

--- a/dashboard/components/etl/RunDetail.tsx
+++ b/dashboard/components/etl/RunDetail.tsx
@@ -10,6 +10,7 @@ export type RunStatus = "success" | "partial" | "failed" | "running";
 export type TableStatus = "success" | "failed" | "running";
 export type SyncMethod = "full_refresh" | "upsert_delta" | "append";
 export type Trigger = "scheduled" | "manual";
+export type RunKind = "delta" | "full";
 
 export interface EtlSyncRun {
   id: number;
@@ -17,6 +18,8 @@ export interface EtlSyncRun {
   finished_at: string | null;
   duration_ms: number | null;
   status: RunStatus;
+  /** 'delta' for the hourly watermark sweep, 'full' for the nightly truncate-and-reinsert pass. */
+  kind: RunKind;
   total_tables: number;
   tables_ok: number;
   tables_failed: number;
@@ -359,6 +362,9 @@ export function RunDetail({ runId }: RunDetailProps) {
               {run.status === "running" ? (
                 <span className="flex items-center gap-1"><span className="h-2 w-2 animate-pulse rounded-full" style={{ background: "var(--accent)" }} />En progreso...</span>
               ) : statusLabel(run.status)}
+            </Badge>
+            <Badge color={run.kind === "delta" ? "blue" : "gray"} data-testid="kind-badge">
+              {run.kind === "delta" ? "Delta" : "Completa"}
             </Badge>
           </div>
           <p className="text-sm text-tremor-content dark:text-dark-tremor-content">

--- a/dashboard/components/etl/RunList.tsx
+++ b/dashboard/components/etl/RunList.tsx
@@ -12,6 +12,8 @@ export interface EtlSyncRun {
   finished_at: string | null;
   duration_ms: number | null;
   status: string;
+  /** 'delta' (hourly watermark sweep) or 'full' (nightly truncate-and-reinsert). */
+  kind: "delta" | "full";
   total_tables: number | null;
   tables_ok: number | null;
   tables_failed: number | null;
@@ -64,6 +66,16 @@ const TRIGGER_LABELS: Record<string, string> = {
 
 function triggerLabel(trigger: string): string {
   return TRIGGER_LABELS[trigger] ?? trigger;
+}
+
+function kindLabel(kind: "delta" | "full"): string {
+  return kind === "delta" ? "Delta" : "Completa";
+}
+
+function kindBadgeColor(kind: "delta" | "full"): BadgeColor {
+  // Delta = blue (cheap, frequent, watermark sweep).
+  // Full  = gray (heavy nightly job; not an alert state, just denser).
+  return kind === "delta" ? "blue" : "gray";
 }
 
 // ─── Loading skeleton ─────────────────────────────────────────────────────────
@@ -122,6 +134,7 @@ export function RunList({ runs, total, page, perPage, loading, onPageChange }: R
           <thead className="bg-tremor-background-muted dark:bg-dark-tremor-background-muted">
             <tr>
               <th className="px-4 py-3 text-left text-xs font-medium text-tremor-content dark:text-dark-tremor-content uppercase tracking-wider">Estado</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-tremor-content dark:text-dark-tremor-content uppercase tracking-wider">Tipo</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-tremor-content dark:text-dark-tremor-content uppercase tracking-wider">Iniciada</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-tremor-content dark:text-dark-tremor-content uppercase tracking-wider">Duración</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-tremor-content dark:text-dark-tremor-content uppercase tracking-wider">Tablas OK / Error</th>
@@ -144,6 +157,13 @@ export function RunList({ runs, total, page, perPage, loading, onPageChange }: R
                   >
                     <Badge color={statusBadgeColor(run.status)} size="xs">
                       {statusLabel(run.status)}
+                    </Badge>
+                  </Link>
+                </td>
+                <td className="px-4 py-3">
+                  <Link href={`/etl/${run.id}`} className="block">
+                    <Badge color={kindBadgeColor(run.kind)} size="xs">
+                      {kindLabel(run.kind)}
                     </Badge>
                   </Link>
                 </td>

--- a/dashboard/components/etl/__tests__/RunDetail.test.tsx
+++ b/dashboard/components/etl/__tests__/RunDetail.test.tsx
@@ -35,6 +35,7 @@ const successRun = {
   tables_failed: 0,
   total_rows_synced: 18500000,
   trigger: "scheduled" as const,
+  kind: "full" as const,
 };
 
 const failedRun = {

--- a/dashboard/components/etl/__tests__/RunList.test.tsx
+++ b/dashboard/components/etl/__tests__/RunList.test.tsx
@@ -19,6 +19,7 @@ function makeRun(overrides: Partial<EtlSyncRun> = {}): EtlSyncRun {
     tables_failed: 0,
     total_rows_synced: 45000,
     trigger: "scheduled",
+    kind: "full",
     ...overrides,
   };
 }

--- a/etl/db/postgres.py
+++ b/etl/db/postgres.py
@@ -383,6 +383,68 @@ def fail_orphan_running_runs(conn) -> int:
         raise
 
 
+# Stable lock-id used by try_acquire_run_lock. PostgreSQL advisory locks
+# take a single bigint; this constant is just a project-scoped magic number
+# (chosen as a CRC32 of "etl_sync_runs" — value is opaque, what matters is
+# that it stays consistent across processes and never collides with any
+# other advisory-lock user in the database).
+RUN_ADVISORY_LOCK_ID = 0x4554_4C53_524E_5F5F  # bigint, fits in PG's lock id
+
+
+def try_acquire_run_lock(conn) -> bool:
+    """Try to grab the project-wide ETL run advisory lock (non-blocking).
+
+    Returns True when the caller is now the sole owner of the lock and is
+    free to call run_full_sync; False when another scheduler instance (or
+    a parallel manual trigger that escaped the _is_run_active check) is
+    already holding it.
+
+    The lock is session-scoped: it auto-releases when this PG connection
+    closes, so a crashed ETL container will release it on its next
+    reconnect — no zombie locks across container restarts.
+
+    Why this exists: _is_run_active() reads etl_sync_runs.status, but
+    create_run is best-effort and may have failed, leaving no row. In that
+    edge case _is_run_active returns False and a second scheduler could
+    start a concurrent run. The advisory lock is independent of the
+    monitoring rows and survives such failures.
+    """
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT pg_try_advisory_lock(%s)", (RUN_ADVISORY_LOCK_ID,))
+            got: bool = bool(cur.fetchone()[0])
+        conn.commit()
+        return got
+    except Exception:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        # If we cannot even check the lock, fail closed so we don't run
+        # twice in parallel. The next scheduler tick will retry.
+        return False
+
+
+def release_run_lock(conn) -> None:
+    """Release the advisory lock acquired by try_acquire_run_lock.
+
+    Safe to call when the lock is not held — pg_advisory_unlock returns
+    false in that case but does not raise. We swallow exceptions because
+    failing to release is recoverable (the lock auto-frees on connection
+    close).
+    """
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT pg_advisory_unlock(%s)", (RUN_ADVISORY_LOCK_ID,))
+            cur.fetchone()
+        conn.commit()
+    except Exception:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+
+
 def create_run(conn, trigger: str, kind: str = "full") -> int:
     """Insert an etl_sync_runs record with status='running' and return its id.
 

--- a/etl/db/postgres.py
+++ b/etl/db/postgres.py
@@ -383,13 +383,22 @@ def fail_orphan_running_runs(conn) -> int:
         raise
 
 
-def create_run(conn, trigger: str) -> int:
-    """Insert an etl_sync_runs record with status='running' and return its id."""
+def create_run(conn, trigger: str, kind: str = "full") -> int:
+    """Insert an etl_sync_runs record with status='running' and return its id.
+
+    `kind` is the run's mode — 'delta' for the hourly watermark-only sweep
+    or 'full' for the nightly everything-pass. Stored as-is so the dashboard
+    can render a Delta/Completa pill without recomputing it from per-table
+    methods.
+    """
+    if kind not in ("delta", "full"):
+        raise ValueError(f"Invalid run kind: {kind!r} (expected 'delta' or 'full')")
     try:
         with conn.cursor() as cur:
             cur.execute(
-                "INSERT INTO etl_sync_runs (trigger, status) VALUES (%s, 'running') RETURNING id",
-                (trigger,),
+                "INSERT INTO etl_sync_runs (trigger, kind, status) "
+                "VALUES (%s, %s, 'running') RETURNING id",
+                (trigger, kind),
             )
             run_id: int = cur.fetchone()[0]
         conn.commit()

--- a/etl/main.py
+++ b/etl/main.py
@@ -50,6 +50,36 @@ def _init_schema(conn_pg) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _get_table_row_estimate(conn_pg, table_name: str) -> int | None:
+    """Return n_live_tup from pg_stat_user_tables for `table_name`.
+
+    Used to populate etl_sync_run_tables.rows_total_after — the dashboard
+    "Total est." column. Reads pg_stat_user_tables instead of COUNT(*) so
+    it's O(1) and never holds a lock on the synced table. The estimate
+    can lag the real total slightly (it's updated by autovacuum/ANALYZE
+    and on pg_stat_get_xact_*), but the column is deliberately labelled
+    "est." in the UI so a small lag is acceptable.
+    """
+    try:
+        with conn_pg.cursor() as cur:
+            cur.execute(
+                "SELECT n_live_tup FROM pg_stat_user_tables WHERE relname = %s",
+                (table_name,),
+            )
+            row = cur.fetchone()
+        conn_pg.rollback()
+        if row is None or row[0] is None:
+            return None
+        return int(row[0])
+    except Exception as exc:
+        logger.debug("rows_total_after lookup failed for %s: %s", table_name, exc)
+        try:
+            conn_pg.rollback()
+        except Exception:
+            pass
+        return None
+
+
 def _run_sync(
     name: str,
     sync_fn,
@@ -57,12 +87,26 @@ def _run_sync(
     conn_pg,
     uses_watermark: bool = False,
     run_id: int | None = None,
+    *,
+    kind: str = "full",
+    target_table: str | None = None,
 ) -> tuple[int, bool]:
     """Run a single sync function with timing, watermark management, and error handling.
 
     Returns (rows_synced, ok).  Errors are logged but do not propagate — the
     caller continues with the next table.  When run_id is provided, calls
     record_table_sync after each table; failures there are also swallowed.
+
+    `kind`:
+      'delta' — pass the stored watermark to the sync fn so it only fetches
+                rows modified since (cheap, no truncate).
+      'full'  — ignore the stored watermark (since=None) so the sync fn
+                does a full reload. The watermark is still updated on
+                completion, so the next delta run picks up correctly.
+      Non-watermark syncs ignore `kind`: they always full-refresh.
+
+    `target_table` is the destination ps_* table; when set, the post-sync
+    n_live_tup estimate is recorded as etl_sync_run_tables.rows_total_after.
     """
     from etl.db.postgres import get_watermark, set_watermark
 
@@ -76,7 +120,7 @@ def _run_sync(
     wm_to: datetime | None = None
     try:
         if uses_watermark:
-            since = get_watermark(conn_pg, name)
+            since = None if kind == "full" else get_watermark(conn_pg, name)
             wm_from = since
             rows = sync_fn(conn_4d, conn_pg, since)
         else:
@@ -98,6 +142,17 @@ def _run_sync(
             logger.error("Failed to write error watermark for %s: %s", name, wm_exc)
         logger.error("%s FAILED duration_ms=%d: %s", name, duration_ms, exc)
 
+    # In a "full" nightly run a watermark-backed sync still does truncate-
+    # and-reinsert (since=None), so log it as full_refresh — not the
+    # incremental upsert label.
+    sync_method = (
+        "upsert_delta" if uses_watermark and kind == "delta" else "full_refresh"
+    )
+
+    rows_total_after: int | None = None
+    if ok and target_table:
+        rows_total_after = _get_table_row_estimate(conn_pg, target_table)
+
     if run_id is not None:
         from etl.db.postgres import record_table_sync
 
@@ -111,7 +166,8 @@ def _run_sync(
                 status="ok" if ok else "failed",
                 started_at=started_at,
                 finished_at=datetime.now(timezone.utc),
-                sync_method="upsert_delta" if uses_watermark else "full_refresh",
+                sync_method=sync_method,
+                rows_total_after=rows_total_after,
                 watermark_from=wm_from,
                 watermark_to=wm_to,
                 error_msg=err,
@@ -234,6 +290,10 @@ def _get_rows_total(conn_pg) -> dict[str, int] | None:
 #      full-refresh anyway, so they are excluded — resetting their watermark
 #      (which does not exist) would be a no-op.
 SYNC_NAMES_WITH_WATERMARK: tuple[str, ...] = (
+    "articulos",
+    "clientes",
+    "ccstock",
+    "facturas",
     "ventas",
     "lineas_ventas",
     "pagos_ventas",
@@ -244,6 +304,35 @@ SYNC_NAMES_WITH_WATERMARK: tuple[str, ...] = (
     "stock",
     "traspasos",
 )
+
+# Map sync name → primary destination ps_* table.  Used to populate
+# etl_sync_run_tables.rows_total_after with a cheap n_live_tup estimate
+# after each sync.  Multi-table syncs (catalogos, stock, traspasos write
+# more than one ps_* table) are intentionally absent — the column would
+# be ambiguous, so it stays NULL for those rows.
+SYNC_TARGET_TABLE: dict[str, str] = {
+    "articulos": "ps_articulos",
+    "tiendas": "ps_tiendas",
+    "clientes": "ps_clientes",
+    "proveedores": "ps_proveedores",
+    "gc_comerciales": "ps_gc_comerciales",
+    "ventas": "ps_ventas",
+    "lineas_ventas": "ps_lineas_ventas",
+    "pagos_ventas": "ps_pagos_ventas",
+    "gc_albaranes": "ps_gc_albaranes",
+    "gc_lin_albarane": "ps_gc_lin_albarane",
+    "gc_facturas": "ps_gc_facturas",
+    "gc_lin_facturas": "ps_gc_lin_facturas",
+    "gc_pedidos": "ps_gc_pedidos",
+    "gc_lin_pedidos": "ps_gc_lin_pedidos",
+    "compras": "ps_compras",
+    "lineas_compras": "ps_lineas_compras",
+    "facturas": "ps_facturas",
+    "albaranes": "ps_albaranes",
+    "facturas_compra": "ps_facturas_compra",
+    "stock": "ps_stock_tienda",
+    "ccstock": "ps_stock_central",
+}
 
 # All sync names, including full-refresh tables. Exposed for the dashboard
 # whitelist so the UI can show every available option.
@@ -303,14 +392,28 @@ def _is_run_active(conn_pg) -> bool:
 
 
 def run_full_sync(
-    conn_4d, conn_pg, trigger: str = "scheduled", trigger_id: int | None = None
+    conn_4d,
+    conn_pg,
+    trigger: str = "scheduled",
+    trigger_id: int | None = None,
+    kind: str = "full",
 ) -> None:
     """Execute all sync tasks in topological order.
+
+    `kind`:
+      'full'  — every module runs; watermark-backed syncs do truncate-and-
+                reinsert (so hard-deletes in 4D are reflected).  Used by
+                the nightly cron and by every manual trigger.
+      'delta' — only watermark-backed syncs run; each fetches FechaModifica
+                > stored_watermark and upserts.  Cheap (~seconds), used by
+                the hourly cron between nightly fulls.
 
     Errors in individual tables are caught and logged; execution continues.
     Monitoring (create_run / record_table_sync / finish_run) is best-effort:
     failures there never abort the data sync.
     """
+    if kind not in ("delta", "full"):
+        raise ValueError(f"Invalid kind: {kind!r} (expected 'delta' or 'full')")
     from etl.db.postgres import (
         create_run,
         finish_run,
@@ -343,7 +446,7 @@ def run_full_sync(
     from etl.sync.stock import sync_stock, sync_traspasos
     from etl.sync.ventas import sync_lineas_ventas, sync_pagos_ventas, sync_ventas
 
-    logger.info("=== Full sync started ===")
+    logger.info("=== %s sync started ===", "Delta" if kind == "delta" else "Full")
     pipeline_start = time.time()
 
     # ------------------------------------------------------------------
@@ -422,7 +525,7 @@ def run_full_sync(
 
     run_id: int | None = None
     try:
-        run_id = create_run(conn_pg, trigger)
+        run_id = create_run(conn_pg, trigger, kind=kind)
     except Exception:
         logger.exception(
             "Monitoring: create_run failed; continuing without run tracking"
@@ -437,9 +540,21 @@ def run_full_sync(
     total_rows = 0
 
     def _s(name, fn, *, wm=False):
+        """Dispatch one sync. In delta runs, non-watermark modules are skipped
+        — they cover catalog/master/full-refresh-only data that doesn't need
+        per-hour refresh and would needlessly wipe + reinsert their tables."""
         nonlocal total_rows
+        if kind == "delta" and not wm:
+            return
         rows, ok = _run_sync(
-            name, fn, conn_4d, conn_pg, uses_watermark=wm, run_id=run_id
+            name,
+            fn,
+            conn_4d,
+            conn_pg,
+            uses_watermark=wm,
+            run_id=run_id,
+            kind=kind,
+            target_table=SYNC_TARGET_TABLE.get(name),
         )
         results.append(ok)
         # Accumulate row counts for etl_sync_runs.total_rows_synced so the
@@ -448,21 +563,22 @@ def run_full_sync(
         total_rows += rows
 
     # ------------------------------------------------------------------
-    # 1. Catalog (full refresh, no watermark)
+    # 1. Catalog (full refresh, no watermark) — full-runs only
     # ------------------------------------------------------------------
     # Load catalogos BEFORE articulos: truncate_and_insert uses TRUNCATE ...
     # CASCADE, and ps_articulos has FKs to all five catalog tables.  If
     # articulos ran first, the next catalog truncate would cascade-wipe it.
     _s("catalogos", _run_sync_catalogos)
-    _s("articulos", sync_articulos)
+    # articulos is delta-capable — runs every hour AND every full-refresh.
+    _s("articulos", sync_articulos, wm=True)
 
     # ------------------------------------------------------------------
-    # 2. Masters (full refresh, no watermark)
+    # 2. Masters
     # ------------------------------------------------------------------
-    _s("tiendas", sync_tiendas)
-    _s("clientes", sync_clientes)
-    _s("proveedores", sync_proveedores)
-    _s("gc_comerciales", sync_gc_comerciales)
+    _s("tiendas", sync_tiendas)  # full-only (51 rows)
+    _s("clientes", sync_clientes, wm=True)  # delta-capable
+    _s("proveedores", sync_proveedores)  # full-only (520 rows)
+    _s("gc_comerciales", sync_gc_comerciales)  # full-only (5 rows)
 
     # ------------------------------------------------------------------
     # 3. Retail sales (delta by FechaModifica) — run before stock (stock is slow)
@@ -478,17 +594,20 @@ def run_full_sync(
     _s("gc_lin_albarane", sync_gc_lin_albarane, wm=True)
     _s("gc_facturas", sync_gc_facturas, wm=True)
     _s("gc_lin_facturas", sync_gc_lin_facturas, wm=True)
-    _s("gc_pedidos", sync_gc_pedidos)
-    _s("gc_lin_pedidos", sync_gc_lin_pedidos)
+    _s("gc_pedidos", sync_gc_pedidos)  # full-only — workflow data, can shrink
+    _s("gc_lin_pedidos", sync_gc_lin_pedidos)  # full-only — same reason
 
     # ------------------------------------------------------------------
-    # 6. Purchasing (full refresh)
+    # 6. Purchasing — facturas is delta-capable; the rest stay full because
+    # the 4D source tables don't expose a FechaModifica field.
     # ------------------------------------------------------------------
-    _s("compras", sync_compras)
-    _s("lineas_compras", sync_lineas_compras)
-    _s("facturas", sync_facturas)
-    _s("albaranes", sync_albaranes)
-    _s("facturas_compra", sync_facturas_compra)
+    _s("compras", sync_compras)  # full-only (no FechaModifica in Compras)
+    _s(
+        "lineas_compras", sync_lineas_compras
+    )  # full-only (CCLineasCompr has only Fecha)
+    _s("facturas", sync_facturas, wm=True)
+    _s("albaranes", sync_albaranes)  # full-only (only FechaRecibido)
+    _s("facturas_compra", sync_facturas_compra)  # full-only (only FechaFactura)
 
     # ------------------------------------------------------------------
     # 7. Stock (delta by FechaModifica) — last because Exportaciones is very slow (2M rows)
@@ -497,9 +616,9 @@ def run_full_sync(
     _s("traspasos", sync_traspasos, wm=True)
 
     # ------------------------------------------------------------------
-    # 7b. CCStock (central warehouse, full refresh) — small table (~41 500 rows)
+    # 7b. CCStock (central warehouse) — delta-capable
     # ------------------------------------------------------------------
-    _s("ccstock", sync_ccstock)
+    _s("ccstock", sync_ccstock, wm=True)
 
     # ------------------------------------------------------------------
     # 8. MA cascade cleanup — remove line-table rows referencing MA articles
@@ -510,16 +629,23 @@ def run_full_sync(
     # This is necessary because line tables use delta/upsert strategies that
     # may have inserted MA-linked rows in previous sync runs before this filter.
     # Failures are logged but do not abort the pipeline (consistent with _run_sync).
-    ma_ok = True
-    try:
-        _cleanup_ma_linked_rows(conn_4d, conn_pg)
-    except Exception:
-        logger.exception("MA cleanup failed; continuing with pipeline completion")
-        ma_ok = False
-    results.append(ma_ok)
+    # Skipped on delta runs: it scans every line-item table and the MA set
+    # only changes on full runs (when ps_articulos is fully reloaded).
+    if kind == "full":
+        ma_ok = True
+        try:
+            _cleanup_ma_linked_rows(conn_4d, conn_pg)
+        except Exception:
+            logger.exception("MA cleanup failed; continuing with pipeline completion")
+            ma_ok = False
+        results.append(ma_ok)
 
     total_ms = int((time.time() - pipeline_start) * 1000)
-    logger.info("=== Full sync completed in %d ms ===", total_ms)
+    logger.info(
+        "=== %s sync completed in %d ms ===",
+        "Delta" if kind == "delta" else "Full",
+        total_ms,
+    )
 
     rows_total = _get_rows_total(conn_pg)
     if rows_total:
@@ -662,9 +788,12 @@ def _record_connection_failure(
     return run_id
 
 
-def _run_scheduler_loop(config, conn_pg, conn_4d, cron_hour: int) -> None:
-    """Blocking scheduler loop: registers the daily job, runs the initial
-    on-startup sync, then polls every 10 s for manual triggers.
+def _run_scheduler_loop(
+    config, conn_pg, conn_4d, cron_hour: int, *, delta_minute: int = 0
+) -> None:
+    """Blocking scheduler loop: registers the hourly delta + nightly full
+    jobs, runs an initial sync on startup, then polls every 10 s for manual
+    triggers.
 
     conn_4d may start as None (4D unreachable at process startup). Both the
     scheduled job and the manual-trigger branch reconnect lazily through this
@@ -680,14 +809,21 @@ def _run_scheduler_loop(config, conn_pg, conn_4d, cron_hour: int) -> None:
 
     from etl.db.postgres import check_and_consume_trigger
 
-    def _job() -> None:
-        """Daily scheduled job. Updates the surrounding scope's conn_4d so
-        the polling branch sees reconnects performed here.
+    def _job(kind: str) -> None:
+        """Scheduled job entry point. Updates the surrounding scope's conn_4d
+        so the polling branch sees reconnects performed here.
 
         Always closes + reopens the 4D connection before the run: the cron
-        fires after ~24 h of idle wait and any socket held across that
+        may fire after a long idle wait and any socket held across that
         window is almost certainly stale (see _refresh_4d_connection)."""
         nonlocal conn_4d
+        # Skip overlapping firings (a delta could land while the previous
+        # full or delta is still running).
+        if _is_run_active(conn_pg):
+            logger.info(
+                "Skipping scheduled %s sync — a run is already in progress", kind
+            )
+            return
         conn_4d, err_msg = _refresh_4d_connection(conn_4d, config)
         if conn_4d is None:
             _record_connection_failure(
@@ -695,10 +831,11 @@ def _run_scheduler_loop(config, conn_pg, conn_4d, cron_hour: int) -> None:
             )
             return
         try:
-            run_full_sync(conn_4d, conn_pg, trigger="scheduled")
+            run_full_sync(conn_4d, conn_pg, trigger="scheduled", kind=kind)
         except Exception:
             logger.exception(
-                "Scheduled run_full_sync raised; dropping 4D connection for retry"
+                "Scheduled %s run_full_sync raised; dropping 4D connection for retry",
+                kind,
             )
             try:
                 conn_4d.close()
@@ -706,11 +843,20 @@ def _run_scheduler_loop(config, conn_pg, conn_4d, cron_hour: int) -> None:
                 pass
             conn_4d = None
 
-    schedule.every().day.at(f"{cron_hour:02d}:00").do(_job)
+    # Nightly full — the heavy pass that catches hard-deletes by truncating
+    # and reinserting the watermark-backed tables. Registered FIRST so when
+    # both jobs are due at the same wall-clock minute (cron_hour:delta_minute),
+    # the schedule library runs this one first; the hourly delta then sees
+    # _is_run_active=True and skips.
+    schedule.every().day.at(f"{cron_hour:02d}:{delta_minute:02d}").do(_job, kind="full")
+    # Hourly delta — at :MM past every hour. At cron_hour:delta_minute the
+    # full has already started, so this firing is a no-op.
+    schedule.every().hour.at(f":{delta_minute:02d}").do(_job, kind="delta")
 
-    # Initial sync at startup so we don't wait until 02:00 the first time.
-    logger.info("Running initial sync on startup ...")
-    _job()
+    # Initial sync at startup so we don't wait an hour the first time. Use a
+    # full sync so the operator gets a clean baseline immediately after deploy.
+    logger.info("Running initial full sync on startup ...")
+    _job(kind="full")
 
     while True:
         schedule.run_pending()
@@ -771,8 +917,18 @@ def main() -> None:
         logger.error("Configuration error: %s", exc)
         sys.exit(1)
 
-    # ETL_CRON_HOUR is env-only; cron schedule changes require container restart.
+    # ETL_CRON_HOUR / ETL_DELTA_CRON_MINUTE are env-only; cron schedule
+    # changes require container restart. cron_hour controls the nightly full;
+    # delta_cron_minute controls the minute-of-hour for the hourly delta
+    # (and also the minute the nightly full fires on cron_hour).
     cron_hour = int(os.environ.get("ETL_CRON_HOUR", "2"))
+    delta_cron_minute = int(os.environ.get("ETL_DELTA_CRON_MINUTE", "0"))
+    if not (0 <= delta_cron_minute <= 59):
+        logger.warning(
+            "ETL_DELTA_CRON_MINUTE=%d out of range; clamping to 0",
+            delta_cron_minute,
+        )
+        delta_cron_minute = 0
 
     from etl.db import postgres
 
@@ -832,10 +988,21 @@ def main() -> None:
 
     try:
         if args.once:
-            run_full_sync(conn_4d, conn_pg, trigger="cli")
+            run_full_sync(conn_4d, conn_pg, trigger="cli", kind="full")
         else:
-            logger.info("Scheduler mode: daily sync at %02d:00", cron_hour)
-            _run_scheduler_loop(config, conn_pg, conn_4d, cron_hour)
+            logger.info(
+                "Scheduler mode: hourly delta at :%02d, nightly full at %02d:%02d",
+                delta_cron_minute,
+                cron_hour,
+                delta_cron_minute,
+            )
+            _run_scheduler_loop(
+                config,
+                conn_pg,
+                conn_4d,
+                cron_hour,
+                delta_minute=delta_cron_minute,
+            )
     finally:
         if conn_4d is not None:
             try:

--- a/etl/main.py
+++ b/etl/main.py
@@ -418,8 +418,24 @@ def run_full_sync(
         create_run,
         finish_run,
         get_trigger_force_flags,
+        release_run_lock,
         reset_watermarks,
+        try_acquire_run_lock,
     )
+
+    # Cross-process exclusion. _is_run_active (row check) can race with
+    # create_run when a manual trigger and a cron firing land close in
+    # time, letting two runs proceed in parallel. The advisory lock is
+    # held inside PG and is independent of any monitoring row, so it is
+    # the authoritative gate. Session-scoped: auto-released on connection
+    # close, so a crashed container leaves no zombie lock.
+    if not try_acquire_run_lock(conn_pg):
+        logger.warning(
+            "Another ETL run is already in progress (advisory lock held) — skipping %s sync",
+            kind,
+        )
+        return
+
     from etl.sync.articulos import sync_articulos
     from etl.sync.compras import (
         sync_albaranes,
@@ -446,242 +462,247 @@ def run_full_sync(
     from etl.sync.stock import sync_stock, sync_traspasos
     from etl.sync.ventas import sync_lineas_ventas, sync_pagos_ventas, sync_ventas
 
-    logger.info("=== %s sync started ===", "Delta" if kind == "delta" else "Full")
-    pipeline_start = time.time()
+    try:
+        logger.info("=== %s sync started ===", "Delta" if kind == "delta" else "Full")
+        pipeline_start = time.time()
 
-    # ------------------------------------------------------------------
-    # Honour manual trigger's force flags BEFORE creating the run, so the
-    # watermark reset happens even if create_run fails downstream. Resetting
-    # watermarks is idempotent and safe: the worst case is one extra pass over
-    # incremental tables on the next sync.
-    # ------------------------------------------------------------------
-    if trigger == "manual" and trigger_id is not None:
-        try:
-            force_full, force_tables, triggered_by = get_trigger_force_flags(
-                conn_pg, trigger_id
-            )
-        except Exception:
-            logger.exception(
-                "Trigger %d: could not read force flags — running incrementally",
-                trigger_id,
-            )
-            force_full, force_tables, triggered_by = False, [], None
-
-        logger.info(
-            "Trigger %d: triggered_by=%r",
-            trigger_id,
-            triggered_by if triggered_by else "unknown",
-        )
-
-        if force_full:
-            logger.warning(
-                "Trigger %d requested force_full=True — clearing ALL watermarks "
-                "for %d tables (this can dramatically increase sync duration)",
-                trigger_id,
-                len(SYNC_NAMES_WITH_WATERMARK),
-            )
+        # ------------------------------------------------------------------
+        # Honour manual trigger's force flags BEFORE creating the run, so the
+        # watermark reset happens even if create_run fails downstream. Resetting
+        # watermarks is idempotent and safe: the worst case is one extra pass over
+        # incremental tables on the next sync.
+        # ------------------------------------------------------------------
+        if trigger == "manual" and trigger_id is not None:
             try:
-                deleted = reset_watermarks(conn_pg, list(SYNC_NAMES_WITH_WATERMARK))
-                logger.info(
-                    "Trigger %d: reset_watermarks(force_full) deleted %d rows",
-                    trigger_id,
-                    deleted,
+                force_full, force_tables, triggered_by = get_trigger_force_flags(
+                    conn_pg, trigger_id
                 )
             except Exception:
                 logger.exception(
-                    "Trigger %d: force_full watermark reset failed; continuing",
+                    "Trigger %d: could not read force flags — running incrementally",
                     trigger_id,
                 )
-        elif force_tables:
-            # Filter to known watermark-backed syncs only. A name absent from
-            # SYNC_NAMES_WITH_WATERMARK is dropped with a warning — API/UI
-            # already validate, this is a defense-in-depth check.
-            valid = [t for t in force_tables if t in SYNC_NAMES_WITH_WATERMARK]
-            unknown = sorted(set(force_tables) - set(valid))
-            if unknown:
+                force_full, force_tables, triggered_by = False, [], None
+
+            logger.info(
+                "Trigger %d: triggered_by=%r",
+                trigger_id,
+                triggered_by if triggered_by else "unknown",
+            )
+
+            if force_full:
                 logger.warning(
-                    "Trigger %d: ignoring unknown force_tables %s (not in registry)",
+                    "Trigger %d requested force_full=True — clearing ALL watermarks "
+                    "for %d tables (this can dramatically increase sync duration)",
                     trigger_id,
-                    unknown,
-                )
-            if valid:
-                logger.info(
-                    "Trigger %d: force_tables=%s — resetting watermarks",
-                    trigger_id,
-                    valid,
+                    len(SYNC_NAMES_WITH_WATERMARK),
                 )
                 try:
-                    deleted = reset_watermarks(conn_pg, valid)
+                    deleted = reset_watermarks(conn_pg, list(SYNC_NAMES_WITH_WATERMARK))
                     logger.info(
-                        "Trigger %d: reset_watermarks deleted %d row(s)",
+                        "Trigger %d: reset_watermarks(force_full) deleted %d rows",
                         trigger_id,
                         deleted,
                     )
                 except Exception:
                     logger.exception(
-                        "Trigger %d: reset_watermarks failed; continuing incrementally",
+                        "Trigger %d: force_full watermark reset failed; continuing",
                         trigger_id,
                     )
+            elif force_tables:
+                # Filter to known watermark-backed syncs only. A name absent from
+                # SYNC_NAMES_WITH_WATERMARK is dropped with a warning — API/UI
+                # already validate, this is a defense-in-depth check.
+                valid = [t for t in force_tables if t in SYNC_NAMES_WITH_WATERMARK]
+                unknown = sorted(set(force_tables) - set(valid))
+                if unknown:
+                    logger.warning(
+                        "Trigger %d: ignoring unknown force_tables %s (not in registry)",
+                        trigger_id,
+                        unknown,
+                    )
+                if valid:
+                    logger.info(
+                        "Trigger %d: force_tables=%s — resetting watermarks",
+                        trigger_id,
+                        valid,
+                    )
+                    try:
+                        deleted = reset_watermarks(conn_pg, valid)
+                        logger.info(
+                            "Trigger %d: reset_watermarks deleted %d row(s)",
+                            trigger_id,
+                            deleted,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Trigger %d: reset_watermarks failed; continuing incrementally",
+                            trigger_id,
+                        )
 
-    run_id: int | None = None
-    try:
-        run_id = create_run(conn_pg, trigger, kind=kind)
-    except Exception:
-        logger.exception(
-            "Monitoring: create_run failed; continuing without run tracking"
-        )
-        if trigger == "manual" and trigger_id is not None:
-            logger.warning(
-                "Manual trigger %d will complete but run_id tracking is unavailable",
-                trigger_id,
-            )
-
-    results: list[bool] = []
-    total_rows = 0
-
-    def _s(name, fn, *, wm=False):
-        """Dispatch one sync. In delta runs, non-watermark modules are skipped
-        — they cover catalog/master/full-refresh-only data that doesn't need
-        per-hour refresh and would needlessly wipe + reinsert their tables."""
-        nonlocal total_rows
-        if kind == "delta" and not wm:
-            return
-        rows, ok = _run_sync(
-            name,
-            fn,
-            conn_4d,
-            conn_pg,
-            uses_watermark=wm,
-            run_id=run_id,
-            kind=kind,
-            target_table=SYNC_TARGET_TABLE.get(name),
-        )
-        results.append(ok)
-        # Accumulate row counts for etl_sync_runs.total_rows_synced so the
-        # Monitor ETL "Filas sincronizadas" KPI reflects the real sum across
-        # all tables. Failures return rows=0, so they do not skew the total.
-        total_rows += rows
-
-    # ------------------------------------------------------------------
-    # 1. Catalog (full refresh, no watermark) — full-runs only
-    # ------------------------------------------------------------------
-    # Load catalogos BEFORE articulos: truncate_and_insert uses TRUNCATE ...
-    # CASCADE, and ps_articulos has FKs to all five catalog tables.  If
-    # articulos ran first, the next catalog truncate would cascade-wipe it.
-    _s("catalogos", _run_sync_catalogos)
-    # articulos is delta-capable — runs every hour AND every full-refresh.
-    _s("articulos", sync_articulos, wm=True)
-
-    # ------------------------------------------------------------------
-    # 2. Masters
-    # ------------------------------------------------------------------
-    _s("tiendas", sync_tiendas)  # full-only (51 rows)
-    _s("clientes", sync_clientes, wm=True)  # delta-capable
-    _s("proveedores", sync_proveedores)  # full-only (520 rows)
-    _s("gc_comerciales", sync_gc_comerciales)  # full-only (5 rows)
-
-    # ------------------------------------------------------------------
-    # 3. Retail sales (delta by FechaModifica) — run before stock (stock is slow)
-    # ------------------------------------------------------------------
-    _s("ventas", sync_ventas, wm=True)
-    _s("lineas_ventas", sync_lineas_ventas, wm=True)
-    _s("pagos_ventas", sync_pagos_ventas, wm=True)
-
-    # ------------------------------------------------------------------
-    # 5. Wholesale (delta by Modifica for headers; full for pedidos lines)
-    # ------------------------------------------------------------------
-    _s("gc_albaranes", sync_gc_albaranes, wm=True)
-    _s("gc_lin_albarane", sync_gc_lin_albarane, wm=True)
-    _s("gc_facturas", sync_gc_facturas, wm=True)
-    _s("gc_lin_facturas", sync_gc_lin_facturas, wm=True)
-    _s("gc_pedidos", sync_gc_pedidos)  # full-only — workflow data, can shrink
-    _s("gc_lin_pedidos", sync_gc_lin_pedidos)  # full-only — same reason
-
-    # ------------------------------------------------------------------
-    # 6. Purchasing — facturas is delta-capable; the rest stay full because
-    # the 4D source tables don't expose a FechaModifica field.
-    # ------------------------------------------------------------------
-    _s("compras", sync_compras)  # full-only (no FechaModifica in Compras)
-    _s(
-        "lineas_compras", sync_lineas_compras
-    )  # full-only (CCLineasCompr has only Fecha)
-    _s("facturas", sync_facturas, wm=True)
-    _s("albaranes", sync_albaranes)  # full-only (only FechaRecibido)
-    _s("facturas_compra", sync_facturas_compra)  # full-only (only FechaFactura)
-
-    # ------------------------------------------------------------------
-    # 7. Stock (delta by FechaModifica) — last because Exportaciones is very slow (2M rows)
-    # ------------------------------------------------------------------
-    _s("stock", sync_stock, wm=True)
-    _s("traspasos", sync_traspasos, wm=True)
-
-    # ------------------------------------------------------------------
-    # 7b. CCStock (central warehouse) — delta-capable
-    # ------------------------------------------------------------------
-    _s("ccstock", sync_ccstock, wm=True)
-
-    # ------------------------------------------------------------------
-    # 8. MA cascade cleanup — remove line-table rows referencing MA articles
-    # ------------------------------------------------------------------
-    # MA articles (CCRefeJOFACM starting with 'MA') are excluded from
-    # ps_articulos at the source query level.  Here we cascade that exclusion
-    # to line-item tables whose rows reference MA article codes via `codigo`.
-    # This is necessary because line tables use delta/upsert strategies that
-    # may have inserted MA-linked rows in previous sync runs before this filter.
-    # Failures are logged but do not abort the pipeline (consistent with _run_sync).
-    # Skipped on delta runs: it scans every line-item table and the MA set
-    # only changes on full runs (when ps_articulos is fully reloaded).
-    if kind == "full":
-        ma_ok = True
+        run_id: int | None = None
         try:
-            _cleanup_ma_linked_rows(conn_4d, conn_pg)
+            run_id = create_run(conn_pg, trigger, kind=kind)
         except Exception:
-            logger.exception("MA cleanup failed; continuing with pipeline completion")
-            ma_ok = False
-        results.append(ma_ok)
+            logger.exception(
+                "Monitoring: create_run failed; continuing without run tracking"
+            )
+            if trigger == "manual" and trigger_id is not None:
+                logger.warning(
+                    "Manual trigger %d will complete but run_id tracking is unavailable",
+                    trigger_id,
+                )
 
-    total_ms = int((time.time() - pipeline_start) * 1000)
-    logger.info(
-        "=== %s sync completed in %d ms ===",
-        "Delta" if kind == "delta" else "Full",
-        total_ms,
-    )
+        results: list[bool] = []
+        total_rows = 0
 
-    rows_total = _get_rows_total(conn_pg)
-    if rows_total:
-        logger.info("Post-sync row totals: %s", rows_total)
-
-    if run_id is not None:
-        tables_ok = sum(results)
-        tables_failed = len(results) - tables_ok
-        # Three buckets so the dashboard can distinguish "everything broke"
-        # (typically a 4D-side outage or a stale connection) from a real
-        # partial run where some tables landed and others didn't.
-        if tables_failed == 0:
-            status = "success"
-        elif tables_ok == 0:
-            status = "failed"
-        else:
-            status = "partial"
-        try:
-            finish_run(
+        def _s(name, fn, *, wm=False):
+            """Dispatch one sync. In delta runs, non-watermark modules are skipped
+            — they cover catalog/master/full-refresh-only data that doesn't need
+            per-hour refresh and would needlessly wipe + reinsert their tables."""
+            nonlocal total_rows
+            if kind == "delta" and not wm:
+                return
+            rows, ok = _run_sync(
+                name,
+                fn,
+                conn_4d,
                 conn_pg,
-                run_id,
-                status,
-                tables_ok,
-                tables_failed,
-                total_rows_synced=total_rows,
+                uses_watermark=wm,
+                run_id=run_id,
+                kind=kind,
+                target_table=SYNC_TARGET_TABLE.get(name),
             )
-        except Exception:
-            logger.exception("Monitoring: finish_run failed")
+            results.append(ok)
+            # Accumulate row counts for etl_sync_runs.total_rows_synced so the
+            # Monitor ETL "Filas sincronizadas" KPI reflects the real sum across
+            # all tables. Failures return rows=0, so they do not skew the total.
+            total_rows += rows
 
-        if trigger == "manual" and trigger_id is not None:
-            from etl.db.postgres import update_trigger_run_id
+        # ------------------------------------------------------------------
+        # 1. Catalog (full refresh, no watermark) — full-runs only
+        # ------------------------------------------------------------------
+        # Load catalogos BEFORE articulos: truncate_and_insert uses TRUNCATE ...
+        # CASCADE, and ps_articulos has FKs to all five catalog tables.  If
+        # articulos ran first, the next catalog truncate would cascade-wipe it.
+        _s("catalogos", _run_sync_catalogos)
+        # articulos is delta-capable — runs every hour AND every full-refresh.
+        _s("articulos", sync_articulos, wm=True)
 
+        # ------------------------------------------------------------------
+        # 2. Masters
+        # ------------------------------------------------------------------
+        _s("tiendas", sync_tiendas)  # full-only (51 rows)
+        _s("clientes", sync_clientes, wm=True)  # delta-capable
+        _s("proveedores", sync_proveedores)  # full-only (520 rows)
+        _s("gc_comerciales", sync_gc_comerciales)  # full-only (5 rows)
+
+        # ------------------------------------------------------------------
+        # 3. Retail sales (delta by FechaModifica) — run before stock (stock is slow)
+        # ------------------------------------------------------------------
+        _s("ventas", sync_ventas, wm=True)
+        _s("lineas_ventas", sync_lineas_ventas, wm=True)
+        _s("pagos_ventas", sync_pagos_ventas, wm=True)
+
+        # ------------------------------------------------------------------
+        # 5. Wholesale (delta by Modifica for headers; full for pedidos lines)
+        # ------------------------------------------------------------------
+        _s("gc_albaranes", sync_gc_albaranes, wm=True)
+        _s("gc_lin_albarane", sync_gc_lin_albarane, wm=True)
+        _s("gc_facturas", sync_gc_facturas, wm=True)
+        _s("gc_lin_facturas", sync_gc_lin_facturas, wm=True)
+        _s("gc_pedidos", sync_gc_pedidos)  # full-only — workflow data, can shrink
+        _s("gc_lin_pedidos", sync_gc_lin_pedidos)  # full-only — same reason
+
+        # ------------------------------------------------------------------
+        # 6. Purchasing — facturas is delta-capable; the rest stay full because
+        # the 4D source tables don't expose a FechaModifica field.
+        # ------------------------------------------------------------------
+        _s("compras", sync_compras)  # full-only (no FechaModifica in Compras)
+        _s(
+            "lineas_compras", sync_lineas_compras
+        )  # full-only (CCLineasCompr has only Fecha)
+        _s("facturas", sync_facturas, wm=True)
+        _s("albaranes", sync_albaranes)  # full-only (only FechaRecibido)
+        _s("facturas_compra", sync_facturas_compra)  # full-only (only FechaFactura)
+
+        # ------------------------------------------------------------------
+        # 7. Stock (delta by FechaModifica) — last because Exportaciones is very slow (2M rows)
+        # ------------------------------------------------------------------
+        _s("stock", sync_stock, wm=True)
+        _s("traspasos", sync_traspasos, wm=True)
+
+        # ------------------------------------------------------------------
+        # 7b. CCStock (central warehouse) — delta-capable
+        # ------------------------------------------------------------------
+        _s("ccstock", sync_ccstock, wm=True)
+
+        # ------------------------------------------------------------------
+        # 8. MA cascade cleanup — remove line-table rows referencing MA articles
+        # ------------------------------------------------------------------
+        # MA articles (CCRefeJOFACM starting with 'MA') are excluded from
+        # ps_articulos at the source query level.  Here we cascade that exclusion
+        # to line-item tables whose rows reference MA article codes via `codigo`.
+        # This is necessary because line tables use delta/upsert strategies that
+        # may have inserted MA-linked rows in previous sync runs before this filter.
+        # Failures are logged but do not abort the pipeline (consistent with _run_sync).
+        # Skipped on delta runs: it scans every line-item table and the MA set
+        # only changes on full runs (when ps_articulos is fully reloaded).
+        if kind == "full":
+            ma_ok = True
             try:
-                update_trigger_run_id(conn_pg, trigger_id, run_id)
+                _cleanup_ma_linked_rows(conn_4d, conn_pg)
             except Exception:
-                logger.warning("Could not update trigger run_id — non-fatal")
+                logger.exception(
+                    "MA cleanup failed; continuing with pipeline completion"
+                )
+                ma_ok = False
+            results.append(ma_ok)
+
+        total_ms = int((time.time() - pipeline_start) * 1000)
+        logger.info(
+            "=== %s sync completed in %d ms ===",
+            "Delta" if kind == "delta" else "Full",
+            total_ms,
+        )
+
+        rows_total = _get_rows_total(conn_pg)
+        if rows_total:
+            logger.info("Post-sync row totals: %s", rows_total)
+
+        if run_id is not None:
+            tables_ok = sum(results)
+            tables_failed = len(results) - tables_ok
+            # Three buckets so the dashboard can distinguish "everything broke"
+            # (typically a 4D-side outage or a stale connection) from a real
+            # partial run where some tables landed and others didn't.
+            if tables_failed == 0:
+                status = "success"
+            elif tables_ok == 0:
+                status = "failed"
+            else:
+                status = "partial"
+            try:
+                finish_run(
+                    conn_pg,
+                    run_id,
+                    status,
+                    tables_ok,
+                    tables_failed,
+                    total_rows_synced=total_rows,
+                )
+            except Exception:
+                logger.exception("Monitoring: finish_run failed")
+
+            if trigger == "manual" and trigger_id is not None:
+                from etl.db.postgres import update_trigger_run_id
+
+                try:
+                    update_trigger_run_id(conn_pg, trigger_id, run_id)
+                except Exception:
+                    logger.warning("Could not update trigger run_id — non-fatal")
+    finally:
+        release_run_lock(conn_pg)
 
 
 # ---------------------------------------------------------------------------
@@ -824,6 +845,21 @@ def _run_scheduler_loop(
                 "Skipping scheduled %s sync — a run is already in progress", kind
             )
             return
+        # Avoid the back-to-back full+delta pair at the nightly minute. Both
+        # jobs are due at cron_hour:delta_minute; the daily full runs first
+        # and finishes (clearing _is_run_active) BEFORE the delta job in the
+        # same run_pending tick fires. The original "register full first"
+        # comment was wrong — schedule.run_pending dispatches sequentially.
+        # Drop the colliding delta explicitly.
+        if kind == "delta":
+            now = datetime.now(timezone.utc)
+            if now.hour == cron_hour and now.minute == delta_minute:
+                logger.info(
+                    "Skipping delta at %02d:%02d — daily full just ran in this slot",
+                    cron_hour,
+                    delta_minute,
+                )
+                return
         conn_4d, err_msg = _refresh_4d_connection(conn_4d, config)
         if conn_4d is None:
             _record_connection_failure(
@@ -844,13 +880,11 @@ def _run_scheduler_loop(
             conn_4d = None
 
     # Nightly full — the heavy pass that catches hard-deletes by truncating
-    # and reinserting the watermark-backed tables. Registered FIRST so when
-    # both jobs are due at the same wall-clock minute (cron_hour:delta_minute),
-    # the schedule library runs this one first; the hourly delta then sees
-    # _is_run_active=True and skips.
+    # and reinserting the watermark-backed tables.
     schedule.every().day.at(f"{cron_hour:02d}:{delta_minute:02d}").do(_job, kind="full")
-    # Hourly delta — at :MM past every hour. At cron_hour:delta_minute the
-    # full has already started, so this firing is a no-op.
+    # Hourly delta — at :MM past every hour. At the cron_hour:delta_minute
+    # slot both jobs are due; the explicit wall-clock guard inside _job
+    # drops this one so we don't get a full+delta pair in the same tick.
     schedule.every().hour.at(f":{delta_minute:02d}").do(_job, kind="delta")
 
     # Initial sync at startup so we don't wait an hour the first time. Use a

--- a/etl/schema/init.sql
+++ b/etl/schema/init.sql
@@ -598,6 +598,10 @@ CREATE TABLE IF NOT EXISTS etl_sync_runs (
     finished_at       TIMESTAMPTZ,
     duration_ms       INTEGER,
     status            TEXT         NOT NULL DEFAULT 'running',
+    -- 'delta' (hourly, only watermark-driven syncs) vs 'full' (nightly,
+    -- every module including the truncate-only ones). Pre-existing rows
+    -- are backfilled to 'full' since that was the only mode before.
+    kind              TEXT         NOT NULL DEFAULT 'full',
     tables_ok         INTEGER,
     tables_failed     INTEGER,
     total_tables      INTEGER,
@@ -605,6 +609,7 @@ CREATE TABLE IF NOT EXISTS etl_sync_runs (
 );
 
 ALTER TABLE etl_sync_runs ADD COLUMN IF NOT EXISTS total_tables INTEGER;
+ALTER TABLE etl_sync_runs ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'full';
 
 CREATE TABLE IF NOT EXISTS etl_sync_run_tables (
     id               SERIAL       PRIMARY KEY,

--- a/etl/sync/articulos.py
+++ b/etl/sync/articulos.py
@@ -252,47 +252,58 @@ def get_ma_article_codes(conn_4d: Any) -> set[str]:
     return {r["codigo"] for r in rows if r.get("codigo")}
 
 
-def sync_articulos(conn_4d: Any, conn_pg: Any) -> int:
-    """Full-refresh ps_articulos from the 4D Articulos table.
+def sync_articulos(conn_4d: Any, conn_pg: Any, since: Any = None) -> int:
+    """Sync ps_articulos from the 4D Articulos table.
+
+    Two modes:
+      since=None  → full refresh (TRUNCATE + INSERT). Used by the nightly
+                    cron and any manual force_full trigger; catches hard-
+                    deletes in 4D since the table is fully reloaded.
+      since=date  → delta upsert (WHERE FechaModifica > since, ON CONFLICT
+                    (reg_articulo) DO UPDATE). Used by the hourly cron.
+                    Hard-deletes are not reflected, but the nightly full
+                    pass takes care of those.
 
     MA-prefix articles (CCRefeJOFACM starting with 'MA') are excluded at the
-    source query level.  Any MA rows left over from previous syncs are also
-    deleted after the truncate+insert to ensure a clean state.
-
-    Args:
-        conn_4d: An open p4d connection.
-        conn_pg: An open psycopg2 connection.
-
-    Returns:
-        Number of rows loaded into ps_articulos.
+    source query level in both modes.  In full mode an extra safety-net
+    DELETE removes any stragglers from before the WHERE filter existed.
     """
     from etl.db.fourd import safe_fetch
-    from etl.db.postgres import truncate_and_insert
+    from etl.db.postgres import truncate_and_insert, upsert
 
-    raw_rows = safe_fetch(conn_4d, _SQL_ARTICULOS)
+    if since is None:
+        sql = _SQL_ARTICULOS
+    else:
+        date_str = since.strftime("%Y-%m-%d")
+        sql = f"{_SQL_ARTICULOS} AND FechaModifica > {{d '{date_str}'}}"
+
+    raw_rows = safe_fetch(conn_4d, sql)
     pg_rows = [_nullify_zero_fks(_map_row(r, _ARTICULOS_MAPPING)) for r in raw_rows]
-    count = truncate_and_insert(conn_pg, "ps_articulos", pg_rows)
 
-    # Safety net: remove any MA rows that survived from a previous sync run
-    # before this filter was applied.  truncate_and_insert already wipes the
-    # table, so in practice this is a no-op after the first clean run.
-    # This DELETE runs in a separate transaction from the truncate+insert above,
-    # which already committed.  A failure here does NOT undo the loaded data;
-    # we log a warning and continue rather than raising, since ps_articulos is
-    # already in a valid (MA-free) state thanks to the WHERE clause in the
-    # source query.
-    try:
-        with conn_pg.cursor() as cur:
-            cur.execute("DELETE FROM ps_articulos WHERE LEFT(ccrefejofacm, 2) = 'MA'")
-        conn_pg.commit()
-    except Exception as exc:
-        conn_pg.rollback()
-        logger.warning(
-            "sync_articulos: safety-net DELETE failed (data already loaded cleanly): %s",
-            exc,
-        )
+    if since is None:
+        count = truncate_and_insert(conn_pg, "ps_articulos", pg_rows)
+        # Safety net: drop any pre-WHERE-filter MA rows that may have
+        # survived. After the first clean run this is a no-op. The DELETE
+        # runs in its own transaction; failure here does NOT undo the
+        # loaded data — the source-query WHERE already keeps MA out.
+        try:
+            with conn_pg.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM ps_articulos WHERE LEFT(ccrefejofacm, 2) = 'MA'"
+                )
+            conn_pg.commit()
+        except Exception as exc:
+            conn_pg.rollback()
+            logger.warning(
+                "sync_articulos: safety-net DELETE failed "
+                "(data already loaded cleanly): %s",
+                exc,
+            )
+        return count
 
-    return count
+    if not pg_rows:
+        return 0
+    return upsert(conn_pg, "ps_articulos", pg_rows, pk_cols=["reg_articulo"])
 
 
 def sync_catalogos(conn_4d: Any, conn_pg: Any) -> dict[str, int]:

--- a/etl/sync/articulos.py
+++ b/etl/sync/articulos.py
@@ -274,8 +274,13 @@ def sync_articulos(conn_4d: Any, conn_pg: Any, since: Any = None) -> int:
     if since is None:
         sql = _SQL_ARTICULOS
     else:
+        # `>=` not `>`: 4D's FechaModifica is a date-only field. With strict
+        # `>` once the watermark advances to today, same-day updates with
+        # FechaModifica == today are silently skipped until tomorrow. `>=`
+        # re-fetches every row already touched today; upsert is idempotent
+        # so the only cost is one extra UPDATE per untouched row.
         date_str = since.strftime("%Y-%m-%d")
-        sql = f"{_SQL_ARTICULOS} AND FechaModifica > {{d '{date_str}'}}"
+        sql = f"{_SQL_ARTICULOS} AND FechaModifica >= {{d '{date_str}'}}"
 
     raw_rows = safe_fetch(conn_4d, sql)
     pg_rows = [_nullify_zero_fks(_map_row(r, _ARTICULOS_MAPPING)) for r in raw_rows]

--- a/etl/sync/ccstock.py
+++ b/etl/sync/ccstock.py
@@ -37,7 +37,7 @@ from decimal import ROUND_HALF_UP, Decimal
 from typing import Any
 
 from etl.db.fourd import decode_signed_int16_word, safe_fetch
-from etl.db.postgres import truncate_and_insert
+from etl.db.postgres import truncate_and_insert, upsert
 
 logger = logging.getLogger(__name__)
 
@@ -91,23 +91,23 @@ def _map_ccstock_row(src: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
-def sync_ccstock(conn_4d: Any, conn_pg: Any) -> int:
-    """Full-refresh ps_stock_central from the 4D CCStock table.
+def sync_ccstock(conn_4d: Any, conn_pg: Any, since: Any = None) -> int:
+    """Sync ps_stock_central from the 4D CCStock table.
 
-    Fetches all rows from CCStock, decodes the 34 signed-int16 stock slots
-    per row (applying decode_signed_int16_word — same as Exportaciones), sums
-    them into a single ``stock`` integer, and bulk-inserts into
-    ps_stock_central via truncate_and_insert.
-
-    Args:
-        conn_4d: An open p4d connection.
-        conn_pg: An open psycopg2 connection.
-
-    Returns:
-        Number of rows loaded into ps_stock_central.
+    since=None  → full refresh (TRUNCATE + INSERT). Catches articles
+                  removed from the central warehouse.
+    since=date  → delta upsert (WHERE FechaModifica > since). The hourly
+                  delta cron uses this; the nightly full pass cleans up.
     """
-    sql = f"SELECT {_CCSTOCK_COLUMNS} FROM CCStock"
-    logger.info("sync_ccstock: fetching all rows from CCStock ...")
+    where = ""
+    if since is not None:
+        date_str = since.strftime("%Y-%m-%d")
+        where = f" WHERE FechaModifica > {{d '{date_str}'}}"
+    sql = f"SELECT {_CCSTOCK_COLUMNS} FROM CCStock{where}"
+    logger.info(
+        "sync_ccstock: fetching %s rows from CCStock ...",
+        "delta" if since is not None else "all",
+    )
 
     raw_rows = safe_fetch(conn_4d, sql)
     logger.info("sync_ccstock: fetched %d source rows", len(raw_rows))
@@ -126,6 +126,13 @@ def sync_ccstock(conn_4d: Any, conn_pg: Any) -> int:
             "sync_ccstock: skipped %d rows with missing/zero NumArticulo", skipped
         )
 
-    count = truncate_and_insert(conn_pg, "ps_stock_central", pg_rows)
-    logger.info("sync_ccstock: inserted %d rows into ps_stock_central", count)
+    if since is None:
+        count = truncate_and_insert(conn_pg, "ps_stock_central", pg_rows)
+        logger.info("sync_ccstock: inserted %d rows into ps_stock_central", count)
+        return count
+
+    if not pg_rows:
+        return 0
+    count = upsert(conn_pg, "ps_stock_central", pg_rows, pk_cols=["num_articulo"])
+    logger.info("sync_ccstock: upserted %d rows into ps_stock_central", count)
     return count

--- a/etl/sync/ccstock.py
+++ b/etl/sync/ccstock.py
@@ -101,8 +101,12 @@ def sync_ccstock(conn_4d: Any, conn_pg: Any, since: Any = None) -> int:
     """
     where = ""
     if since is not None:
+        # `>=` not `>`: FechaModifica is date-only (DATA_TYPE=8). Strict `>`
+        # would silently skip same-day updates once the watermark advances
+        # to today. Upsert is idempotent so re-fetching today's rows is
+        # harmless.
         date_str = since.strftime("%Y-%m-%d")
-        where = f" WHERE FechaModifica > {{d '{date_str}'}}"
+        where = f" WHERE FechaModifica >= {{d '{date_str}'}}"
     sql = f"SELECT {_CCSTOCK_COLUMNS} FROM CCStock{where}"
     logger.info(
         "sync_ccstock: fetching %s rows from CCStock ...",

--- a/etl/sync/compras.py
+++ b/etl/sync/compras.py
@@ -261,8 +261,11 @@ def sync_facturas(conn_4d: Any, conn_pg: Any, since: Any = None) -> int:
                 "sync_facturas: delta requested but FechaModifica missing — falling back to full refresh"
             )
         else:
+            # `>=` not `>`: FechaModifica is date-only; strict `>` would
+            # silently skip same-day updates once the watermark advances.
+            # Upsert is idempotent so re-fetching today's rows is harmless.
             date_str = since.strftime("%Y-%m-%d")
-            where = f" WHERE FechaModifica > {{d '{date_str}'}}"
+            where = f" WHERE FechaModifica >= {{d '{date_str}'}}"
 
     sql = (
         "SELECT " + ", ".join(orig_case[k] for k in selected) + " FROM Facturas" + where

--- a/etl/sync/compras.py
+++ b/etl/sync/compras.py
@@ -39,8 +39,11 @@ FK link to ps_compras and ps_proveedores.
 
 from __future__ import annotations
 
+import logging
 from decimal import Decimal
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -223,21 +226,14 @@ def sync_lineas_compras(conn_4d: Any, conn_pg: Any) -> int:
     return truncate_and_insert(conn_pg, "ps_lineas_compras", pg_rows)
 
 
-def sync_facturas(conn_4d: Any, conn_pg: Any) -> int:
-    """Full-refresh ps_facturas from the 4D Facturas table.
+def sync_facturas(conn_4d: Any, conn_pg: Any, since: Any = None) -> int:
+    """Sync ps_facturas from the 4D Facturas table.
 
-    Verifies PK column existence and uses get_queryable_columns to avoid
-    type-0 column errors.
-
-    Args:
-        conn_4d: An open p4d connection.
-        conn_pg: An open psycopg2 connection.
-
-    Returns:
-        Number of rows loaded into ps_facturas.
+    since=None  → full refresh (TRUNCATE + INSERT). Catches hard-deletes.
+    since=date  → delta upsert (WHERE FechaModifica > since).
     """
     from etl.db.fourd import get_queryable_columns, safe_fetch
-    from etl.db.postgres import truncate_and_insert
+    from etl.db.postgres import truncate_and_insert, upsert
 
     # Verify PK
     pk_check = safe_fetch(
@@ -257,11 +253,30 @@ def sync_facturas(conn_4d: Any, conn_pg: Any) -> int:
 
     cols_map = {k: v for k, v in _FACTURAS_MAPPING.items() if k in queryable_lower}
     selected = [k for k in _FACTURAS_MAPPING if k in queryable_lower]
-    sql = "SELECT " + ", ".join(orig_case[k] for k in selected) + " FROM Facturas"
+
+    where = ""
+    if since is not None:
+        if "fechamodifica" not in queryable_lower:
+            logger.warning(
+                "sync_facturas: delta requested but FechaModifica missing — falling back to full refresh"
+            )
+        else:
+            date_str = since.strftime("%Y-%m-%d")
+            where = f" WHERE FechaModifica > {{d '{date_str}'}}"
+
+    sql = (
+        "SELECT " + ", ".join(orig_case[k] for k in selected) + " FROM Facturas" + where
+    )
 
     raw_rows = safe_fetch(conn_4d, sql)
     pg_rows = [_map_row(r, cols_map) for r in raw_rows]
-    return truncate_and_insert(conn_pg, "ps_facturas", pg_rows)
+
+    if since is None or not where:
+        return truncate_and_insert(conn_pg, "ps_facturas", pg_rows)
+
+    if not pg_rows:
+        return 0
+    return upsert(conn_pg, "ps_facturas", pg_rows, pk_cols=["reg_factura"])
 
 
 def sync_albaranes(conn_4d: Any, conn_pg: Any) -> int:

--- a/etl/sync/maestros.py
+++ b/etl/sync/maestros.py
@@ -123,11 +123,17 @@ _CLIENTES_DESIRED = [
 ]
 
 
-def sync_clientes(conn_4d, conn_pg) -> int:
-    """Full-refresh sync of Clientes → ps_clientes.
+def sync_clientes(conn_4d, conn_pg, since=None) -> int:
+    """Sync Clientes → ps_clientes.
 
-    Returns the number of rows inserted.
+    since=None  → full refresh (TRUNCATE + INSERT). Catches hard-deletes.
+    since=date  → delta upsert (WHERE FechaModifica > since). The hourly
+                  delta cron uses this; the nightly full pass cleans up.
+
+    Returns the number of rows touched.
     """
+    from etl.db.postgres import upsert
+
     # Discover which desired columns actually exist in 4D (safe columns only).
     safe_cols = set(_discover_columns(conn_4d, "Clientes"))
     # Intersect with desired list, preserving desired order.
@@ -142,7 +148,17 @@ def sync_clientes(conn_4d, conn_pg) -> int:
         )
         return 0
 
-    sql = f"SELECT {', '.join(cols_to_query)} FROM Clientes"
+    where = ""
+    if since is not None:
+        if "FechaModifica" not in safe_cols:
+            logger.warning(
+                "sync_clientes: delta requested but FechaModifica missing — falling back to full refresh"
+            )
+        else:
+            date_str = since.strftime("%Y-%m-%d")
+            where = f" WHERE FechaModifica > {{d '{date_str}'}}"
+
+    sql = f"SELECT {', '.join(cols_to_query)} FROM Clientes{where}"
     logger.info("sync_clientes: querying 4D — %s", sql)
     rows_4d = safe_fetch(conn_4d, sql)
     logger.info("sync_clientes: fetched %d rows from 4D", len(rows_4d))
@@ -159,8 +175,15 @@ def sync_clientes(conn_4d, conn_pg) -> int:
                 mapped[pg_key] = v
         pg_rows.append(mapped)
 
-    count = truncate_and_insert(conn_pg, "ps_clientes", pg_rows)
-    logger.info("sync_clientes: inserted %d rows into ps_clientes", count)
+    if since is None or not where:
+        count = truncate_and_insert(conn_pg, "ps_clientes", pg_rows)
+        logger.info("sync_clientes: inserted %d rows into ps_clientes", count)
+        return count
+
+    if not pg_rows:
+        return 0
+    count = upsert(conn_pg, "ps_clientes", pg_rows, pk_cols=["reg_cliente"])
+    logger.info("sync_clientes: upserted %d rows into ps_clientes", count)
     return count
 
 

--- a/etl/sync/maestros.py
+++ b/etl/sync/maestros.py
@@ -155,8 +155,11 @@ def sync_clientes(conn_4d, conn_pg, since=None) -> int:
                 "sync_clientes: delta requested but FechaModifica missing — falling back to full refresh"
             )
         else:
+            # `>=` not `>`: FechaModifica is date-only; strict `>` would
+            # silently skip same-day updates once the watermark advances.
+            # Upsert is idempotent so re-fetching today's rows is harmless.
             date_str = since.strftime("%Y-%m-%d")
-            where = f" WHERE FechaModifica > {{d '{date_str}'}}"
+            where = f" WHERE FechaModifica >= {{d '{date_str}'}}"
 
     sql = f"SELECT {', '.join(cols_to_query)} FROM Clientes{where}"
     logger.info("sync_clientes: querying 4D — %s", sql)

--- a/etl/sync/ventas.py
+++ b/etl/sync/ventas.py
@@ -74,7 +74,16 @@ def _map_row(
 
 
 def _date_literal(dt: datetime) -> str:
-    """Return a 4D SQL date literal string: {d 'YYYY-MM-DD'}."""
+    """Return a 4D SQL date literal string: {d 'YYYY-MM-DD'}.
+
+    Callers in this module pair the literal with `FechaModifica >=` (not
+    strict `>`). Ventas/LineasVentas/PagosVentas.FechaModifica are date-
+    only (`_USER_COLUMNS` DATA_TYPE=8): with strict `>` once the watermark
+    advances to today, same-day updates with FechaModifica == today are
+    silently skipped until tomorrow's run. `>=` re-fetches every row
+    already touched today; upsert is idempotent so the only cost is one
+    extra UPDATE per untouched row. See issue #459 / PR #461.
+    """
     return f"{{d '{dt.strftime('%Y-%m-%d')}'}}"
 
 
@@ -98,7 +107,7 @@ def _sync_table(
 
     Args:
         sql_base:     SELECT ... FROM table (no WHERE/ORDER/LIMIT).
-        where_clause: Already-formatted WHERE clause (e.g. "FechaModifica > {d '...'}").
+        where_clause: Already-formatted WHERE clause (e.g. "FechaModifica >= {d '...'}").
         pk_col_4d:    4D column name used for ORDER BY (original casing). Unused now but kept for API compat.
         pg_table:     Target PostgreSQL table name.
         pk_cols_pg:   PK column list for ON CONFLICT.
@@ -257,7 +266,7 @@ def sync_ventas(conn_4d: Any, conn_pg: Any, since: datetime | None = None) -> in
           memory usage for the initial full load (~911K rows).
     """
     effective_since = since if since is not None else _EPOCH
-    where = f"FechaModifica > {_date_literal(effective_since)}"
+    where = f"FechaModifica >= {_date_literal(effective_since)}"
     return _sync_table(
         conn_4d,
         conn_pg,
@@ -291,7 +300,7 @@ def sync_lineas_ventas(
         - PK and FK floats (RegLineas, NumVentas, NDocumento) converted to Decimal.
     """
     effective_since = since if since is not None else _EPOCH
-    where = f"FechaModifica > {_date_literal(effective_since)}"
+    where = f"FechaModifica >= {_date_literal(effective_since)}"
     return _sync_table(
         conn_4d,
         conn_pg,
@@ -323,7 +332,7 @@ def sync_pagos_ventas(conn_4d: Any, conn_pg: Any, since: datetime | None = None)
           concatenates store codes; ImporteCob is unaffected.
     """
     effective_since = since if since is not None else _EPOCH
-    where = f"FechaModifica > {_date_literal(effective_since)}"
+    where = f"FechaModifica >= {_date_literal(effective_since)}"
     return _sync_table(
         conn_4d,
         conn_pg,

--- a/etl/tests/test_monitoring.py
+++ b/etl/tests/test_monitoring.py
@@ -77,7 +77,7 @@ def test_create_run_called_once():
         from etl.main import run_full_sync
 
         run_full_sync(conn_4d, conn_pg)
-    mocks["create_run"].assert_called_once_with(conn_pg, "scheduled")
+    mocks["create_run"].assert_called_once_with(conn_pg, "scheduled", kind="full")
 
 
 def test_finish_run_called_once_with_success():

--- a/etl/tests/test_trigger.py
+++ b/etl/tests/test_trigger.py
@@ -185,7 +185,7 @@ class TestRunFullSyncTriggerParam:
 
         captured_trigger: list[str] = []
 
-        def _capture_create_run(conn_pg, trigger):
+        def _capture_create_run(conn_pg, trigger, kind="full"):
             captured_trigger.append(trigger)
             return 1
 


### PR DESCRIPTION
## Summary

- **Hourly delta + nightly full** — scheduler installs two cron jobs. Hourly delta sweeps the watermark-backed syncs (~seconds, no truncate window on hot tables); nightly full at \`ETL_CRON_HOUR\` runs every module and forces watermark-backed syncs through truncate+reinsert so hard-deletes in 4D are reflected. New env var \`ETL_DELTA_CRON_MINUTE\` (default 0) sets the minute for both.
- **Tier-1 syncs converted to delta-capable** — \`articulos\`, \`clientes\`, \`ccstock\`, \`facturas\` accept \`since=None|datetime\`. \`None\` → existing full refresh; datetime → upsert by \`FechaModifica\`. Verified against \`_USER_COLUMNS\` that all four sources have \`FechaModifica\` with 100% coverage.
- **\`etl_sync_runs.kind\`** column ('delta' | 'full') surfaced as a "Tipo" pill in the dashboard run list and run-detail header. Existing rows backfill to 'full' via the column default.
- **"Total est." column fix** — \`_run_sync\` now reads \`pg_stat_user_tables.n_live_tup\` after each sync writes and persists it as \`etl_sync_run_tables.rows_total_after\`. The column was always NULL before because the producer never populated it.

The compras chain (\`Compras\` / \`CCLineasCompr\` / \`Albaranes\` / \`FacturasCompra\`) does NOT expose \`FechaModifica\` in 4D so it stays full-only and only runs in the nightly pass — same for the tiny master tables (\`tiendas\`, \`proveedores\`, \`catalogos\`, \`gc_comerciales\`) and the workflow \`gc_pedidos\`/\`gc_lin_pedidos\` (which deliberately need a truncate to catch line-level deletes as orders progress).

MA cascade cleanup runs on full only — it scans every line-item table and the MA set only changes when \`articulos\` is fully reloaded.

## Test plan

- [x] Verified \`FechaModifica\` exists + 100% coverage on Articulos/Clientes/CCStock/Facturas via \`_USER_COLUMNS\` against live 4D
- [x] Schema migration: \`ALTER TABLE etl_sync_runs ADD COLUMN kind\` applied to local PG, surfaced via API + UI
- [x] Python unit tests pass (\`test_main\`, \`test_run_tracking\`, \`test_trigger\`, \`test_monitoring\`)
- [x] Dashboard tests pass (\`components/etl\`, \`app/api/etl\`, \`app/__tests__/etl-page\`)
- [x] \`ruff format\` + \`ruff check\` clean
- [x] Initial full sync on container startup runs every module against live 4D
- [ ] Wait for CI green
- [ ] Manual: trigger a delta from the dashboard "Sincronizar ahora" and verify Tipo=Delta + Total est. populated
- [ ] Manual: confirm hourly delta firing at the configured minute via container logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)