### PR TITLE
fix(dashboard): live Claude streaming + review SQL/JOIN fixes + UI cleanup

### DIFF
--- a/dashboard/app/__tests__/review-queries.test.ts
+++ b/dashboard/app/__tests__/review-queries.test.ts
@@ -54,9 +54,9 @@ describe("REVIEW_QUERIES", () => {
     expect(count).toBe(3);
   });
 
-  it("has 2 compras queries", () => {
+  it("has 4 compras queries", () => {
     const count = REVIEW_QUERIES.filter((q) => q.domain === "compras").length;
-    expect(count).toBe(2);
+    expect(count).toBe(4);
   });
 });
 
@@ -132,12 +132,22 @@ describe("executeReviewQueries", () => {
     }
   });
 
-  it("calls the query function with the SQL of each query and week bounds", async () => {
+  it("calls the query function with the SQL of each query and exactly the placeholders it uses", async () => {
     const mockQueryFn = vi.fn().mockResolvedValue({ columns: [], rows: [] });
     await executeReviewQueries(mockQueryFn, SAMPLE_WEEK_START, SAMPLE_WEEK_END_EXCL);
 
+    // PostgreSQL rejects extra parameters: a query referencing only $1 must
+    // not be called with [start, end]. The runner slices weekParams to the
+    // highest $N actually present in the SQL (and passes undefined for $0).
     for (const q of REVIEW_QUERIES) {
-      expect(mockQueryFn).toHaveBeenCalledWith(q.sql, [SAMPLE_WEEK_START, SAMPLE_WEEK_END_EXCL]);
+      const usesEnd = /\$2\b/.test(q.sql);
+      const usesStart = /\$1\b/.test(q.sql);
+      const expectedParams = usesEnd
+        ? [SAMPLE_WEEK_START, SAMPLE_WEEK_END_EXCL]
+        : usesStart
+          ? [SAMPLE_WEEK_START]
+          : undefined;
+      expect(mockQueryFn).toHaveBeenCalledWith(q.sql, expectedParams);
     }
   });
 });

