### PR TITLE
fix(ai-factory): stop spawning duplicate PRs + auto-rebase stale ai/* PRs

### DIFF
--- a/.github/workflows/ai-plan.yml
+++ b/.github/workflows/ai-plan.yml
@@ -77,6 +77,14 @@ jobs:
             List every discrete unit of work. Each task must be independently implementable
             (own branch + PR) and small enough to complete in a focused session.
 
+            **DO NOT create sub-issues for lifecycle steps.** "Run all checks", "Copilot
+            review", "Opus review", and "Create commit" are steps inside the feature PR's
+            lifecycle (the worker handles them automatically) — they are not independent
+            code changes. Decomposing a parent into one `ai-task` per lifecycle step
+            spawns N parallel PRs that all implement the same feature (this happened
+            with #481 → #482..#487 → PRs #490, #491, #494, #496). If the parent produces
+            only one logical change, output **one** sub-issue, not five.
+
             | # | Title | Files | Acceptance |
             |---|-------|-------|------------|
             | 1 | ... | ... | ... |

--- a/.github/workflows/ai-pr-mergeability.yml
+++ b/.github/workflows/ai-pr-mergeability.yml
@@ -1,0 +1,241 @@
+name: AI PR Mergeability
+# Keeps factory PRs (ai/*) merge-ready: when a PR falls behind main or has
+# merge conflicts, attempts an automated rebase + push. If the rebase cannot
+# be resolved cleanly, the PR is labeled `ai-blocked` + `ai-merge-conflict`
+# and the owner is pinged. Companion to ai-ci-remediation.yml — that one
+# fixes failing CI; this one fixes everything BEFORE CI can even run.
+on:
+  schedule:
+    # Every 30 minutes
+    - cron: "*/30 * * * *"
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Specific PR number to check (omit for all open ai/* PRs)"
+        required: false
+        type: string
+
+concurrency:
+  group: ai-pr-mergeability
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      pr_numbers: ${{ steps.list.outputs.pr_numbers }}
+    steps:
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create "ai-merge-conflict" --color "B60205" \
+            --description "AI Factory: PR has unresolvable merge conflict" 2>/dev/null || true
+          gh label create "ai-stale-base" --color "FBCA04" \
+            --description "AI Factory: PR was rebased onto latest main" 2>/dev/null || true
+
+      - name: List PRs to check
+        id: list
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            echo "pr_numbers=[${{ inputs.pr_number }}]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Open PRs from ai/* branches that are NOT already flagged blocked.
+          # mergeable is one of: MERGEABLE, CONFLICTING, UNKNOWN.
+          # mergeStateStatus is one of: CLEAN, DIRTY, BLOCKED, BEHIND, UNSTABLE, HAS_HOOKS, UNKNOWN.
+          PRS=$(gh pr list --repo "$REPO" --state open --limit 100 \
+            --search "head:ai/" \
+            --json number,headRefName,mergeable,mergeStateStatus,labels \
+            --jq '[.[] | select(
+                    (.headRefName | startswith("ai/")) and
+                    ([.labels[].name] | any(. == "no-ai") | not) and
+                    (
+                      .mergeable == "CONFLICTING" or
+                      .mergeStateStatus == "DIRTY"  or
+                      .mergeStateStatus == "BEHIND"
+                    )
+                  ) | .number]')
+          echo "PRs needing attention: $PRS"
+          echo "pr_numbers=$PRS" >> "$GITHUB_OUTPUT"
+
+  remediate:
+    needs: scan
+    if: needs.scan.outputs.pr_numbers != '[]' && needs.scan.outputs.pr_numbers != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        pr_number: ${{ fromJSON(needs.scan.outputs.pr_numbers) }}
+    env:
+      PR_NUMBER: ${{ matrix.pr_number }}
+      REPO: ${{ github.repository }}
+      OWNER_HANDLE: alvarolobato
+    steps:
+      - name: Read PR metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          DATA=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json number,headRefName,baseRefName,mergeable,mergeStateStatus,headRepositoryOwner,headRefOid)
+          echo "data=$DATA"
+          BRANCH=$(echo "$DATA" | jq -r .headRefName)
+          BASE=$(echo "$DATA" | jq -r .baseRefName)
+          MERGEABLE=$(echo "$DATA" | jq -r .mergeable)
+          STATUS=$(echo "$DATA" | jq -r .mergeStateStatus)
+          HEAD_OWNER=$(echo "$DATA" | jq -r .headRepositoryOwner.login)
+          {
+            echo "branch=$BRANCH"
+            echo "base=$BASE"
+            echo "mergeable=$MERGEABLE"
+            echo "status=$STATUS"
+            echo "head_owner=$HEAD_OWNER"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Skip cross-fork PRs
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Only rebase same-repo PRs — pushing to a fork from this workflow
+          # is not authorized and would fail anyway.
+          if [ "${{ steps.pr.outputs.head_owner }}" != "${{ github.repository_owner }}" ]; then
+            echo "Cross-fork PR — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.skip != 'true'
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.pr.outputs.branch }}
+          persist-credentials: true
+
+      - name: Configure git
+        if: steps.gate.outputs.skip != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Skip if a remediation comment was already posted for this head SHA
+        id: dedup
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          HEAD_SHA=$(git rev-parse HEAD)
+          MARKER="<!-- ai-pr-mergeability head=$HEAD_SHA -->"
+          if gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+              --jq -r '.[].body' | grep -Fq "$MARKER"; then
+            echo "Already remediated this head SHA. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "marker=$MARKER" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Attempt rebase onto base branch
+        id: rebase
+        if: steps.gate.outputs.skip != 'true' && steps.dedup.outputs.skip != 'true'
+        env:
+          BASE: ${{ steps.pr.outputs.base }}
+          BRANCH: ${{ steps.pr.outputs.branch }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$BASE" --depth=0
+          BEFORE=$(git rev-parse HEAD)
+
+          # Try a clean rebase. We DO NOT pass --strategy-option=theirs/ours —
+          # silent conflict resolution can lose review-resolved changes.
+          # If a real conflict exists, surface it as ai-merge-conflict so a
+          # human (or address-feedback) can resolve it.
+          if git rebase "origin/$BASE"; then
+            AFTER=$(git rev-parse HEAD)
+            if [ "$BEFORE" = "$AFTER" ]; then
+              echo "outcome=noop" >> "$GITHUB_OUTPUT"
+            else
+              echo "outcome=rebased" >> "$GITHUB_OUTPUT"
+              echo "before=$BEFORE" >> "$GITHUB_OUTPUT"
+              echo "after=$AFTER" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            git rebase --abort || true
+            echo "outcome=conflict" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push rebased branch
+        id: push
+        if: steps.rebase.outputs.outcome == 'rebased'
+        env:
+          BRANCH: ${{ steps.pr.outputs.branch }}
+        run: |
+          set -euo pipefail
+          # force-with-lease guards against clobbering a concurrent push.
+          # Retry up to 4 times on transient network failure (per repo guideline).
+          for attempt in 1 2 3 4; do
+            if git push --force-with-lease origin "HEAD:$BRANCH"; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep_for=$(( 2 ** attempt ))
+            echo "Push attempt $attempt failed. Sleeping ${sleep_for}s..."
+            sleep "$sleep_for"
+          done
+          echo "pushed=false" >> "$GITHUB_OUTPUT"
+          exit 1
+
+      - name: Comment + label on successful rebase
+        if: steps.rebase.outputs.outcome == 'rebased' && steps.push.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MARKER: ${{ steps.dedup.outputs.marker }}
+          HEAD_SHA: ${{ steps.dedup.outputs.head_sha }}
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "ai-stale-base" || true
+          # Clear ai-merge-conflict if it was previously set — we just resolved it.
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "ai-merge-conflict" || true
+          BEFORE="${{ steps.rebase.outputs.before }}"
+          AFTER="${{ steps.rebase.outputs.after }}"
+          BASE="${{ steps.pr.outputs.base }}"
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "🔁 **AI Mergeability**: rebased \`${{ steps.pr.outputs.branch }}\` onto \`origin/$BASE\` (\`${BEFORE:0:7}\` → \`${AFTER:0:7}\`). CI will re-run on the new head. $MARKER" || true
+
+      - name: Mark unresolvable conflict
+        if: steps.rebase.outputs.outcome == 'conflict'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MARKER: ${{ steps.dedup.outputs.marker }}
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "$REPO" \
+            --add-label "ai-blocked" --add-label "ai-merge-conflict" \
+            --remove-label "ai-awaiting-owner" || true
+          BASE="${{ steps.pr.outputs.base }}"
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "⚠️ **AI Mergeability**: cannot auto-rebase \`${{ steps.pr.outputs.branch }}\` onto \`origin/$BASE\` — there is a real conflict. Marked \`ai-blocked\` + \`ai-merge-conflict\`. cc @$OWNER_HANDLE — resolve locally or run \`/plan\` on this PR for a fix proposal. $MARKER" || true
+
+      - name: Push failure
+        if: steps.rebase.outputs.outcome == 'rebased' && steps.push.outputs.pushed != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MARKER: ${{ steps.dedup.outputs.marker }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "⚠️ **AI Mergeability**: rebased the branch locally but \`git push --force-with-lease\` failed (likely a concurrent push). Will retry next cycle. $MARKER" || true

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -104,11 +104,35 @@ jobs:
             - Independently implementable (own branch + PR)
             - Small enough to complete in a single focused session
             - Clearly scoped (specific files, specific behaviour)
+            - **A genuinely independent code change** — see "What is NOT a sub-task" below.
 
             | # | Title | Files | Acceptance |
             |---|-------|-------|------------|
             | 1 | ... | ... | ... |
             | 2 | ... | ... | ... |
+
+            ### What is NOT a sub-task — DO NOT create sub-issues for these
+            The AGENTS.md issue template lists lifecycle steps (`Run all checks`,
+            `Copilot review`, `Opus review`, `Create commit`) as numbered tasks
+            inside ONE feature's lifecycle — they are **not** independent code
+            changes and **must never** become separate `ai-task` sub-issues.
+            Creating one `ai-task` per lifecycle step produces N parallel PRs
+            that all implement the same feature (this happened with #481 →
+            #482..#487 → PRs #490, #491, #494, #496).
+
+            Specifically, do NOT create a sub-issue for any of these:
+            - "Run checks / fix lint / fix tests" — the feature sub-task already
+              owns this. The implementer runs checks before pushing.
+            - "Copilot review" — the worker requests Copilot automatically once
+              the feature PR exists (`Handle success` step in `ai-worker.yml`).
+            - "Opus review" — handled by `ai-pr-review.yml` on the feature PR.
+            - "Create commit / merge" — the implementer commits as part of the
+              feature sub-task; merge is a human decision.
+
+            Only create sub-issues for **distinct code changes** that touch
+            different files / different concerns and could legitimately be
+            reviewed and merged independently. If the parent issue produces
+            only one logical change, output **one** sub-issue, not five.
 
             ### Dependency order
             [Which tasks must be done before others, and why]
@@ -356,10 +380,40 @@ jobs:
             2. Read the PARENT issue (linked in the body) for full context and architecture decisions
             3. Read CLAUDE.md and AGENTS.md
             4. Read relevant skill docs in docs/skills/ for the affected domain
-            5. Before starting, check whether another PR has already implemented part or all of this
-               task (the planner sometimes bundles work): `gh pr list --state all --search "issue-${{ env.ISSUE_NUMBER }}"`.
-               If the work is already done in a merged or open PR, post a comment on the issue
-               explaining which PR covers it, close the issue with `--reason completed`, and exit.
+            5. Before starting, run the **sibling-PR pre-flight check** — this is
+               critical to prevent the duplicate-PR fan-out (#481 → 4 PRs problem).
+               a. Check for a PR already opened against THIS sub-issue:
+                  ```
+                  gh pr list --state all --search "head:ai/issue-${{ env.ISSUE_NUMBER }}-"
+                  gh pr list --state all --search "Closes #${{ env.ISSUE_NUMBER }} in:body"
+                  ```
+               b. **Also** look at SIBLING sub-issues of the same parent. The planner
+                  may have created multiple sub-issues whose work overlaps. Find the
+                  parent from the issue body (line `Closes #PARENT`) and list all
+                  open PRs that close any sibling:
+                  ```
+                  PARENT=$(gh issue view ${{ env.ISSUE_NUMBER }} --json body --jq .body \
+                    | grep -oE 'Closes #[0-9]+' | head -1 | tr -d '#A-Za-z ')
+                  if [ -n "$PARENT" ]; then
+                    SIBLINGS=$(gh issue list --state open --search "Closes #${PARENT} in:body" \
+                      --json number --jq '.[].number')
+                    for SIB in $SIBLINGS; do
+                      gh pr list --state all --search "Closes #${SIB} in:body" \
+                        --json number,title,state,headRefName,body
+                    done
+                  fi
+                  ```
+               c. If ANY existing PR already implements the same change (same files,
+                  same intent), do NOT open a duplicate. Instead:
+                  - Comment on this issue explaining which PR (#NNN) already covers it
+                    and listing the sibling sub-issues that map to the same lifecycle.
+                  - Close this issue with `gh issue close ${{ env.ISSUE_NUMBER }} --reason "not planned"`.
+                  - Exit normally (don't push an empty branch, don't create a PR).
+               d. Lifecycle-style sub-issues — anything titled "Run all checks", "Copilot
+                  review", "Opus review", or "Create commit" — should ALWAYS be closed
+                  here without a PR: those are steps inside the feature PR's lifecycle,
+                  not independent code changes. See the planner section in this same
+                  workflow for context on why these no longer get sub-issues.
             6. Create branch: `ai/issue-${{ env.ISSUE_NUMBER }}-{short-slug}`
             7. Implement the changes:
                - Follow existing code style and patterns


### PR DESCRIPTION
## Summary

Fixes the duplicate-PR fan-out from the AI Factory (#481 → #482..#487 → 4 PRs #490/#491/#494/#496) and adds an auto-rebase workflow for stale `ai/*` PRs.

## Root cause

Parent issue #481 was decomposed by the AI Planner into 5 sub-tasks, copying the AGENTS.md issue template literally — including its **lifecycle steps** ("Run all checks", "Copilot review", "Opus review", "Create commit"). Each sub-task got `ai-task` + `ai-work` labels, and the implementer fired in parallel per sub-task, producing four PRs that all implement the same retail-ops delta change.

The worker's existing pre-flight duplicate check (`gh pr list --search "issue-N"`) was racey — by the time worker N starts, worker N-1 may not have pushed its PR yet.

## Triage of the existing duplicates

| PR | Closes | Status | Action |
|----|--------|--------|--------|
| **#496** | #482, #483, #484 | all CI green | **kept** |
| #490 | #482 | duplicate | closed with comment |
| #491 | #487 | duplicate | closed with comment |
| #494 | #483 | duplicate | closed with comment |

Issue #487 (Task 5: "Create commit") was a lifecycle-only sub-issue and has been closed as `not planned`. #485 was already closed.

## Changes

### `.github/workflows/ai-worker.yml`
- **Planner prompt**: new "What is NOT a sub-task" section forbidding lifecycle-step decomposition. Cites the #481 incident.
- **Implementer prompt**: stronger sibling-PR pre-flight check that walks the parent issue's open sub-issues and refuses to open a duplicate PR when any sibling is already being implemented; also closes lifecycle-named sub-issues (`Run all checks`, `Copilot review`, `Opus review`, `Create commit`) without opening a PR.

### `.github/workflows/ai-plan.yml`
- `/plan --full` prompt: same "no lifecycle sub-issues" rule.

### `.github/workflows/ai-pr-mergeability.yml` *(new)*
- Triggers: `cron */30 * * * *`, `push` to `main`, manual `workflow_dispatch`.
- Scans open PRs from `ai/*` branches and finds those where `mergeable == CONFLICTING` or `mergeStateStatus` is `DIRTY` / `BEHIND`.
- Per PR (matrix, max-parallel 3):
  - Skip cross-fork PRs (we cannot push there from this workflow).
  - Skip PRs we already remediated for this head SHA (idempotency marker in a comment).
  - `git rebase origin/<base>`. On clean rebase: `git push --force-with-lease` (with 4-attempt exponential backoff per repo guideline), label `ai-stale-base`, comment with before/after SHAs, clear `ai-merge-conflict` if it was set.
  - On conflict: `git rebase --abort`, label `ai-blocked` + `ai-merge-conflict`, remove `ai-awaiting-owner`, ping `@alvarolobato`.
- Companion to existing `ai-ci-remediation.yml` (which fixes failing CI). This one fixes mergeability *before* CI can even run.

## Test plan

- [x] YAML syntax validated for all three workflows (`python -c yaml.safe_load`).
- [ ] Verify `ai-pr-mergeability.yml` runs cleanly on `workflow_dispatch` once merged.
- [ ] Confirm next planner run on a parent issue produces ≤ N sub-tasks where N = number of independent code changes (no separate `Run checks` / `Copilot` / `Opus` / `Create commit` sub-issues).
- [ ] Manually rebase one stale ai/* PR via the new workflow's `workflow_dispatch` to confirm the force-with-lease push path works.

Closes the duplicate-PR class of incident; relates to #481.

---
_Generated by [Claude Code](https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD)_