--- a/dashboard/app/api/dashboard/analyze/route.ts
+++ b/dashboard/app/api/dashboard/analyze/route.ts
@@ -55,7 +55,7 @@ import {
 import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
 import { isAgenticToolsEnabled, getAgenticConfig } from "@/lib/llm-tools/config";
 import { buildAgenticErrorDiagnostic, persistAgenticError } from "@/lib/llm-tools/diagnostic";
-import { agenticEventToLogLine } from "@/lib/format-agentic-progress";
+import { agenticEventToLogLine, pushAgenticLogLine } from "@/lib/format-agentic-progress";
 import type { AgenticProgressEvent, LlmAgenticContext } from "@/lib/llm-tools/types";
 import type { LogLine } from "@/components/LogBlock";
 
@@ -293,9 +293,13 @@ export async function POST(request: Request) {
     console.error(`[${requestId}] createInteraction(analyze) failed:`, e);
   }
 
-  // --- Run the LLM call, collecting progress events into a buffer ----------
+  // --- Run the LLM call, with live event pump once streaming opens ---------
+  // See modify/route.ts for design notes — same pattern: events buffer until
+  // the streaming controller installs `liveSend`, then bypass the buffer so
+  // the client sees Claude thinking + writing in real time.
   const t0 = Date.now();
   const buffer: { type: "progress"; logLine: LogLine }[] = [];
+  let liveSend: ((entry: { type: "progress"; logLine: LogLine }) => void) | null = null;
   let firstEventResolve: (() => void) | null = null;
   const firstEvent = new Promise<void>((resolve) => {
     firstEventResolve = resolve;
@@ -304,7 +308,12 @@ export async function POST(request: Request) {
   const onAgenticProgress = (ev: AgenticProgressEvent) => {
     const logLine = agenticEventToLogLine(ev, Date.now() - t0);
     if (!logLine) return;
-    buffer.push({ type: "progress", logLine });
+    const entry = { type: "progress" as const, logLine };
+    if (liveSend) {
+      liveSend(entry);
+    } else {
+      pushAgenticLogLine(buffer, entry);
+    }
     if (firstEventResolve) {
       firstEventResolve();
       firstEventResolve = null;
@@ -457,7 +466,11 @@ export async function POST(request: Request) {
       };
       drainBuffer();
 
+      // Switch onAgenticProgress to live-pump mode (same as modify route).
+      liveSend = (entry) => send({ ...entry, requestId });
+
       const outcome = await llmPromise;
+      liveSend = null;
       drainBuffer();
 
       if (outcome.kind === "err") {

--- a/dashboard/app/api/dashboard/modify/route.ts
+++ b/dashboard/app/api/dashboard/modify/route.ts
@@ -61,7 +61,7 @@ import {
 import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
 import { isAgenticToolsEnabled, getAgenticConfig } from "@/lib/llm-tools/config";
 import { buildAgenticErrorDiagnostic, persistAgenticError } from "@/lib/llm-tools/diagnostic";
-import { agenticEventToLogLine } from "@/lib/format-agentic-progress";
+import { agenticEventToLogLine, pushAgenticLogLine } from "@/lib/format-agentic-progress";
 import type { AgenticProgressEvent, LlmAgenticContext } from "@/lib/llm-tools/types";
 import type { LogLine } from "@/components/LogBlock";
 
@@ -247,7 +247,12 @@ export async function POST(request: Request) {
   // common case, and (b) only open an NDJSON stream when the agentic runner
   // actually streams progress events.
   const t0 = Date.now();
+  // Buffer accumulates events emitted *before* the streaming controller
+  // installs its live pump (`liveSend`). Once streaming is open, events flow
+  // through `liveSend` directly so the client sees Claude thinking + writing
+  // in real time instead of receiving everything in a single end-of-run dump.
   const buffer: { type: "progress"; logLine: LogLine }[] = [];
+  let liveSend: ((entry: { type: "progress"; logLine: LogLine }) => void) | null = null;
   let firstEventResolve: (() => void) | null = null;
   const firstEvent = new Promise<void>((resolve) => {
     firstEventResolve = resolve;
@@ -256,7 +261,12 @@ export async function POST(request: Request) {
   const onAgenticProgress = (ev: AgenticProgressEvent) => {
     const logLine = agenticEventToLogLine(ev, Date.now() - t0);
     if (!logLine) return;
-    buffer.push({ type: "progress", logLine });
+    const entry = { type: "progress" as const, logLine };
+    if (liveSend) {
+      liveSend(entry);
+    } else {
+      pushAgenticLogLine(buffer, entry);
+    }
     if (firstEventResolve) {
       firstEventResolve();
       firstEventResolve = null;
@@ -471,7 +481,13 @@ export async function POST(request: Request) {
       };
       drainBuffer();
 
+      // Switch onAgenticProgress to live-pump mode. Subsequent events bypass
+      // the buffer and reach the client immediately — same UX as the review
+      // streaming endpoint.
+      liveSend = (entry) => send({ ...entry, requestId });
+
       const outcome = await llmPromise;
+      liveSend = null;
       drainBuffer();
 
       if (outcome.kind === "err") {

--- a/dashboard/app/review/page.tsx
+++ b/dashboard/app/review/page.tsx
@@ -15,6 +15,34 @@ import type { ReviewActionRow } from "@/lib/review-actions-db";
 import { agenticEventToLogLine } from "@/lib/format-agentic-progress";
 import type { AgenticProgressEvent } from "@/lib/llm";
 
+// ─── Error helpers ────────────────────────────────────────────────────────────
+
+/** Error thrown from the generate flow that may carry the structured ApiErrorResponse. */
+type GenerateError = Error & { apiError?: ApiErrorResponse };
+
+/**
+ * Build a `GenerateError` that preserves the full `ApiErrorResponse` when the
+ * server payload looks like one. The catch block in handleGenerate/handleRegenerate
+ * unwraps `.apiError` and feeds it to <ErrorDisplay>, which renders the
+ * AGENTIC_RUNNER diagnostic ("Detalles técnicos" with provider / CLI / tool / limits).
+ * This is the same shape ChatSidebar uses for /generate and /modify.
+ */
+function generateErrorFromPayload(payload: unknown, fallbackMessage: string): GenerateError {
+  const apiError = isApiErrorResponse(payload) ? (payload as ApiErrorResponse) : undefined;
+  const err: GenerateError = new Error(apiError?.error ?? fallbackMessage);
+  if (apiError) err.apiError = apiError;
+  return err;
+}
+
+/** Pull the structured ApiErrorResponse off a thrown error, when present. */
+function apiErrorOf(err: unknown): ApiErrorResponse | undefined {
+  if (err && typeof err === "object" && "apiError" in err) {
+    const candidate = (err as { apiError?: unknown }).apiError;
+    if (isApiErrorResponse(candidate)) return candidate;
+  }
+  return undefined;
+}
+
 // ─── NDJSON stream reader ─────────────────────────────────────────────────────
 
 async function* readNdjsonStream<T>(
@@ -337,9 +365,7 @@ export default function ReviewPage() {
         // Fallback to plain JSON error.
         const payload = await res.json().catch(() => null);
         setStreamingLog(null);
-        throw new Error(
-          isApiErrorResponse(payload) ? payload.error : "Error al generar la revisión.",
-        );
+        throw generateErrorFromPayload(payload, "Error al generar la revisión.");
       }
 
       if (!res.body) {
@@ -361,12 +387,17 @@ export default function ReviewPage() {
           if (line) {
             setStreamingLog((prev) => {
               if (!prev) return [line];
-              // Coalesce model_text_delta: replace last line if it's also "Modelo respondiendo".
-              if (
-                frame.event.type === "model_text_delta" &&
-                prev.length > 0 &&
-                prev[prev.length - 1]?.label === "Modelo respondiendo"
-              ) {
+              // Coalesce streaming ticks (text_delta and thinking_delta) so
+              // each tick replaces the previous one of its own kind. Thinking
+              // and text are *separate* rows — once the thinking block ends
+              // and text starts streaming, a new "Modelo respondiendo" line
+              // appears under the (now frozen) "Claude está razonando".
+              const lastLabel = prev[prev.length - 1]?.label;
+              const isTextCoalesce =
+                frame.event.type === "model_text_delta" && lastLabel === "Modelo respondiendo";
+              const isThinkingCoalesce =
+                frame.event.type === "model_thinking_delta" && lastLabel === "Claude está razonando";
+              if (prev.length > 0 && (isTextCoalesce || isThinkingCoalesce)) {
                 return [...prev.slice(0, -1), line];
               }
               return [...prev, line];
@@ -384,9 +415,7 @@ export default function ReviewPage() {
           return { week_start: frame.review.week_start, id: frame.review.id, message: frame.message };
         } else if (frame.type === "error") {
           setStreamingLog(null);
-          throw Object.assign(new Error(frame.error ?? "Error al generar la revisión."), {
-            apiError: frame,
-          });
+          throw generateErrorFromPayload(frame, "Error al generar la revisión.");
         }
       }
 
@@ -414,7 +443,10 @@ export default function ReviewPage() {
       }
     } catch (err) {
       setStreamingLog(null);
-      setReviewError(err instanceof Error ? err.message : "Error al generar la revisión");
+      const detail = apiErrorOf(err);
+      setReviewError(
+        detail ?? (err instanceof Error ? err.message : "Error al generar la revisión"),
+      );
       setView("error");
     }
   }, [fetchPastReviews, openWeek, callGenerateStreaming]);
@@ -439,7 +471,8 @@ export default function ReviewPage() {
       }
     } catch (err) {
       setStreamingLog(null);
-      setReviewError(err instanceof Error ? err.message : "Error al regenerar");
+      const detail = apiErrorOf(err);
+      setReviewError(detail ?? (err instanceof Error ? err.message : "Error al regenerar"));
       setView("error");
     }
   }, [current, callGenerateStreaming, fetchPastReviews, openWeek, regenMode]);

--- a/dashboard/components/ChatSidebar.tsx
+++ b/dashboard/components/ChatSidebar.tsx
@@ -10,6 +10,7 @@ import type { ApiErrorResponse } from "@/lib/errors";
 import type { WidgetState } from "@/components/DashboardRenderer";
 import LogBlock from "@/components/LogBlock";
 import type { LogLine } from "@/components/LogBlock";
+import { appendCoalescedLogLine } from "@/lib/format-agentic-progress";
 import type { InteractionLine } from "@/lib/db-write";
 import { interactionLineClass } from "@/lib/interaction-line-class";
 import AgenticErrorDetails from "@/components/AgenticErrorDetails";
@@ -639,7 +640,12 @@ function ModificarTab({
 
         for await (const msg of readNdjsonStream<ModifyMsg>(res.body)) {
           if (msg.type === "progress") {
-            capturedLogs.push(msg.logLine);
+            // Coalesce consecutive streaming ticks (model_text_delta /
+            // model_thinking_delta) into a single growing line. With
+            // token-level streaming the server sends one frame per token,
+            // so without dedup the UI would stack hundreds of identical
+            // "Modelo respondiendo · N caracteres" rows.
+            appendCoalescedLogLine(capturedLogs, msg.logLine);
             setStreamingLog([...capturedLogs]);
           } else if (msg.type === "result") {
             resultSpec = msg.spec;
@@ -1060,7 +1066,8 @@ function AnalizarTab({
 
           for await (const msg of readNdjsonStream<AnalyzeMsg>(res.body)) {
             if (msg.type === "progress") {
-              capturedLogs.push(msg.logLine);
+              // Coalesce streaming ticks — see modify branch above.
+              appendCoalescedLogLine(capturedLogs, msg.logLine);
               setStreamingLog([...capturedLogs]);
             } else if (msg.type === "result") {
               result = {

--- a/dashboard/components/LogBlock.tsx
+++ b/dashboard/components/LogBlock.tsx
@@ -11,6 +11,8 @@ export interface LogLine {
   kind: "tool" | "reason" | "done" | "default";
   label: string;
   detail?: string;
+  /** Multi-line content rendered below the row (e.g. streaming model text). */
+  body?: string;
 }
 
 export interface LogBlockProps {
@@ -78,6 +80,25 @@ function LogLineRow({ line, isLast }: { line: LogLine; isLast: boolean }) {
               animation: "pulse-dot 2s ease-in-out infinite",
             }}
           />
+        )}
+        {line.body && (
+          <pre
+            style={{
+              marginTop: 4,
+              padding: "8px 10px",
+              borderLeft: "2px solid var(--accent)",
+              background: "var(--bg-1)",
+              color: "var(--fg)",
+              fontFamily: "inherit",
+              fontSize: 12,
+              lineHeight: 1.5,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              overflowX: "hidden",
+            }}
+          >
+            {line.body}
+          </pre>
         )}
       </span>
     </div>

--- a/dashboard/components/TopBar.tsx
+++ b/dashboard/components/TopBar.tsx
@@ -30,7 +30,6 @@ export function TopBar({
     { href: "/inicio", label: "Inicio" },
     { href: "/paneles", label: "Paneles" },
     { href: "/review", label: "Revisión" },
-    { href: "/glossary", label: "Glosario" },
     { href: "http://localhost:3000", label: "Wren", external: true },
   ] as const;
 

--- a/dashboard/components/__tests__/TopBar.test.tsx
+++ b/dashboard/components/__tests__/TopBar.test.tsx
@@ -66,14 +66,7 @@ describe("TopBar", () => {
     const nav = screen.getByRole("navigation");
     const links = Array.from(nav.querySelectorAll("a"));
     const labels = links.map((l) => l.textContent?.trim());
-    expect(labels).toEqual(["Inicio", "Paneles", "Revisión", "Glosario", "Wren"]);
-  });
-
-  it("includes Glosario link pointing to /glossary", () => {
-    render(<TopBar />);
-    const glossaryLink = screen.getByRole("link", { name: "Glosario" });
-    expect(glossaryLink).toBeInTheDocument();
-    expect(glossaryLink).toHaveAttribute("href", "/glossary");
+    expect(labels).toEqual(["Inicio", "Paneles", "Revisión", "Wren"]);
   });
 
   it("Paneles link points to /paneles", () => {

--- a/dashboard/lib/__tests__/host-token-sync.test.ts
+++ b/dashboard/lib/__tests__/host-token-sync.test.ts
@@ -57,8 +57,11 @@ describe("triggerHostTokenSync", () => {
         expect("timeout" in result && result.timeout).toBeFalsy();
         expect(result.credsPath).toBe(credsPath);
       }
-      // Touching MUST advance the kick file's mtime (or at least not regress).
-      expect(after).toBeGreaterThanOrEqual(before);
+      // Touching MUST advance the kick file's mtime (or at least not regress
+      // by more than the filesystem's mtime granularity — APFS truncates to
+      // 1 ns precision, ext4 to 1 s, so we allow a small tolerance instead
+      // of asserting strict >=).
+      expect(after).toBeGreaterThanOrEqual(Math.floor(before));
     } finally {
       clearTimeout(fakeLaunchd);
     }

--- a/dashboard/lib/__tests__/host-token-sync.test.ts
+++ b/dashboard/lib/__tests__/host-token-sync.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for triggerHostTokenSync — the on-demand kick that fires the host
+ * launchd `claude-token-sync` agent. We don't actually exercise launchd
+ * here; we use real temp files and verify that the helper:
+ *
+ *   1. Touches the kick file (mtime advances).
+ *   2. Waits for the credentials file mtime to advance, returning ok.
+ *   3. Returns ok+timeout when the credentials file never changes.
+ *   4. Returns !ok when the credentials file is missing.
+ *   5. Returns !ok when the kick file is missing/unwritable.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, rm, stat, utimes } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { triggerHostTokenSync } from "@/lib/llm-provider/cli/host-token-sync";
+
+let workdir: string;
+let kickPath: string;
+let credsPath: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "claude-host-token-sync-"));
+  kickPath = join(workdir, "kick");
+  credsPath = join(workdir, "credentials.json");
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("triggerHostTokenSync", () => {
+  it("touches the kick file and returns ok when credentials file mtime advances", async () => {
+    await writeFile(kickPath, "");
+    await writeFile(credsPath, '{"v":1}');
+
+    // Schedule a fake "launchd" that bumps the credentials mtime ~50ms later.
+    const fakeLaunchd = setTimeout(async () => {
+      const future = new Date(Date.now() + 5_000);
+      await utimes(credsPath, future, future);
+    }, 50);
+
+    try {
+      const before = (await stat(kickPath)).mtimeMs;
+      const result = await triggerHostTokenSync({
+        kickPath,
+        credsPath,
+        waitMaxMs: 2_000,
+        pollIntervalMs: 25,
+      });
+      const after = (await stat(kickPath)).mtimeMs;
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect("timeout" in result && result.timeout).toBeFalsy();
+        expect(result.credsPath).toBe(credsPath);
+      }
+      // Touching MUST advance the kick file's mtime (or at least not regress).
+      expect(after).toBeGreaterThanOrEqual(before);
+    } finally {
+      clearTimeout(fakeLaunchd);
+    }
+  });
+
+  it("returns ok+timeout when the credentials mtime never advances", async () => {
+    await writeFile(kickPath, "");
+    await writeFile(credsPath, '{"v":1}');
+
+    const result = await triggerHostTokenSync({
+      kickPath,
+      credsPath,
+      waitMaxMs: 200,
+      pollIntervalMs: 25,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect("timeout" in result && result.timeout).toBe(true);
+      expect(result.waitedMs).toBeGreaterThanOrEqual(150);
+    }
+  });
+
+  it("returns !ok when the credentials file is missing", async () => {
+    await writeFile(kickPath, "");
+
+    const result = await triggerHostTokenSync({
+      kickPath,
+      credsPath,
+      waitMaxMs: 100,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/credentials file not found/);
+    }
+  });
+
+  it("returns !ok when the kick file cannot be touched", async () => {
+    await writeFile(credsPath, '{"v":1}');
+    // kickPath was never created and points inside workdir without a parent.
+
+    const result = await triggerHostTokenSync({
+      kickPath: join(workdir, "nonexistent-dir", "kick"),
+      credsPath,
+      waitMaxMs: 100,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/cannot touch kick file/);
+    }
+  });
+});

--- a/dashboard/lib/__tests__/llm-provider-claude-code-cli.test.ts
+++ b/dashboard/lib/__tests__/llm-provider-claude-code-cli.test.ts
@@ -75,14 +75,66 @@ function makeStreamJsonResult(finalText: string): string[] {
 }
 
 describe("parseStreamJsonLine", () => {
-  it("parses assistant text content", () => {
+  it("parses cumulative assistant text content as text_full", () => {
     const line = JSON.stringify({
       type: "assistant",
       message: { content: [{ type: "text", text: "hello" }] },
     });
     const r = parseStreamJsonLine(line);
-    expect(r.kind).toBe("text");
-    if (r.kind === "text") expect(r.text).toBe("hello");
+    expect(r.kind).toBe("text_full");
+    if (r.kind === "text_full") expect(r.text).toBe("hello");
+  });
+
+  it("parses incremental content_block_delta text_delta as text_delta", () => {
+    const line = JSON.stringify({
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "1, 2, 3" },
+      },
+    });
+    const r = parseStreamJsonLine(line);
+    expect(r.kind).toBe("text_delta");
+    if (r.kind === "text_delta") expect(r.text).toBe("1, 2, 3");
+  });
+
+  it("parses extended-thinking content_block_delta thinking_delta as thinking_delta", () => {
+    const line = JSON.stringify({
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "thinking_delta", thinking: "Let me check the data..." },
+      },
+    });
+    const r = parseStreamJsonLine(line);
+    expect(r.kind).toBe("thinking_delta");
+    if (r.kind === "thinking_delta") expect(r.text).toBe("Let me check the data...");
+  });
+
+  it("ignores signature_delta (extended-thinking signature, not visible)", () => {
+    const line = JSON.stringify({
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "signature_delta", signature: "abc123" },
+      },
+    });
+    expect(parseStreamJsonLine(line).kind).toBe("ignore");
+  });
+
+  it("ignores non-text content_block_delta variants (e.g. input_json_delta)", () => {
+    const line = JSON.stringify({
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: "{\"a\":" },
+      },
+    });
+    expect(parseStreamJsonLine(line).kind).toBe("ignore");
   });
 
   it("ignores tool_use content blocks", () => {
@@ -257,28 +309,63 @@ describe("claudeCliAgenticStep", () => {
     ).rejects.toMatchObject({ code: "LLM_CLI_API_ERROR" });
   });
 
-  it("invokes onTextDelta for each text chunk", async () => {
+  it("invokes onTextDelta for each token-level text_delta and forwards accumulated text", async () => {
     const finalText = '{"kind":"final","content":"answer"}';
+    // Newer claude builds emit incremental stream_event content_block_delta
+    // events with --include-partial-messages; we forward each one through
+    // onTextDelta and also pass the running cumulative text.
     mockRunCliProcessStreaming.mockImplementation(
       makeStreamingMock([
-        JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: '{"kind":"fina' }] } }),
-        JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: 'l","content":"answer"}' }] } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: '{"kind":"fina' } },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: 'l","content":"answer"}' } },
+        }),
+        // The cumulative assistant envelope follows; runner skips it because
+        // text_delta events were already seen for this message.
+        JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: finalText }] } }),
         JSON.stringify({ type: "result", is_error: false, result: finalText }),
       ]),
     );
 
-    const deltas: { chars: number; totalChars: number }[] = [];
+    const deltas: { chars: number; totalChars: number; accumulated: string }[] = [];
     await claudeCliAgenticStep({
       cfg,
       messages: [{ role: "user", content: "hi" }],
-      onTextDelta: (chars, totalChars) => deltas.push({ chars, totalChars }),
+      onTextDelta: (chars, totalChars, accumulated) => deltas.push({ chars, totalChars, accumulated }),
     });
 
-    expect(deltas.length).toBeGreaterThanOrEqual(2);
-    expect(deltas[deltas.length - 1].totalChars).toBeGreaterThan(0);
+    expect(deltas.length).toBe(2);
+    expect(deltas[0].accumulated).toBe('{"kind":"fina');
+    expect(deltas[1].accumulated).toBe(finalText);
+    expect(deltas[1].totalChars).toBe(finalText.length);
   });
 
-  it("uses --output-format stream-json --verbose flags", async () => {
+  it("falls back to text_full when no deltas arrive (older binary or flag ignored)", async () => {
+    const finalText = '{"kind":"final","content":"ok"}';
+    mockRunCliProcessStreaming.mockImplementation(
+      makeStreamingMock([
+        // No stream_event deltas — only the cumulative assistant envelope.
+        JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: finalText }] } }),
+        JSON.stringify({ type: "result", is_error: false, result: finalText }),
+      ]),
+    );
+
+    const deltas: { chars: number; totalChars: number; accumulated: string }[] = [];
+    await claudeCliAgenticStep({
+      cfg,
+      messages: [{ role: "user", content: "hi" }],
+      onTextDelta: (chars, totalChars, accumulated) => deltas.push({ chars, totalChars, accumulated }),
+    });
+
+    expect(deltas.length).toBe(1);
+    expect(deltas[0].accumulated).toBe(finalText);
+  });
+
+  it("uses --output-format stream-json --verbose --include-partial-messages flags", async () => {
     const finalText = '{"kind":"final","content":"ok"}';
     mockRunCliProcessStreaming.mockImplementation(
       makeStreamingMock(makeStreamJsonResult(finalText)),
@@ -290,5 +377,6 @@ describe("claudeCliAgenticStep", () => {
     expect(callArgs.args).toContain("--output-format");
     expect(callArgs.args).toContain("stream-json");
     expect(callArgs.args).toContain("--verbose");
+    expect(callArgs.args).toContain("--include-partial-messages");
   });
 });

--- a/dashboard/lib/format-agentic-progress.ts
+++ b/dashboard/lib/format-agentic-progress.ts
@@ -32,11 +32,24 @@ export function agenticEventToLogLine(event: AgenticProgressEvent, ms: number): 
     case "model_step_start":
       return { timestamp: ts, kind: "reason", label: "Modelo pensando…", detail: undefined };
     case "model_text_delta":
+      // The streaming "text" in agentic flows is the JSON tool-protocol payload
+      // (e.g. submit_weekly_review with the full spec inlined) — not human
+      // prose. Showing it as a body floods the log with unreadable JSON, so we
+      // only show the progress count here. Readable reasoning lives in the
+      // thinking block (model_thinking_delta) below.
       return {
         timestamp: ts,
-        kind: "default",
+        kind: "reason",
         label: "Modelo respondiendo",
         detail: `${event.totalChars} caracteres`,
+      };
+    case "model_thinking_delta":
+      return {
+        timestamp: ts,
+        kind: "reason",
+        label: "Claude está razonando",
+        detail: `${event.totalChars} caracteres`,
+        body: event.text,
       };
     case "finalizing":
       return { timestamp: ts, kind: "done", label: "Respuesta lista", detail: `${event.messageChars} chars` };
@@ -46,6 +59,58 @@ export function agenticEventToLogLine(event: AgenticProgressEvent, ms: number): 
     default:
       return null;
   }
+}
+
+/** Labels whose consecutive ticks should be coalesced into a single growing
+ *  log line (model_text_delta + model_thinking_delta variants). Shared by the
+ *  server-side pushAgenticLogLine helper and the client-side appendCoalesced
+ *  helper used in ChatSidebar / review page. */
+export const COALESCEABLE_LABELS: ReadonlySet<string> = new Set([
+  "Modelo respondiendo",
+  "Claude está razonando",
+]);
+
+/**
+ * Append a `LogLine` to a streaming buffer, coalescing consecutive
+ * model-text ticks (Claude está escribiendo / Modelo respondiendo) into a
+ * single line that grows. Called by API routes that buffer NDJSON `progress`
+ * frames so the client doesn't receive one frame per token.
+ */
+export function pushAgenticLogLine<T extends { logLine: LogLine }>(
+  buffer: T[],
+  entry: T,
+): void {
+  const lastLabel = buffer[buffer.length - 1]?.logLine.label;
+  const newLabel = entry.logLine.label;
+  if (
+    buffer.length > 0 &&
+    COALESCEABLE_LABELS.has(newLabel) &&
+    lastLabel === newLabel
+  ) {
+    buffer[buffer.length - 1] = entry;
+    return;
+  }
+  buffer.push(entry);
+}
+
+/**
+ * Client-side counterpart: append a `LogLine` to an array, coalescing
+ * consecutive ticks of the same coalesce-eligible label. Returns the
+ * mutated array (which is the same reference as `lines`) so callers can
+ * pass it straight to `setState([...lines])`.
+ */
+export function appendCoalescedLogLine(lines: LogLine[], next: LogLine): LogLine[] {
+  const lastLabel = lines[lines.length - 1]?.label;
+  if (
+    lines.length > 0 &&
+    COALESCEABLE_LABELS.has(next.label) &&
+    lastLabel === next.label
+  ) {
+    lines[lines.length - 1] = next;
+  } else {
+    lines.push(next);
+  }
+  return lines;
 }
 
 /** Build a LogLine collector for use as onAgenticProgress, then call toLogLines() after the run. */
@@ -66,14 +131,13 @@ function eventsToLogLines(events: TimedEvent[]): LogLine[] {
   for (const { event, ms } of events) {
     const line = agenticEventToLogLine(event, ms);
     if (!line) continue;
-    // Coalesce consecutive model_text_delta lines so LogBlock shows a single
-    // updating "Modelo respondiendo" tick per round instead of one per chunk.
-    if (
-      event.type === "model_text_delta" &&
-      lines.length > 0 &&
-      lines[lines.length - 1]?.label === "Modelo respondiendo"
-    ) {
-      // Replace the previous delta line with the newer (higher totalChars) one.
+    // Coalesce consecutive streaming ticks (text_delta or thinking_delta) so
+    // LogBlock shows one growing line per kind instead of one per chunk.
+    const lastLabel = lines[lines.length - 1]?.label;
+    const isTextTick = event.type === "model_text_delta" && lastLabel === "Modelo respondiendo";
+    const isThinkingTick =
+      event.type === "model_thinking_delta" && lastLabel === "Claude está razonando";
+    if (lines.length > 0 && (isTextTick || isThinkingTick)) {
       lines[lines.length - 1] = line;
     } else {
       lines.push(line);

--- a/dashboard/lib/format-agentic-progress.ts
+++ b/dashboard/lib/format-agentic-progress.ts
@@ -71,10 +71,11 @@ export const COALESCEABLE_LABELS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Append a `LogLine` to a streaming buffer, coalescing consecutive
- * model-text ticks (Claude está escribiendo / Modelo respondiendo) into a
- * single line that grows. Called by API routes that buffer NDJSON `progress`
- * frames so the client doesn't receive one frame per token.
+ * Append a `LogLine` to a streaming buffer, coalescing consecutive ticks of
+ * the same coalesce-eligible label (currently "Modelo respondiendo" and
+ * "Claude está razonando" — see {@link COALESCEABLE_LABELS}) into a single
+ * line that grows. Called by API routes that buffer NDJSON `progress` frames
+ * so the client doesn't receive one frame per token.
  */
 export function pushAgenticLogLine<T extends { logLine: LogLine }>(
   buffer: T[],
@@ -131,17 +132,11 @@ function eventsToLogLines(events: TimedEvent[]): LogLine[] {
   for (const { event, ms } of events) {
     const line = agenticEventToLogLine(event, ms);
     if (!line) continue;
-    // Coalesce consecutive streaming ticks (text_delta or thinking_delta) so
+    // Coalesce consecutive streaming ticks of the same eligible label so
     // LogBlock shows one growing line per kind instead of one per chunk.
-    const lastLabel = lines[lines.length - 1]?.label;
-    const isTextTick = event.type === "model_text_delta" && lastLabel === "Modelo respondiendo";
-    const isThinkingTick =
-      event.type === "model_thinking_delta" && lastLabel === "Claude está razonando";
-    if (lines.length > 0 && (isTextTick || isThinkingTick)) {
-      lines[lines.length - 1] = line;
-    } else {
-      lines.push(line);
-    }
+    // Reuses COALESCEABLE_LABELS so the post-run collector and the live
+    // streaming helpers stay aligned.
+    appendCoalescedLogLine(lines, line);
   }
   return lines;
 }

--- a/dashboard/lib/llm-provider/cli/agent-adapter.ts
+++ b/dashboard/lib/llm-provider/cli/agent-adapter.ts
@@ -13,10 +13,10 @@ function makeToolCallId(round: number, index: number): string {
 export function createClaudeCodeAgenticAdapter(cfg: DashboardLlmConfig): AgenticModelAdapter {
   let roundCounter = 0;
   return {
-    async runStep({ messages, onTextDelta }) {
+    async runStep({ messages, onTextDelta, onThinkingDelta }) {
       roundCounter += 1;
       const r = roundCounter;
-      const step = await claudeCliAgenticStep({ cfg, messages, onTextDelta });
+      const step = await claudeCliAgenticStep({ cfg, messages, onTextDelta, onThinkingDelta });
       if (step.kind === "final") {
         return {
           kind: "final",

--- a/dashboard/lib/llm-provider/cli/claude-code.ts
+++ b/dashboard/lib/llm-provider/cli/claude-code.ts
@@ -98,7 +98,11 @@ export interface ClaudeCliAgenticStepInput {
   messages: ChatCompletionMessageParam[];
   /** Optional callback invoked as the model streams text. `chars` is the delta;
    *  `totalChars` is the running total since this step began. */
-  onTextDelta?: (chars: number, totalChars: number) => void;
+  onTextDelta?: (chars: number, totalChars: number, accumulatedText: string) => void;
+  /** Optional callback invoked as the model streams extended-thinking content.
+   *  Same contract as onTextDelta but for the chain-of-thought block (only
+   *  emitted on Claude builds with thinking enabled). */
+  onThinkingDelta?: (chars: number, totalChars: number, accumulatedThinking: string) => void;
 }
 
 export type ClaudeAgenticStepKind = "final" | "tools";
@@ -213,19 +217,33 @@ export function parseClaudeAgenticStepJson(stdout: string): ClaudeAgenticStep {
 /**
  * Parse a single stream-json NDJSON line from `claude --output-format stream-json --verbose`.
  *
+ * With `--include-partial-messages` the binary also emits incremental
+ * `stream_event` lines with `content_block_delta` for each token chunk —
+ * we surface those as `text_delta` so the UI can show Claude typing in
+ * real time. The cumulative `assistant` envelope is emitted at the end
+ * of each message and carries the same content; on newer builds (where
+ * deltas are present) callers should treat it as a redundant duplicate.
+ *
  * Supported event shapes (defensive — unknown shapes are silently ignored):
  *   { type: "system", subtype: "init", ... }
+ *   { type: "stream_event", event: { type:"content_block_delta", delta:{ type:"text_delta", text:"..." } } }
  *   { type: "assistant", message: { content: [ {type:"text", text:"..."} | {type:"tool_use",...} ] } }
  *   { type: "result", is_error: bool, result: string, ... }
  *
  * Returns:
- *   { kind: "text", text: string }         — assistant text chunk
+ *   { kind: "text_delta", text: string }    — incremental token chunk (partial-messages flag)
+ *   { kind: "text_full",  text: string }    — cumulative assistant text (one per message)
  *   { kind: "result", text: string, isError: bool, status?: number }  — terminal result line
  *   { kind: "ignore" }                     — all other lines
  */
-export function parseStreamJsonLine(
-  line: string,
-): { kind: "text"; text: string } | { kind: "result"; text: string; isError: boolean; status?: number | null } | { kind: "ignore" } {
+export type StreamJsonLineParse =
+  | { kind: "text_delta"; text: string }
+  | { kind: "thinking_delta"; text: string }
+  | { kind: "text_full"; text: string }
+  | { kind: "result"; text: string; isError: boolean; status?: number | null }
+  | { kind: "ignore" };
+
+export function parseStreamJsonLine(line: string): StreamJsonLineParse {
   let obj: Record<string, unknown>;
   try {
     const parsed = JSON.parse(line);
@@ -245,6 +263,28 @@ export function parseStreamJsonLine(
     return { kind: "result", text: resultText, isError, status };
   }
 
+  // Incremental token chunks emitted with --include-partial-messages.
+  if (type === "stream_event") {
+    const ev = obj.event;
+    if (!ev || typeof ev !== "object" || Array.isArray(ev)) return { kind: "ignore" };
+    const e = ev as Record<string, unknown>;
+    if (e.type === "content_block_delta") {
+      const delta = e.delta;
+      if (delta && typeof delta === "object" && !Array.isArray(delta)) {
+        const d = delta as Record<string, unknown>;
+        if (d.type === "text_delta" && typeof d.text === "string" && d.text) {
+          return { kind: "text_delta", text: d.text };
+        }
+        // Extended thinking: visible chain-of-thought reasoning emitted before
+        // the final answer. Surface it so the UI can show "Claude razonando".
+        if (d.type === "thinking_delta" && typeof d.thinking === "string" && d.thinking) {
+          return { kind: "thinking_delta", text: d.thinking };
+        }
+      }
+    }
+    return { kind: "ignore" };
+  }
+
   // Assistant message — can carry text content or tool_use blocks.
   if (type === "assistant") {
     const message = obj.message;
@@ -261,7 +301,7 @@ export function parseStreamJsonLine(
       }
     }
     const joined = textParts.join("");
-    if (joined) return { kind: "text", text: joined };
+    if (joined) return { kind: "text_full", text: joined };
     return { kind: "ignore" };
   }
 
@@ -269,16 +309,20 @@ export function parseStreamJsonLine(
 }
 
 export async function claudeCliAgenticStep(input: ClaudeCliAgenticStepInput): Promise<ClaudeAgenticStep> {
-  const { cfg, messages, onTextDelta } = input;
+  const { cfg, messages, onTextDelta, onThinkingDelta } = input;
   const transcript = serializeChatMessagesForCli(messages);
   const printArg = AGENTIC_PROTOCOL_INSTRUCTION;
   const stdinBody = buildAgenticStdin(transcript);
 
-  // Use --output-format stream-json --verbose so we get incremental NDJSON events
-  // while the model is generating. The --verbose flag includes the full message
-  // content in the event stream. --include-partial-messages adds partial assistant
-  // messages for each chunk (only when supported by this binary version; the flag
-  // is silently ignored on older builds).
+  // Use --output-format stream-json --verbose --include-partial-messages so we get
+  // token-level NDJSON events while the model is generating. Each token chunk
+  // arrives as { type:"stream_event", event:{ type:"content_block_delta", delta:
+  // { type:"text_delta", text } } } and is forwarded via onTextDelta so the UI
+  // can show Claude typing in real time. The cumulative `type:"assistant"`
+  // envelope at the end of each message is treated as a duplicate and skipped
+  // (sawAnyDelta below). On older binaries that ignore --include-partial-messages
+  // no deltas arrive — we then fall back to the cumulative assistant message
+  // and emit it as a single chunk.
   const args = [
     ...cfg.cliExtraArgs,
     "-p",
@@ -288,17 +332,49 @@ export async function claudeCliAgenticStep(input: ClaudeCliAgenticStepInput): Pr
     "--output-format",
     "stream-json",
     "--verbose",
+    "--include-partial-messages",
   ];
   const fullArgv = [cfg.cliBin, ...args];
 
   // Accumulate assistant text across chunks so we can parse the full step JSON
-  // once the result line arrives. We also call onTextDelta for each increment.
+  // once the result line arrives. Extended-thinking blocks accumulate in
+  // parallel and are forwarded via onThinkingDelta.
   let accumulatedText = "";
   let totalCharsEmitted = 0;
+  let accumulatedThinking = "";
+  let totalThinkingCharsEmitted = 0;
+  // Whether any incremental text_delta events arrived for this step. When true,
+  // the cumulative `type:"assistant"` envelope (text_full) is a duplicate and
+  // must be ignored to avoid double-counting.
+  let sawAnyDelta = false;
   // Store the last result line so we can use its envelope for error detection.
   // Use a box object to avoid TypeScript control-flow narrowing issues with
   // variables mutated inside closures.
   const resultBox: { line: { text: string; isError: boolean; status?: number | null } | null } = { line: null };
+
+  const emitDelta = (deltaText: string) => {
+    accumulatedText += deltaText;
+    totalCharsEmitted += deltaText.length;
+    if (onTextDelta) {
+      try {
+        onTextDelta(deltaText.length, totalCharsEmitted, accumulatedText);
+      } catch {
+        /* ignore callback errors */
+      }
+    }
+  };
+
+  const emitThinkingDelta = (deltaText: string) => {
+    accumulatedThinking += deltaText;
+    totalThinkingCharsEmitted += deltaText.length;
+    if (onThinkingDelta) {
+      try {
+        onThinkingDelta(deltaText.length, totalThinkingCharsEmitted, accumulatedThinking);
+      } catch {
+        /* ignore callback errors */
+      }
+    }
+  };
 
   const result = await runCliProcessStreaming({
     file: cfg.cliBin,
@@ -309,16 +385,17 @@ export async function claudeCliAgenticStep(input: ClaudeCliAgenticStepInput): Pr
     maxStderrBytes: Math.min(cfg.cliMaxCaptureBytes, 512_000),
     onStdoutLine: (line) => {
       const parsed = parseStreamJsonLine(line);
-      if (parsed.kind === "text") {
-        accumulatedText += parsed.text;
-        const delta = parsed.text.length;
-        totalCharsEmitted += delta;
-        if (onTextDelta) {
-          try {
-            onTextDelta(delta, totalCharsEmitted);
-          } catch {
-            /* ignore callback errors */
-          }
+      if (parsed.kind === "text_delta") {
+        sawAnyDelta = true;
+        emitDelta(parsed.text);
+      } else if (parsed.kind === "thinking_delta") {
+        emitThinkingDelta(parsed.text);
+      } else if (parsed.kind === "text_full") {
+        // Older CLI builds (or partial-messages flag silently ignored) emit
+        // only the cumulative assistant message — surface it as one chunk.
+        // Newer builds emit deltas first and then this duplicate; skip it.
+        if (!sawAnyDelta) {
+          emitDelta(parsed.text);
         }
       } else if (parsed.kind === "result") {
         resultBox.line = parsed;

--- a/dashboard/lib/llm-provider/cli/claude-code.ts
+++ b/dashboard/lib/llm-provider/cli/claude-code.ts
@@ -10,6 +10,40 @@ import { serializeChatMessagesForCli } from "./transcript";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import { DASHBOARD_AGENTIC_TOOLS } from "@/lib/llm-tools/catalog";
 import { sanitize, sanitizeArgv, sanitizeTail } from "../sanitize";
+import { triggerHostTokenSync } from "./host-token-sync";
+
+/**
+ * Run a CLI operation and, on `LLM_CLI_AUTH` failure (typically caused by an
+ * out-of-band rotation of the Keychain refresh_token while the container was
+ * holding the previous access_token), trigger an on-demand sync of the host
+ * Keychain into the credentials file via launchd's WatchPaths and retry once.
+ *
+ * Strict scope: this NEVER refreshes the token itself — the kick fires the
+ * existing host-side sync-only script. Single-refresher rule (D-025) stands.
+ */
+async function withAuthAutoRecovery<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (err) {
+    if (!(err instanceof CliRunnerError) || err.code !== "LLM_CLI_AUTH") {
+      throw err;
+    }
+    const sync = await triggerHostTokenSync();
+    if (!sync.ok) {
+      // Plumbing missing on the host — the retry would fail the same way.
+      // Surface the original auth error verbatim.
+      console.warn(
+        `[claude-cli] auth-recovery skipped: ${sync.reason}`,
+      );
+      throw err;
+    }
+    const note = "timeout" in sync && sync.timeout
+      ? `mtime didn't advance within ${sync.waitedMs}ms — retrying anyway`
+      : `creds refreshed in ${sync.waitedMs}ms`;
+    console.warn(`[claude-cli] LLM_CLI_AUTH → kicked host launchd, ${note}; retrying once`);
+    return await operation();
+  }
+}
 
 /** Tail size to retain on CliRunnerError details (matches process.ts). */
 const TAIL_MAX_BYTES = 4096;
@@ -55,7 +89,11 @@ export interface ClaudeCliSingleShotInput {
   prompt: string;
 }
 
-export async function claudeCliSingleShot(input: ClaudeCliSingleShotInput): Promise<string> {
+export function claudeCliSingleShot(input: ClaudeCliSingleShotInput): Promise<string> {
+  return withAuthAutoRecovery(() => claudeCliSingleShotOnce(input));
+}
+
+async function claudeCliSingleShotOnce(input: ClaudeCliSingleShotInput): Promise<string> {
   const { cfg, prompt } = input;
   const args = [
     ...cfg.cliExtraArgs,
@@ -308,7 +346,11 @@ export function parseStreamJsonLine(line: string): StreamJsonLineParse {
   return { kind: "ignore" };
 }
 
-export async function claudeCliAgenticStep(input: ClaudeCliAgenticStepInput): Promise<ClaudeAgenticStep> {
+export function claudeCliAgenticStep(input: ClaudeCliAgenticStepInput): Promise<ClaudeAgenticStep> {
+  return withAuthAutoRecovery(() => claudeCliAgenticStepOnce(input));
+}
+
+async function claudeCliAgenticStepOnce(input: ClaudeCliAgenticStepInput): Promise<ClaudeAgenticStep> {
   const { cfg, messages, onTextDelta, onThinkingDelta } = input;
   const transcript = serializeChatMessagesForCli(messages);
   const printArg = AGENTIC_PROTOCOL_INSTRUCTION;

--- a/dashboard/lib/llm-provider/cli/host-token-sync.ts
+++ b/dashboard/lib/llm-provider/cli/host-token-sync.ts
@@ -1,0 +1,129 @@
+/**
+ * On-demand trigger for the host's launchd `claude-token-sync` agent.
+ *
+ * Background — see DECISIONS-AND-CHANGES.md D-025 for the full context.
+ * The macOS Keychain is the single source of truth for the Claude OAuth
+ * payload, refreshed only by the host `claude` CLI during interactive use.
+ * A launchd agent on the host mirrors the Keychain into
+ * `~/.claude/.credentials.json` every 2 h so the dashboard container can
+ * read it. **The container never refreshes the token.**
+ *
+ * Failure mode this module fixes: a host-side `claude` invocation (e.g. an
+ * agent debugging from the same machine) rotates the Keychain refresh_token,
+ * which revokes the access_token still cached in the container's mounted
+ * credentials file. The next CLI spawn from the container fails with
+ * `401 authentication_failed`. Without this helper, the user has to wait
+ * up to 2 h for the next launchd cycle (or run the install script manually).
+ *
+ * On-demand path:
+ *   1. The CLI runner detects a 401 / LLM_CLI_AUTH error.
+ *   2. It calls `triggerHostTokenSync()`.
+ *   3. We touch `/config/.claude-token-kick` (host-mounted rw at
+ *      `~/.config/powershop-analytics/.claude-token-kick`).
+ *   4. The host launchd agent's `WatchPaths` fires, runs the same
+ *      sync-only script (no refresh — D-025 stands), and writes the
+ *      current Keychain content into `~/.claude/.credentials.json`
+ *      via temp+rename (atomic).
+ *   5. We poll the credentials file's mtime; once it advances we know
+ *      the file was rewritten and the runner can retry the spawn.
+ *
+ * This helper is deliberately a no-op when the host plumbing is missing
+ * (kick path absent or unwritable, credentials file absent) — a single
+ * 401 will then surface to the user as before, with the diagnostic hint
+ * to run the install script.
+ */
+
+import { stat, utimes } from "node:fs/promises";
+
+/** Default container-side path to the host kick file (bind-mounted rw). */
+export const DEFAULT_KICK_PATH = "/config/.claude-token-kick";
+/** Default container-side path to the (read-only) credentials mirror. */
+export const DEFAULT_CREDS_PATH = "/home/nextjs/.claude/.credentials.json";
+
+export interface TriggerHostTokenSyncOptions {
+  /** Override path to the kick file (mostly for tests). */
+  kickPath?: string;
+  /** Override path to the credentials file used to detect a fresh sync. */
+  credsPath?: string;
+  /** Maximum total wait for the credentials file mtime to advance, ms. */
+  waitMaxMs?: number;
+  /** Polling interval while waiting, ms. */
+  pollIntervalMs?: number;
+}
+
+export type TriggerHostTokenSyncOutcome =
+  /** Kick was sent and the credentials file mtime advanced before the timeout. */
+  | { ok: true; waitedMs: number; credsPath: string }
+  /** Kick was sent but the credentials file did not change in time. The
+   *  caller should still retry once — launchd may have fired but the file's
+   *  mtime granularity (1 s on HFS+/APFS via Docker volume) can hide a
+   *  same-second update. */
+  | { ok: true; timeout: true; waitedMs: number; credsPath: string }
+  /** Could not even send the kick (kick file missing / not writable, or
+   *  credentials path missing). Caller should not retry — it would fail
+   *  exactly the same way. The reason is included verbatim for the
+   *  diagnostic surface. */
+  | { ok: false; reason: string };
+
+async function readMtimeMs(path: string): Promise<number | null> {
+  try {
+    const s = await stat(path);
+    return s.mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/** Touch a path by setting its atime/mtime to "now" via `utimes`. Does NOT
+ *  create the file if absent — the install script seeds it. */
+async function touchPath(path: string): Promise<void> {
+  const now = new Date();
+  await utimes(path, now, now);
+}
+
+export async function triggerHostTokenSync(
+  opts: TriggerHostTokenSyncOptions = {},
+): Promise<TriggerHostTokenSyncOutcome> {
+  const kickPath = opts.kickPath ?? DEFAULT_KICK_PATH;
+  const credsPath = opts.credsPath ?? DEFAULT_CREDS_PATH;
+  const waitMaxMs = opts.waitMaxMs ?? 6_000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 200;
+
+  // Snapshot the credentials mtime *before* the kick so we can detect the
+  // sync writing a new file. If the credentials path doesn't exist we can't
+  // detect anything — surface clearly.
+  const beforeMs = await readMtimeMs(credsPath);
+  if (beforeMs === null) {
+    return {
+      ok: false,
+      reason: `credentials file not found at ${credsPath} — host launchd agent may not be installed or volume mount is missing`,
+    };
+  }
+
+  try {
+    await touchPath(kickPath);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      reason: `cannot touch kick file at ${kickPath}: ${message} — host launchd agent likely not installed (run scripts/install-claude-token-launchd.sh on the host)`,
+    };
+  }
+
+  // Poll for mtime advance with exponential-ish steady polling.
+  const startedAtMs = Date.now();
+  while (Date.now() - startedAtMs < waitMaxMs) {
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+    const nowMs = await readMtimeMs(credsPath);
+    if (nowMs !== null && nowMs > beforeMs) {
+      return { ok: true, waitedMs: Date.now() - startedAtMs, credsPath };
+    }
+  }
+
+  return {
+    ok: true,
+    timeout: true,
+    waitedMs: Date.now() - startedAtMs,
+    credsPath,
+  };
+}

--- a/dashboard/lib/llm-provider/openrouter.ts
+++ b/dashboard/lib/llm-provider/openrouter.ts
@@ -147,7 +147,7 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
           totalCharsEmitted += deltaChars;
           if (input.onTextDelta) {
             try {
-              input.onTextDelta(deltaChars, totalCharsEmitted);
+              input.onTextDelta(deltaChars, totalCharsEmitted, textContent);
             } catch {
               /* ignore callback errors */
             }

--- a/dashboard/lib/llm-tools/runner-types.ts
+++ b/dashboard/lib/llm-tools/runner-types.ts
@@ -35,8 +35,16 @@ export interface AgenticRunStepInput {
   temperature: number;
   maxTokens: number;
   /** Optional callback invoked as the model streams text chunks. `chars` is the
-   *  incremental count for this chunk; `totalChars` is the running total. */
-  onTextDelta?: (chars: number, totalChars: number) => void;
+   *  incremental count for this chunk; `totalChars` is the running total.
+   *  `accumulatedText` is the full assistant text emitted so far this step,
+   *  so the UI can render Claude's response in real time. */
+  onTextDelta?: (chars: number, totalChars: number, accumulatedText: string) => void;
+  /** Optional callback invoked while the model is in extended-thinking mode.
+   *  Same contract as `onTextDelta` but for the chain-of-thought block. Fires
+   *  *before* the final answer text starts streaming (Claude only — OpenRouter
+   *  text streaming has no extended-thinking phase, so this is never invoked
+   *  for that adapter). */
+  onThinkingDelta?: (chars: number, totalChars: number, accumulatedThinking: string) => void;
 }
 
 export interface AgenticModelAdapter {

--- a/dashboard/lib/llm-tools/runner.ts
+++ b/dashboard/lib/llm-tools/runner.ts
@@ -182,7 +182,15 @@ function emitAgenticProgress(ctx: LlmAgenticContext, event: AgenticProgressEvent
   } catch (hookErr) {
     console.warn("[agentic] onAgenticProgress hook failed:", hookErr);
   }
-  console.info(`[agentic][${ctx.endpoint}][${ctx.requestId}]`, JSON.stringify(event));
+  // Server logs: drop the cumulative `text` payload from model_text_delta /
+  // model_thinking_delta — it grows with every token chunk and would flood the
+  // log with redundant copies of Claude's running response/reasoning. The
+  // client still receives the full text via the NDJSON stream.
+  const logEvent =
+    (event.type === "model_text_delta" || event.type === "model_thinking_delta") && "text" in event
+      ? { ...event, text: undefined }
+      : event;
+  console.info(`[agentic][${ctx.endpoint}][${ctx.requestId}]`, JSON.stringify(logEvent));
 }
 
 export async function runAgenticChat(params: AgenticRunParams): Promise<AgenticRunResult> {
@@ -255,12 +263,22 @@ export async function runAgenticChat(params: AgenticRunParams): Promise<AgenticR
         model,
         temperature,
         maxTokens,
-        onTextDelta: (chars, totalChars) => {
+        onTextDelta: (chars, totalChars, accumulatedText) => {
           emitAgenticProgress(ctx, {
             type: "model_text_delta",
             round: round + 1,
             chars,
             totalChars,
+            text: accumulatedText,
+          });
+        },
+        onThinkingDelta: (chars, totalChars, accumulatedThinking) => {
+          emitAgenticProgress(ctx, {
+            type: "model_thinking_delta",
+            round: round + 1,
+            chars,
+            totalChars,
+            text: accumulatedThinking,
           });
         },
       };

--- a/dashboard/lib/llm-tools/runner.ts
+++ b/dashboard/lib/llm-tools/runner.ts
@@ -182,12 +182,12 @@ function emitAgenticProgress(ctx: LlmAgenticContext, event: AgenticProgressEvent
   } catch (hookErr) {
     console.warn("[agentic] onAgenticProgress hook failed:", hookErr);
   }
-  // Server logs: drop the cumulative `text` payload from model_text_delta /
-  // model_thinking_delta — it grows with every token chunk and would flood the
-  // log with redundant copies of Claude's running response/reasoning. The
-  // client still receives the full text via the NDJSON stream.
+  // Server logs: drop the cumulative `text` payload from model_thinking_delta
+  // — it grows with every token chunk and would flood the log with redundant
+  // copies of Claude's running reasoning. The client still receives the full
+  // text via the NDJSON stream. (`model_text_delta` no longer carries `text`.)
   const logEvent =
-    (event.type === "model_text_delta" || event.type === "model_thinking_delta") && "text" in event
+    event.type === "model_thinking_delta" && "text" in event
       ? { ...event, text: undefined }
       : event;
   console.info(`[agentic][${ctx.endpoint}][${ctx.requestId}]`, JSON.stringify(logEvent));
@@ -263,13 +263,12 @@ export async function runAgenticChat(params: AgenticRunParams): Promise<AgenticR
         model,
         temperature,
         maxTokens,
-        onTextDelta: (chars, totalChars, accumulatedText) => {
+        onTextDelta: (chars, totalChars) => {
           emitAgenticProgress(ctx, {
             type: "model_text_delta",
             round: round + 1,
             chars,
             totalChars,
-            text: accumulatedText,
           });
         },
         onThinkingDelta: (chars, totalChars, accumulatedThinking) => {

--- a/dashboard/lib/llm-tools/types.ts
+++ b/dashboard/lib/llm-tools/types.ts
@@ -10,7 +10,23 @@ import type { ReviewLlmOutput } from "@/lib/review-schema";
 export type AgenticProgressEvent =
   | { type: "round"; round: number; maxRounds: number }
   | { type: "model_step_start"; round: number; provider: DashboardLlmProviderId; driver: DashboardCliDriverId | null }
-  | { type: "model_text_delta"; round: number; chars: number; totalChars: number }
+  | {
+      type: "model_text_delta";
+      round: number;
+      chars: number;
+      totalChars: number;
+      /** Full assistant text streamed so far this step (cumulative). Optional —
+       *  older clients/adapters may omit it; UI must tolerate undefined. */
+      text?: string;
+    }
+  | {
+      type: "model_thinking_delta";
+      round: number;
+      chars: number;
+      totalChars: number;
+      /** Full extended-thinking text streamed so far this step (cumulative). */
+      text?: string;
+    }
   | { type: "assistant_tools"; round: number; tools: string[] }
   | { type: "tool_start"; round: number; name: string; toolCallId: string; argsPreview?: string }
   | {

--- a/dashboard/lib/llm-tools/types.ts
+++ b/dashboard/lib/llm-tools/types.ts
@@ -15,9 +15,11 @@ export type AgenticProgressEvent =
       round: number;
       chars: number;
       totalChars: number;
-      /** Full assistant text streamed so far this step (cumulative). Optional —
-       *  older clients/adapters may omit it; UI must tolerate undefined. */
-      text?: string;
+      // No `text` field: the streaming UI only renders the running counter for
+      // text deltas (the body is the JSON tool-protocol payload, not human
+      // prose), so emitting the cumulative text on every token would grow each
+      // NDJSON frame quadratically. Readable prose is carried by
+      // `model_thinking_delta` instead.
     }
   | {
       type: "model_thinking_delta";

--- a/dashboard/lib/llm.ts
+++ b/dashboard/lib/llm.ts
@@ -111,7 +111,6 @@ async function chatTextWithProgress(
           round: 1,
           chars: text.length,
           totalChars: text.length,
-          text,
         });
       } catch {
         /* ignore */
@@ -149,7 +148,6 @@ async function chatTextWithProgress(
             round: 1,
             chars: deltaChars,
             totalChars: totalCharsEmitted,
-            text: textContent,
           });
         } catch {
           /* ignore */

--- a/dashboard/lib/llm.ts
+++ b/dashboard/lib/llm.ts
@@ -111,6 +111,7 @@ async function chatTextWithProgress(
           round: 1,
           chars: text.length,
           totalChars: text.length,
+          text,
         });
       } catch {
         /* ignore */
@@ -148,6 +149,7 @@ async function chatTextWithProgress(
             round: 1,
             chars: deltaChars,
             totalChars: totalCharsEmitted,
+            text: textContent,
           });
         } catch {
           /* ignore */

--- a/dashboard/lib/review-queries.ts
+++ b/dashboard/lib/review-queries.ts
@@ -192,6 +192,11 @@ WHERE abono = false
   AND fecha_factura < $2::date`,
   },
   {
+    // ps_gc_facturas.num_cliente actually stores the parent's `reg_cliente`
+    // PK (the `.990`-suffixed Real, not the `.000` `NumCliente` code), so the
+    // join key on the right side is `ps_clientes.reg_cliente`. Joining on
+    // `c.num_cliente` returned zero matches and the COALESCE fell back to
+    // the numeric ID instead of the textual name.
     name: "top3_clientes_mayorista_semana_cerrada",
     domain: "canal_mayorista",
     sql: `SELECT
@@ -200,7 +205,7 @@ WHERE abono = false
   COALESCE(SUM(f.base1 + f.base2 + f.base3), 0) AS facturacion_neta,
   COUNT(*) AS num_facturas
 FROM ps_gc_facturas f
-LEFT JOIN ps_clientes c ON c.num_cliente = f.num_cliente
+LEFT JOIN ps_clientes c ON c.reg_cliente = f.num_cliente
 WHERE f.abono = false
   AND f.fecha_factura >= $1::date
   AND f.fecha_factura < $2::date
@@ -227,15 +232,20 @@ WHERE NOT EXISTS (
   // ── Stock ──────────────────────────────────────────────────────────────────
 
   {
+    // Warehouse stock lives in ps_stock_central (sourced from 4D CCStock per
+    // D-017), NOT in ps_stock_tienda — there is no `tienda='99'` row in the
+    // store-level mirror. Tiendas = SUM over real stores; Almacén = SUM over
+    // ps_stock_central. Total combines both. Each side uses its own
+    // distinct-codigo count.
     name: "stock_total_unidades",
     domain: "stock",
     sql: `SELECT
-  COUNT(DISTINCT codigo) AS num_referencias,
-  SUM(stock) AS stock_total,
-  SUM(CASE WHEN tienda <> '99' THEN stock ELSE 0 END) AS stock_tiendas,
-  SUM(CASE WHEN tienda = '99' THEN stock ELSE 0 END) AS stock_almacen
-FROM ps_stock_tienda
-WHERE stock > 0`,
+  (SELECT COUNT(DISTINCT codigo) FROM ps_stock_tienda WHERE stock > 0 AND tienda <> '99') AS referencias_tiendas,
+  (SELECT COUNT(*) FROM ps_stock_central WHERE stock > 0) AS referencias_almacen,
+  (SELECT COALESCE(SUM(stock), 0) FROM ps_stock_tienda WHERE stock > 0 AND tienda <> '99') AS stock_tiendas,
+  (SELECT COALESCE(SUM(stock), 0) FROM ps_stock_central WHERE stock > 0) AS stock_almacen,
+  (SELECT COALESCE(SUM(stock), 0) FROM ps_stock_tienda WHERE stock > 0 AND tienda <> '99')
+    + (SELECT COALESCE(SUM(stock), 0) FROM ps_stock_central WHERE stock > 0) AS stock_total`,
   },
   {
     name: "articulos_stock_critico",
@@ -262,24 +272,83 @@ WHERE (fecha_s >= $1::date AND fecha_s < $2::date)
   },
 
   // ── Compras ────────────────────────────────────────────────────────────────
+  // Header counts come from ps_compras (fecha_pedido). Amount + unit totals
+  // come from ps_lineas_compras (CCLineasCompr; total_si and unidades both
+  // populated, confirmed 2026-05-01). The two counts can diverge: a header
+  // can exist without lines (open POs not yet detailed) — we surface both
+  // so the model can flag the gap.
 
   {
     name: "compras_semana_cerrada",
     domain: "compras",
     sql: `SELECT
-  COUNT(*) AS num_pedidos
-FROM ps_compras
-WHERE fecha_pedido >= $1::date
-  AND fecha_pedido < $2::date`,
+  (SELECT COUNT(*) FROM ps_compras
+     WHERE fecha_pedido >= $1::date AND fecha_pedido < $2::date) AS num_pedidos,
+  (SELECT COUNT(DISTINCT lc.num_pedido) FROM ps_lineas_compras lc
+     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
+     WHERE c.fecha_pedido >= $1::date AND c.fecha_pedido < $2::date) AS pedidos_con_lineas,
+  (SELECT COUNT(*) FROM ps_lineas_compras lc
+     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
+     WHERE c.fecha_pedido >= $1::date AND c.fecha_pedido < $2::date) AS num_lineas,
+  (SELECT COALESCE(SUM(lc.unidades), 0) FROM ps_lineas_compras lc
+     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
+     WHERE c.fecha_pedido >= $1::date AND c.fecha_pedido < $2::date) AS unidades_compradas,
+  (SELECT COALESCE(SUM(lc.total_si), 0) FROM ps_lineas_compras lc
+     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
+     WHERE c.fecha_pedido >= $1::date AND c.fecha_pedido < $2::date) AS importe_neto_si`,
   },
   {
     name: "compras_semana_previa",
     domain: "compras",
     sql: `SELECT
-  COUNT(*) AS num_pedidos
-FROM ps_compras
-WHERE fecha_pedido >= ($1::date - INTERVAL '7 days')
-  AND fecha_pedido < $1::date`,
+  (SELECT COUNT(*) FROM ps_compras
+     WHERE fecha_pedido >= ($1::date - INTERVAL '7 days') AND fecha_pedido < $1::date) AS num_pedidos,
+  (SELECT COUNT(DISTINCT lc.num_pedido) FROM ps_lineas_compras lc
+     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
+     WHERE c.fecha_pedido >= ($1::date - INTERVAL '7 days') AND c.fecha_pedido < $1::date) AS pedidos_con_lineas,
+  (SELECT COUNT(*) FROM ps_lineas_compras lc
+     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
+     WHERE c.fecha_pedido >= ($1::date - INTERVAL '7 days') AND c.fecha_pedido < $1::date) AS num_lineas,
+  (SELECT COALESCE(SUM(lc.unidades), 0) FROM ps_lineas_compras lc
+     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
+     WHERE c.fecha_pedido >= ($1::date - INTERVAL '7 days') AND c.fecha_pedido < $1::date) AS unidades_compradas,
+  (SELECT COALESCE(SUM(lc.total_si), 0) FROM ps_lineas_compras lc
+     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
+     WHERE c.fecha_pedido >= ($1::date - INTERVAL '7 days') AND c.fecha_pedido < $1::date) AS importe_neto_si`,
+  },
+  {
+    name: "top3_proveedores_compras_semana_cerrada",
+    domain: "compras",
+    sql: `SELECT
+  COALESCE(p.nombre, lc.num_proveedor::text) AS proveedor,
+  COUNT(DISTINCT lc.num_pedido) AS num_pedidos,
+  COALESCE(SUM(lc.unidades), 0) AS unidades,
+  COALESCE(SUM(lc.total_si), 0) AS importe_neto_si
+FROM ps_lineas_compras lc
+JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
+LEFT JOIN ps_proveedores p ON p.reg_proveedor = lc.num_proveedor
+WHERE c.fecha_pedido >= $1::date
+  AND c.fecha_pedido < $2::date
+GROUP BY p.nombre, lc.num_proveedor
+ORDER BY importe_neto_si DESC NULLS LAST
+LIMIT 3`,
+  },
+  {
+    name: "top5_articulos_compras_semana_cerrada",
+    domain: "compras",
+    sql: `SELECT
+  COALESCE(a.ccrefejofacm, a.codigo, lc.num_articulo::text) AS referencia,
+  COALESCE(a.descripcion, '') AS descripcion,
+  COALESCE(SUM(lc.unidades), 0) AS unidades,
+  COALESCE(SUM(lc.total_si), 0) AS importe_neto_si
+FROM ps_lineas_compras lc
+JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
+LEFT JOIN ps_articulos a ON a.reg_articulo = lc.num_articulo
+WHERE c.fecha_pedido >= $1::date
+  AND c.fecha_pedido < $2::date
+GROUP BY a.ccrefejofacm, a.codigo, a.descripcion, lc.num_articulo
+ORDER BY unidades DESC NULLS LAST
+LIMIT 5`,
   },
 ];
 

--- a/dashboard/lib/review-queries.ts
+++ b/dashboard/lib/review-queries.ts
@@ -234,18 +234,27 @@ WHERE NOT EXISTS (
   {
     // Warehouse stock lives in ps_stock_central (sourced from 4D CCStock per
     // D-017), NOT in ps_stock_tienda — there is no `tienda='99'` row in the
-    // store-level mirror. Tiendas = SUM over real stores; Almacén = SUM over
-    // ps_stock_central. Total combines both. Each side uses its own
-    // distinct-codigo count.
+    // store-level mirror. CTEs aggregate each table once (count + sum) so
+    // PostgreSQL doesn't re-scan the 12 M-row stock_tienda for every column.
     name: "stock_total_unidades",
     domain: "stock",
-    sql: `SELECT
-  (SELECT COUNT(DISTINCT codigo) FROM ps_stock_tienda WHERE stock > 0 AND tienda <> '99') AS referencias_tiendas,
-  (SELECT COUNT(*) FROM ps_stock_central WHERE stock > 0) AS referencias_almacen,
-  (SELECT COALESCE(SUM(stock), 0) FROM ps_stock_tienda WHERE stock > 0 AND tienda <> '99') AS stock_tiendas,
-  (SELECT COALESCE(SUM(stock), 0) FROM ps_stock_central WHERE stock > 0) AS stock_almacen,
-  (SELECT COALESCE(SUM(stock), 0) FROM ps_stock_tienda WHERE stock > 0 AND tienda <> '99')
-    + (SELECT COALESCE(SUM(stock), 0) FROM ps_stock_central WHERE stock > 0) AS stock_total`,
+    sql: `WITH tiendas AS (
+  SELECT COUNT(DISTINCT codigo) AS refs, COALESCE(SUM(stock), 0) AS stk
+  FROM ps_stock_tienda
+  WHERE stock > 0 AND tienda <> '99'
+),
+almacen AS (
+  SELECT COUNT(*) AS refs, COALESCE(SUM(stock), 0) AS stk
+  FROM ps_stock_central
+  WHERE stock > 0
+)
+SELECT
+  tiendas.refs AS referencias_tiendas,
+  almacen.refs AS referencias_almacen,
+  tiendas.stk  AS stock_tiendas,
+  almacen.stk  AS stock_almacen,
+  tiendas.stk + almacen.stk AS stock_total
+FROM tiendas, almacen`,
   },
   {
     name: "articulos_stock_critico",
@@ -279,42 +288,60 @@ WHERE (fecha_s >= $1::date AND fecha_s < $2::date)
   // so the model can flag the gap.
 
   {
+    // Single-pass aggregation: pedidos count from ps_compras, line metrics
+    // from ps_lineas_compras filtered through the same date range. Cross-join
+    // produces one row with all five columns and avoids re-scanning either
+    // table per scalar subquery.
     name: "compras_semana_cerrada",
     domain: "compras",
-    sql: `SELECT
-  (SELECT COUNT(*) FROM ps_compras
-     WHERE fecha_pedido >= $1::date AND fecha_pedido < $2::date) AS num_pedidos,
-  (SELECT COUNT(DISTINCT lc.num_pedido) FROM ps_lineas_compras lc
-     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
-     WHERE c.fecha_pedido >= $1::date AND c.fecha_pedido < $2::date) AS pedidos_con_lineas,
-  (SELECT COUNT(*) FROM ps_lineas_compras lc
-     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
-     WHERE c.fecha_pedido >= $1::date AND c.fecha_pedido < $2::date) AS num_lineas,
-  (SELECT COALESCE(SUM(lc.unidades), 0) FROM ps_lineas_compras lc
-     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
-     WHERE c.fecha_pedido >= $1::date AND c.fecha_pedido < $2::date) AS unidades_compradas,
-  (SELECT COALESCE(SUM(lc.total_si), 0) FROM ps_lineas_compras lc
-     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
-     WHERE c.fecha_pedido >= $1::date AND c.fecha_pedido < $2::date) AS importe_neto_si`,
+    sql: `WITH pedidos AS (
+  SELECT COUNT(*) AS n
+  FROM ps_compras
+  WHERE fecha_pedido >= $1::date AND fecha_pedido < $2::date
+),
+lineas AS (
+  SELECT
+    COUNT(DISTINCT lc.num_pedido) AS pedidos_con_lineas,
+    COUNT(*) AS num_lineas,
+    COALESCE(SUM(lc.unidades), 0) AS unidades,
+    COALESCE(SUM(lc.total_si), 0) AS importe
+  FROM ps_lineas_compras lc
+  JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
+  WHERE c.fecha_pedido >= $1::date AND c.fecha_pedido < $2::date
+)
+SELECT
+  pedidos.n               AS num_pedidos,
+  lineas.pedidos_con_lineas,
+  lineas.num_lineas,
+  lineas.unidades         AS unidades_compradas,
+  lineas.importe          AS importe_neto_si
+FROM pedidos, lineas`,
   },
   {
     name: "compras_semana_previa",
     domain: "compras",
-    sql: `SELECT
-  (SELECT COUNT(*) FROM ps_compras
-     WHERE fecha_pedido >= ($1::date - INTERVAL '7 days') AND fecha_pedido < $1::date) AS num_pedidos,
-  (SELECT COUNT(DISTINCT lc.num_pedido) FROM ps_lineas_compras lc
-     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
-     WHERE c.fecha_pedido >= ($1::date - INTERVAL '7 days') AND c.fecha_pedido < $1::date) AS pedidos_con_lineas,
-  (SELECT COUNT(*) FROM ps_lineas_compras lc
-     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
-     WHERE c.fecha_pedido >= ($1::date - INTERVAL '7 days') AND c.fecha_pedido < $1::date) AS num_lineas,
-  (SELECT COALESCE(SUM(lc.unidades), 0) FROM ps_lineas_compras lc
-     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
-     WHERE c.fecha_pedido >= ($1::date - INTERVAL '7 days') AND c.fecha_pedido < $1::date) AS unidades_compradas,
-  (SELECT COALESCE(SUM(lc.total_si), 0) FROM ps_lineas_compras lc
-     JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
-     WHERE c.fecha_pedido >= ($1::date - INTERVAL '7 days') AND c.fecha_pedido < $1::date) AS importe_neto_si`,
+    sql: `WITH pedidos AS (
+  SELECT COUNT(*) AS n
+  FROM ps_compras
+  WHERE fecha_pedido >= ($1::date - INTERVAL '7 days') AND fecha_pedido < $1::date
+),
+lineas AS (
+  SELECT
+    COUNT(DISTINCT lc.num_pedido) AS pedidos_con_lineas,
+    COUNT(*) AS num_lineas,
+    COALESCE(SUM(lc.unidades), 0) AS unidades,
+    COALESCE(SUM(lc.total_si), 0) AS importe
+  FROM ps_lineas_compras lc
+  JOIN ps_compras c ON c.reg_pedido = lc.num_pedido
+  WHERE c.fecha_pedido >= ($1::date - INTERVAL '7 days') AND c.fecha_pedido < $1::date
+)
+SELECT
+  pedidos.n               AS num_pedidos,
+  lineas.pedidos_con_lineas,
+  lineas.num_lineas,
+  lineas.unidades         AS unidades_compradas,
+  lineas.importe          AS importe_neto_si
+FROM pedidos, lineas`,
   },
   {
     name: "top3_proveedores_compras_semana_cerrada",
@@ -396,8 +423,9 @@ export async function executeReviewQueries(
     REVIEW_QUERIES.map((q) => {
       const n = highestPlaceholder(q.sql);
       // Slice to exactly the placeholders this query uses (n=0 → no params).
-      // Pads with undefined defensively if a query references $N beyond the
-      // available `weekParams`, so the DB driver returns a clear error.
+      // If a query references `$N` beyond the supplied `weekParams`, slice
+      // returns the full array and the driver surfaces a missing-parameter
+      // error — that's the expected loud failure for a malformed query.
       const params = n === 0 ? undefined : weekParams.slice(0, n);
       return queryFn(q.sql, params);
     })

--- a/dashboard/lib/review-queries.ts
+++ b/dashboard/lib/review-queries.ts
@@ -301,6 +301,22 @@ WHERE fecha_pedido >= ($1::date - INTERVAL '7 days')
  * @param weekEndExclusive - Monday after the review week (YYYY-MM-DD), exclusive upper bound
  * @returns Array of ReviewQueryResult (success or error per query)
  */
+/**
+ * Highest `$N` placeholder referenced by a SQL string. PostgreSQL's bind
+ * protocol rejects extra parameters with "wrong number of parameters for
+ * prepared statement" — a query that only references `$1` must receive
+ * exactly one parameter, not two. We use this to size the per-query param
+ * array correctly even when callers always pass `[weekStart, weekEnd]`.
+ */
+function highestPlaceholder(sql: string): number {
+  let max = 0;
+  for (const m of sql.matchAll(/\$(\d+)/g)) {
+    const n = Number(m[1]);
+    if (n > max) max = n;
+  }
+  return max;
+}
+
 export async function executeReviewQueries(
   queryFn: (sql: string, params?: unknown[]) => Promise<QueryResult>,
   weekStart: string,
@@ -308,7 +324,14 @@ export async function executeReviewQueries(
 ): Promise<ReviewQueryResult[]> {
   const weekParams = [weekStart, weekEndExclusive];
   const results = await Promise.allSettled(
-    REVIEW_QUERIES.map((q) => queryFn(q.sql, weekParams))
+    REVIEW_QUERIES.map((q) => {
+      const n = highestPlaceholder(q.sql);
+      // Slice to exactly the placeholders this query uses (n=0 → no params).
+      // Pads with undefined defensively if a query references $N beyond the
+      // available `weekParams`, so the DB driver returns a clear error.
+      const params = n === 0 ? undefined : weekParams.slice(0, n);
+      return queryFn(q.sql, params);
+    })
   );
 
   return REVIEW_QUERIES.map((q, i) => {

--- a/etl/sync/maestros.py
+++ b/etl/sync/maestros.py
@@ -85,16 +85,19 @@ def _discover_columns(
 
 # Mapping from lowercase 4D column names → PostgreSQL column names.
 # Only the columns present in ps_clientes (init.sql) are mapped.
-# Actual 4D column names discovered via _USER_COLUMNS:
+# Actual 4D column names discovered via _USER_COLUMNS + docs/schema-discovery:
 #   - NumCliente does not exist; Codigo is the client code
-#   - Nombre does not exist; NombreComercial is the commercial name (it's in safe cols)
+#   - Cliente (Alpha 100) is the canonical customer name. NombreComercial
+#     exists too but is empty for ~98% of rows (27 452 / 27 988); using it
+#     leaves the wholesale review showing num_cliente numerics instead of
+#     names. Same gotcha pattern as Proveedores.NombreComercial (D-017).
 #   - NIF does not exist; CIF is the tax ID
 #   - Email does not exist (case-sensitive); 'email' (lowercase) is the column
 #   - CodigoPostal does not exist; Postal is the zip code
 _CLIENTES_MAP: dict[str, str] = {
     "regcliente": "reg_cliente",
     "codigo": "num_cliente",  # Codigo = client code (maps to num_cliente)
-    "nombrecomercial": "nombre",  # NombreComercial = business name (maps to nombre)
+    "cliente": "nombre",  # Cliente = canonical customer name (Alpha 100)
     "cif": "nif",  # CIF = tax ID (maps to nif)
     "email": "email",  # email (lowercase in 4D)
     "postal": "codigo_postal",  # Postal = zip code (maps to codigo_postal)
@@ -108,10 +111,13 @@ _CLIENTES_MAP: dict[str, str] = {
 # Preferred 4D column names to query (original casing required in SQL).
 # These are the *desired* columns; if a column is missing from the table
 # it will be silently omitted by the discovery step.
+# `NombreComercial` is queried as a fallback for the few rows where Cliente
+# is empty: the post-fetch loop COALESCEs them.
 _CLIENTES_DESIRED = [
     "RegCliente",
     "Codigo",  # client code → num_cliente
-    "NombreComercial",  # business name → nombre
+    "Cliente",  # canonical name → nombre (preferred)
+    "NombreComercial",  # business name fallback when Cliente is empty
     "CIF",  # tax ID → nif
     "email",  # email (lowercase in 4D)
     "Postal",  # zip code → codigo_postal
@@ -157,6 +163,15 @@ def sync_clientes(conn_4d, conn_pg) -> int:
                 if pg_key in ("reg_cliente", "num_cliente"):
                     v = _to_decimal(v)
                 mapped[pg_key] = v
+        # Fallback: if the canonical Cliente field is empty for this row but
+        # NombreComercial has something, use it. ~98% of clients had Cliente
+        # populated and NombreComercial empty in the live mirror, but the few
+        # rows that only have NombreComercial would otherwise show num_cliente.
+        nombre = mapped.get("nombre")
+        if (nombre is None or nombre == "") and "nombrecomercial" in row:
+            fallback = row["nombrecomercial"]
+            if fallback:
+                mapped["nombre"] = fallback
         pg_rows.append(mapped)
 
     count = truncate_and_insert(conn_pg, "ps_clientes", pg_rows)

--- a/scripts/install-claude-token-launchd.sh
+++ b/scripts/install-claude-token-launchd.sh
@@ -37,6 +37,17 @@ fi
 
 mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs"
 
+# Ensure the kick file exists so launchd's WatchPaths has something to watch.
+# The dashboard container touches this file on demand to trigger an
+# immediate Keychain → ~/.claude/.credentials.json sync (recovery path
+# for the case where a host-side `claude` invocation rotates the
+# refresh_token while the container still holds the previous access_token).
+KICK_DIR="$HOME/.config/powershop-analytics"
+KICK_FILE="$KICK_DIR/.claude-token-kick"
+mkdir -p "$KICK_DIR"
+[ -e "$KICK_FILE" ] || : > "$KICK_FILE"
+chmod 0664 "$KICK_FILE"
+
 # Render template. We use `|` as the sed delimiter so the substituted absolute
 # paths (which contain `/`) do not need escaping.
 sed \

--- a/scripts/launchd/com.powershop.claude-token-sync.plist.template
+++ b/scripts/launchd/com.powershop.claude-token-sync.plist.template
@@ -17,6 +17,18 @@
   <key>StartInterval</key>
   <integer>7200</integer>
 
+  <!-- Also fire on demand: when a process (typically the dashboard container)
+       writes/touches the kick file, launchd runs the sync script immediately.
+       This is the recovery path for the case where my own use of `claude` on
+       the host rotates the Keychain refresh_token while the container still
+       holds the previous access_token (now revoked server-side). The kick
+       only ever triggers the same mirror-from-Keychain script — it never
+       refreshes anything itself, preserving D-025's single-refresher rule. -->
+  <key>WatchPaths</key>
+  <array>
+    <string>__HOME__/.config/powershop-analytics/.claude-token-kick</string>
+  </array>
+
   <!-- Capture both streams to the same log file so the cause of any error is
        in one place. The launchd agent runs as the user, so the log inherits
        the user's permissions. -->


### PR DESCRIPTION
## Summary

End-to-end fixes for the three issues that surfaced together while debugging the weekly review with the Claude CLI provider:

- **Live streaming from Claude across review / modify / analyze**: token-level deltas, visible chain-of-thought, no more "Modelo pensando…" hanging while the model thinks for 30-60 s.
- **Five systemic review SQL failures** fixed at root cause: param count and a wrong ETL column mapping for customer name.
- **UI cleanup**: dead `Glosario` nav link removed; review error display now shows the rich `AGENTIC_RUNNER` diagnostic (provider/driver/CLI tail/limits).

## Streaming (review + modify + analyze)

- `claude -p` now runs with `--include-partial-messages` so it emits token-level `stream_event content_block_delta` events. `parseStreamJsonLine` distinguishes `text_delta` (incremental) vs `text_full` (cumulative duplicate, skipped when deltas were already seen) and surfaces extended-thinking via `thinking_delta`.
- New `model_thinking_delta` event + `onThinkingDelta` callback through the runner / CLI / adapter chain. Renders as **"Claude está razonando"** with the chain-of-thought as the row body — users can literally see Claude reason.
- `model_text_delta` keeps only the running char counter (the streamed text is the JSON tool-protocol payload, illegible — per user feedback).
- `LogLine` gains optional `body`; `LogBlock` renders it under the row as a monospace pre-block.
- `modify` and `analyze` routes install a `liveSend` pump once their streaming controller opens — events bypass the buffer that previously held everything until `await llmPromise` resolved.
- `ChatSidebar` coalesces consecutive streaming ticks on receive (`appendCoalescedLogLine`) so token-level frames don't stack hundreds of identical rows.
- Server logs strip the cumulative `text` payload before `console.info` to keep log volume bounded.

## Review SQL fixes (5 systemic failures)

- `executeReviewQueries` now slices `weekParams` to exactly the `$N` placeholders each query uses. PostgreSQL's bind protocol rejects extra parameters with `wrong number of parameters for prepared statement` — root cause for **ventas_semana_previa**, **compras_semana_previa**, **stock_total_unidades**, **articulos_stock_critico** all reporting "error de consulta".
- **top3_clientes_mayorista_semana_cerrada** showed numeric `num_cliente` instead of names because `ps_clientes.nombre` was empty for 27 452 / 27 988 rows: the ETL was mapping `NombreComercial` (empty in 4D) instead of `Cliente` (Alpha 100, the canonical customer name). Same gotcha pattern as `Proveedores.NombreComercial` (D-017). Maestros sync now prefers `Cliente` and falls back to NombreComercial. Take effect next sync; you can also trigger a force-resync via the ETL Monitor for the `clientes` table.

## Review error display

- `/review` now passes the full `ApiErrorResponse` to `<ErrorDisplay>` (which already renders the AGENTIC_RUNNER diagnostic via `AgenticErrorDetails`). Previously only `err.message` was kept and the diagnostic was silently discarded — that's why the original "El flujo de IA alcanzó un límite o no pudo completarse" was useless to debug.

## UI cleanup

- Dead `Glosario` nav link removed from `TopBar` — the route was a no-op redirect to `/`. The real glossary panel inside each dashboard (per-panel button → `GlossaryPanel`) is unaffected.

## Test plan

- [ ] `/review` → "Generar revisión semanal" — the LogBlock shows "Claude está razonando" growing with chain-of-thought; later "Modelo respondiendo · N caracteres" (counter only, no body); `submit_weekly_review` tool call ✓; review page renders without "error de consulta" notes for the 4 SQL queries; top3 clientes shows real names, not num_cliente.
- [ ] Modify a dashboard via chat — streaming progress visible during the call (not at the end).
- [ ] Analyze a dashboard via chat — same.
- [ ] Header has 4 nav items: Inicio · Paneles · Revisión · Wren (no Glosario).
- [ ] Dashboard panel's own "Glosario" button still opens `GlossaryPanel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)