### PR TITLE
fix(ai-factory): enforce D-021 two-rounds rule + per-PR review concurrency

### DIFF
--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -128,6 +128,14 @@ jobs:
             SHOULD_RUN="false"
             REASON="PR #$PR labelled no-address-feedback"
           fi
+          # D-021: don't even kick off the address job for converged PRs.
+          # The address job has its own d021 step as a defence in depth, but
+          # short-circuiting here saves a runner and avoids touching labels.
+          if echo ",$LABELS," | grep -q ",ai-cp-after-1," \
+             && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
+            SHOULD_RUN="false"
+            REASON="PR #$PR already has ai-cp-after-1 + ai-o-after-1 (D-021 converged)"
+          fi
 
           echo "pr_number=$PR" >> "$GITHUB_OUTPUT"
           echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
@@ -141,13 +149,48 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 50
     steps:
+      # D-021 enforcement (must run BEFORE `Announce start`, which strips
+      # ai-awaiting-owner). If both Copilot and Opus rounds have already been
+      # addressed, a fresh address-feedback run would just surface nit-picks
+      # and create a new commit, kicking off another cycle. Bail here and keep
+      # the converged state sticky. PRs #493 / #495 had 4+ rounds before this
+      # guard existed.
+      - name: D-021 — bail if both rounds done
+        id: d021
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ needs.resolve.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          LABELS=$(gh pr view "$PR" --repo "$REPO" --json labels \
+            --jq '[.labels[].name] | join(",")')
+          if echo ",$LABELS," | grep -q ",ai-cp-after-1," \
+             && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
+            echo "PR #$PR has both rounds addressed — D-021 converged."
+            gh pr edit "$PR" --repo "$REPO" \
+              --add-label "ai-awaiting-owner" \
+              --remove-label "ai-ready-for-review" \
+              --remove-label "ai-phase-copilot" \
+              --remove-label "ai-phase-opus" \
+              --remove-label "ai-blocked" \
+              --remove-label "ai-auto-retry" || true
+            gh pr comment "$PR" --repo "$REPO" \
+              --body "ℹ️ **AI Factory**: D-021 — both Copilot and Opus rounds already addressed. Skipping address-feedback to break review-loop. Awaiting owner merge decision." || true
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.d021.outputs.skip != 'true'
         with:
           ref: ${{ needs.resolve.outputs.head_ref }}
           fetch-depth: 0
 
       - name: Capture initial HEAD
         id: initial_head
+        if: steps.d021.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -156,6 +199,7 @@ jobs:
           echo "Initial HEAD: $SHA"
 
       - name: Announce start
+        if: steps.d021.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -173,6 +217,7 @@ jobs:
       # knows why automated address-feedback can't run.
       - name: Detect workflow-file change
         id: workflow_change
+        if: steps.d021.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -193,7 +238,7 @@ jobs:
           fi
 
       - name: Skip Claude address-feedback — PR touches .github/workflows
-        if: steps.workflow_change.outputs.skip == 'true'
+        if: steps.d021.outputs.skip != 'true' && steps.workflow_change.outputs.skip == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -209,7 +254,7 @@ jobs:
 
       - name: Address Review Feedback
         id: address
-        if: steps.workflow_change.outputs.skip != 'true'
+        if: steps.d021.outputs.skip != 'true' && steps.workflow_change.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ github.token }}
@@ -305,7 +350,7 @@ jobs:
             - Stay within this PR's scope — do not pull in unrelated work.
 
       - name: Fetch CI handoff helper from default branch
-        if: success() && steps.workflow_change.outputs.skip != 'true'
+        if: success() && steps.d021.outputs.skip != 'true' && steps.workflow_change.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -317,7 +362,7 @@ jobs:
 
       - name: Route next automated review (or converge)
         id: route
-        if: success() && steps.workflow_change.outputs.skip != 'true'
+        if: success() && steps.d021.outputs.skip != 'true' && steps.workflow_change.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           # PAT-capable token for Copilot reviewer assignment. GITHUB_TOKEN
@@ -424,6 +469,23 @@ jobs:
           gh label create "ai-cp-after-1" --color "0e8a16" --description "AI Factory: addressed Copilot review" 2>/dev/null || true
           gh label create "ai-o-after-1" --color "0e8a16" --description "AI Factory: addressed Opus review" 2>/dev/null || true
           gh label create "ai-ready-for-review" --color "fbca04" --description "AI Factory: PR ready for automated review" 2>/dev/null || true
+
+          # D-021: defensive bail in case both round markers are already set.
+          # The job-level d021 step catches the common case before the
+          # claude-code-action runs; this catches the rarer case where the
+          # bot's address-feedback session itself completed both rounds.
+          if echo ",$LABELS," | grep -q ",ai-cp-after-1," \
+             && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
+            echo "Both ai-cp-after-1 + ai-o-after-1 set — D-021 converged."
+            gh pr edit "$PR" --repo "$REPO" \
+              --remove-label "ai-phase-copilot" \
+              --remove-label "ai-phase-opus" \
+              --remove-label "ai-ready-for-review" \
+              --remove-label "ai-blocked" \
+              --remove-label "ai-auto-retry" || true
+            owner_handoff_or_ci_gate "✅ **AI Factory**: Both review rounds (Copilot + Opus) addressed. PR is ready for human merge decision."
+            exit 0
+          fi
 
           if echo ",$LABELS," | grep -q ",ai-phase-copilot,"; then
             if echo ",$LABELS," | grep -q ",ai-cp-after-1,"; then

--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -168,15 +168,31 @@ jobs:
           if echo ",$LABELS," | grep -q ",ai-cp-after-1," \
              && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
             echo "PR #$PR has both rounds addressed — D-021 converged."
+            # Cosmetic-only label cleanup (always safe).
             gh pr edit "$PR" --repo "$REPO" \
-              --add-label "ai-awaiting-owner" \
               --remove-label "ai-ready-for-review" \
               --remove-label "ai-phase-copilot" \
               --remove-label "ai-phase-opus" \
               --remove-label "ai-blocked" \
               --remove-label "ai-auto-retry" || true
-            gh pr comment "$PR" --repo "$REPO" \
-              --body "ℹ️ **AI Factory**: D-021 — both Copilot and Opus rounds already addressed. Skipping address-feedback to break review-loop. Awaiting owner merge decision." || true
+            # Owner handoff is CI-gated to match the rest of this file
+            # (see `owner_handoff_or_ci_gate` below). Don't claim merge-ready
+            # if CI is failing or still running.
+            HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
+            CI_STATE=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
+              --jq '[.check_runs[] | .conclusion] | if length == 0 then "running" elif any(. == null) then "running" elif all(. == "success" or . == "skipped" or . == "neutral") then "ready" else "failing" end' \
+              2>/dev/null || echo "unknown")
+            if echo ",$LABELS," | grep -q ",ai-ci-failing,"; then
+              CI_STATE="failing"
+            fi
+            if [ "$CI_STATE" = "ready" ]; then
+              gh pr edit "$PR" --repo "$REPO" --add-label "ai-awaiting-owner" || true
+              gh pr comment "$PR" --repo "$REPO" \
+                --body "ℹ️ **AI Factory**: D-021 — both Copilot and Opus rounds already addressed. Skipping address-feedback. Awaiting owner merge decision." || true
+            else
+              gh pr comment "$PR" --repo "$REPO" \
+                --body "ℹ️ **AI Factory**: D-021 — both rounds already addressed. Skipping address-feedback. **Not marking \`ai-awaiting-owner\`** because CI is \`$CI_STATE\`." || true
+            fi
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -13,9 +13,15 @@ on:
         required: true
         type: number
 
-# One Opus PR review at a time across the repo — avoids Anthropic rate limits when many PRs move together.
+# Per-PR concurrency. The previous global `ai-pr-review-global` group serialised
+# every Opus review repo-wide; when many PRs landed at once, downstream steps
+# that dispatch this workflow (e.g. the phase-advance in ai-address-feedback)
+# stranded PRs in `ai-phase-opus` forever (PR #496 was stuck overnight). Per-PR
+# groups still prevent two concurrent reviews of the same PR while letting
+# different PRs proceed in parallel. Anthropic-side rate limits are handled by
+# the claude-code-action's own retry.
 concurrency:
-  group: ai-pr-review-global
+  group: ai-pr-review-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: false
 
 permissions:
@@ -44,19 +50,51 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
     steps:
+      # D-021 enforcement: if both Copilot and Opus rounds have already been
+      # addressed, this PR is converged. Don't run a third review — it will
+      # surface nit-picks that loop with address-feedback (PRs #493 / #495
+      # had 4+ Copilot rounds and 5+ Opus rounds before this guard existed).
+      # Runs first so we can also short-circuit later steps via this output.
+      - name: D-021 — short-circuit when both rounds done
+        id: d021
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" \
+            --json labels --jq '[.labels[].name] | join(",")')
+          if echo ",$LABELS," | grep -q ",ai-cp-after-1," \
+             && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
+            echo "PR #$PR_NUMBER already has ai-cp-after-1 + ai-o-after-1 — D-021 converged."
+            gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
+              --add-label "ai-awaiting-owner" \
+              --remove-label "ai-ready-for-review" \
+              --remove-label "ai-phase-copilot" \
+              --remove-label "ai-phase-opus" || true
+            gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" \
+              --body "ℹ️ **AI Factory**: D-021 — both Copilot and Opus rounds already addressed (\`ai-cp-after-1\` + \`ai-o-after-1\`). Skipping additional review to break review-loop. Awaiting owner merge decision." || true
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Most runs are workflow_dispatch; the label would otherwise linger and the
-      # watchdog would keep re-dispatching this workflow.
+      # watchdog would keep re-dispatching this workflow. We DON'T strip
+      # ai-awaiting-owner here any more — stripping it on every dispatch was
+      # what let the cold-dispatch loop undo the converged state on #493 / #495.
+      # The d021 step above already cleans up label state for converged PRs.
       - name: Clear ai-ready-for-review (best-effort)
+        if: steps.d021.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
             --remove-label "ai-ready-for-review" \
-            --remove-label "ai-awaiting-owner" \
             --remove-label "ai-ci-failing" || true
 
       - name: Resolve PR ref and title
         id: resolve
+        if: steps.d021.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -73,11 +111,13 @@ jobs:
           echo "TITLE_EOF" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
+        if: steps.d021.outputs.skip != 'true'
         with:
           ref: ${{ steps.resolve.outputs.ref }}
           fetch-depth: 0
 
       - name: Fetch CI handoff helper from default branch
+        if: steps.d021.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -90,6 +130,7 @@ jobs:
 
       - name: Load review guidelines
         id: guidelines
+        if: steps.d021.outputs.skip != 'true'
         run: |
           {
             echo 'CONTENT<<PR_REVIEW_EOF'
@@ -100,6 +141,7 @@ jobs:
 
       - name: Check Opus review cap (legacy PRs)
         id: cap
+        if: steps.d021.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -130,7 +172,7 @@ jobs:
           echo "skip_reason=$SKIP_REASON" >> "$GITHUB_OUTPUT"
 
       - name: Skip Claude review — PR touches .github/workflows
-        if: steps.cap.outputs.skip == 'true' && steps.cap.outputs.skip_reason == 'workflow-file-change'
+        if: steps.d021.outputs.skip != 'true' && steps.cap.outputs.skip == 'true' && steps.cap.outputs.skip_reason == 'workflow-file-change'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -143,7 +185,7 @@ jobs:
           gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$MSG" || true
 
       - name: Claude PR Review
-        if: steps.cap.outputs.skip != 'true'
+        if: steps.d021.outputs.skip != 'true' && steps.cap.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         env:
           # Default gh auth for every Claude-side call EXCEPT the Copilot

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -59,20 +59,39 @@ jobs:
         id: d021
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          LABELS=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" \
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
             --json labels --jq '[.labels[].name] | join(",")')
           if echo ",$LABELS," | grep -q ",ai-cp-after-1," \
              && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
             echo "PR #$PR_NUMBER already has ai-cp-after-1 + ai-o-after-1 — D-021 converged."
-            gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
-              --add-label "ai-awaiting-owner" \
+            # Always clean up phase labels (cosmetic; safe).
+            gh pr edit "$PR_NUMBER" --repo "$REPO" \
               --remove-label "ai-ready-for-review" \
               --remove-label "ai-phase-copilot" \
               --remove-label "ai-phase-opus" || true
-            gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" \
-              --body "ℹ️ **AI Factory**: D-021 — both Copilot and Opus rounds already addressed (\`ai-cp-after-1\` + \`ai-o-after-1\`). Skipping additional review to break review-loop. Awaiting owner merge decision." || true
+            # Owner-handoff label is CI-gated, mirroring `owner_handoff_or_ci_gate`
+            # in ai-address-feedback.yml: only mark `ai-awaiting-owner` when CI
+            # is green for the head SHA. If `ai-ci-failing` is already set or CI
+            # is not (yet) green, leave that label as-is and post a different
+            # comment so we don't claim merge-ready prematurely.
+            HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .headRefOid)
+            CI_STATE=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
+              --jq '[.check_runs[] | .conclusion] | if length == 0 then "running" elif any(. == null) then "running" elif all(. == "success" or . == "skipped" or . == "neutral") then "ready" else "failing" end' \
+              2>/dev/null || echo "unknown")
+            if echo ",$LABELS," | grep -q ",ai-ci-failing,"; then
+              CI_STATE="failing"
+            fi
+            if [ "$CI_STATE" = "ready" ]; then
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "ai-awaiting-owner" || true
+              gh pr comment "$PR_NUMBER" --repo "$REPO" \
+                --body "ℹ️ **AI Factory**: D-021 — both Copilot and Opus rounds already addressed (\`ai-cp-after-1\` + \`ai-o-after-1\`). Skipping additional review. Awaiting owner merge decision." || true
+            else
+              gh pr comment "$PR_NUMBER" --repo "$REPO" \
+                --body "ℹ️ **AI Factory**: D-021 — both rounds already addressed. Skipping additional review. **Not marking \`ai-awaiting-owner\`** because CI is \`$CI_STATE\`." || true
+            fi
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -233,7 +252,7 @@ jobs:
             ${{ steps.guidelines.outputs.CONTENT }}
 
       - name: Clear PR review failure labels
-        if: success() && steps.cap.outputs.skip != 'true'
+        if: success() && steps.d021.outputs.skip != 'true' && steps.cap.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -241,7 +260,7 @@ jobs:
             --remove-label "ai-blocked" --remove-label "ai-auto-retry" || true
 
       - name: Max automated Opus reviews reached (legacy)
-        if: success() && steps.cap.outputs.skip == 'true' && steps.cap.outputs.skip_reason == 'legacy-cap-reached'
+        if: success() && steps.d021.outputs.skip != 'true' && steps.cap.outputs.skip == 'true' && steps.cap.outputs.skip_reason == 'legacy-cap-reached'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -272,7 +291,7 @@ jobs:
           fi
 
       - name: Record legacy Opus pass
-        if: success() && steps.cap.outputs.skip != 'true'
+        if: success() && steps.d021.outputs.skip != 'true' && steps.cap.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -288,7 +307,7 @@ jobs:
           fi
 
       - name: Dispatch address-feedback
-        if: success() && steps.cap.outputs.skip != 'true'
+        if: success() && steps.d021.outputs.skip != 'true' && steps.cap.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -184,6 +184,20 @@ jobs:
               continue
             fi
 
+            # D-021: skip PRs where both rounds were already addressed.
+            # The address-feedback workflow now strips ai-ready-for-review on
+            # converge, but a stale label could still trip this step into
+            # re-dispatching a third review (PR #495 had 5+ Opus rounds because
+            # of this loop).
+            if echo ",$LABELS," | grep -q ",ai-cp-after-1," \
+               && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
+              echo "PR #$NUM: D-021 converged (both ai-cp-after-1 + ai-o-after-1) — clearing stale ai-ready-for-review and skipping"
+              gh pr edit "$NUM" --repo "$REPO_FULL" \
+                --remove-label "ai-ready-for-review" \
+                --add-label "ai-awaiting-owner" || true
+              continue
+            fi
+
             # Find when ai-ready-for-review label was last added by looking at
             # pr-review runs triggered for this PR in the last 30 minutes.
             NOW=$(date -u +%s)
@@ -273,7 +287,7 @@ jobs:
             CREATED_AT=$(echo "$pr" | jq -r '.createdAt')
             LABELS=$(echo "$pr" | jq -r '[.labels[].name] | join(",")')
 
-            # Any label that proves pr-review already progressed on this PR.
+            # Any single label that proves pr-review already progressed.
             for HAS in ai-ready-for-review ai-phase-copilot ai-phase-opus \
                        ai-awaiting-owner ai-ci-failing ai-blocked \
                        no-pr-review; do
@@ -282,6 +296,20 @@ jobs:
                 continue 2
               fi
             done
+
+            # D-021: skip when BOTH ai-cp-after-1 + ai-o-after-1 are present.
+            # That's the converged-state signal; an earlier workflow may have
+            # stripped ai-awaiting-owner, leaving the PR exposed to a fresh
+            # cold-dispatch (PRs #493 / #495 hit this — 4 cold-dispatches across
+            # 8 hours despite both rounds being addressed). Re-add awaiting-owner
+            # so the PR's state is consistent.
+            if echo ",$LABELS," | grep -q ",ai-cp-after-1," \
+               && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
+              echo "PR #$NUM has both ai-cp-after-1 + ai-o-after-1 — D-021 converged, skipping cold-dispatch."
+              gh pr edit "$NUM" --repo "$REPO_FULL" \
+                --add-label "ai-awaiting-owner" || true
+              continue
+            fi
 
             # Give the event-driven trigger a grace period.
             NOW=$(date -u +%s)

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -193,8 +193,14 @@ jobs:
                && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
               echo "PR #$NUM: D-021 converged (both ai-cp-after-1 + ai-o-after-1) — clearing stale ai-ready-for-review and skipping"
               gh pr edit "$NUM" --repo "$REPO_FULL" \
-                --remove-label "ai-ready-for-review" \
-                --add-label "ai-awaiting-owner" || true
+                --remove-label "ai-ready-for-review" || true
+              # Owner-handoff label is CI-gated to match owner_handoff_or_ci_gate
+              # in ai-address-feedback.yml: don't claim merge-ready when CI is
+              # failing. If `ai-ci-failing` is set, leave label state alone.
+              if ! echo ",$LABELS," | grep -q ",ai-ci-failing,"; then
+                gh pr edit "$NUM" --repo "$REPO_FULL" \
+                  --add-label "ai-awaiting-owner" || true
+              fi
               continue
             fi
 
@@ -302,12 +308,15 @@ jobs:
             # stripped ai-awaiting-owner, leaving the PR exposed to a fresh
             # cold-dispatch (PRs #493 / #495 hit this — 4 cold-dispatches across
             # 8 hours despite both rounds being addressed). Re-add awaiting-owner
-            # so the PR's state is consistent.
+            # only when CI is not failing so we don't claim merge-ready in front
+            # of a red CI (mirrors owner_handoff_or_ci_gate).
             if echo ",$LABELS," | grep -q ",ai-cp-after-1," \
                && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
               echo "PR #$NUM has both ai-cp-after-1 + ai-o-after-1 — D-021 converged, skipping cold-dispatch."
-              gh pr edit "$NUM" --repo "$REPO_FULL" \
-                --add-label "ai-awaiting-owner" || true
+              if ! echo ",$LABELS," | grep -q ",ai-ci-failing,"; then
+                gh pr edit "$NUM" --repo "$REPO_FULL" \
+                  --add-label "ai-awaiting-owner" || true
+              fi
               continue
             fi
 


### PR DESCRIPTION
## Summary

Diagnosis of the 4 stuck open PRs (#492, #493, #495, #496) revealed three orthogonal defects in the review-flow workflows. This PR fixes all three. **Manual label cleanup applied separately** on the currently-stuck PRs.

## Root cause

| PR | Symptom | Underlying defect |
|----|---------|-------------------|
| **#496** | stuck in `ai-phase-opus` overnight despite Opus posting LGTM | Global `ai-pr-review-global` concurrency: when 9 PRs landed at once, downstream dispatches got swallowed by the queue and the phase never advanced |
| **#493** | 4+ Copilot rounds, 4+ Opus rounds, still looping at 11:31 UTC | D-021 ("two rounds and stop") was documented in AGENTS.md but **never enforced in code** — `ai-cp-after-1` / `ai-o-after-1` were set but no workflow read them as a stop signal |
| **#495** | 3+ Copilot rounds, 5+ Opus rounds before finally converging | Same as #493. The watchdog kept cold-dispatching reviews and address-feedback kept fixing nit-picks |
| **#492** | merge-ready but stale `ai-phase-opus` label, contradictory state | `ai-pr-review.yml` stripped `ai-awaiting-owner` on every dispatch, so cold-dispatches undid converged state |

## Changes

### `.github/workflows/ai-pr-review.yml`
- **Per-PR concurrency** (`ai-pr-review-${pr_number}`) instead of repo-wide. Same-PR races still serialise; cross-PR runs proceed in parallel. Anthropic-side rate limits handled by the action's own retry. Fixes #496-class stalls.
- **`d021` step** at the top: if both `ai-cp-after-1` and `ai-o-after-1` are set, re-stick `ai-awaiting-owner`, post a converged comment, and skip every subsequent step. All later steps gated on `steps.d021.outputs.skip != 'true'`.
- **Stop wiping `ai-awaiting-owner`** in the "Clear ai-ready-for-review (best-effort)" step. Stripping it on every dispatch was what let cold-dispatches undo the converged state on #493 / #495 / #492.

### `.github/workflows/ai-address-feedback.yml`
- **`resolve` job**: refuses to run when both round markers are set (`SHOULD_RUN=false`, reason logged). Saves a runner, doesn't touch labels.
- **`address` job**: new `d021` step *before* `Announce start` (which strips `ai-awaiting-owner`). Bails out, re-sticks `ai-awaiting-owner`, posts converged comment.
- **Defensive bail inside `Route next automated review`**: catches the rarer case where both markers landed during the bot's own session.
- All subsequent steps gated on `steps.d021.outputs.skip != 'true'`.

### `.github/workflows/ai-watchdog.yml`
- **Stalled `ai-ready-for-review` step**: skips PRs with both `ai-cp-after-1` + `ai-o-after-1`, clears stale `ai-ready-for-review`, re-sticks `ai-awaiting-owner`.
- **Cold-dispatch step**: same skip; re-sticks `ai-awaiting-owner`. Comments document why (#493 / #495 incident).

## Manual label cleanup applied separately

Will follow up on the open PRs:
- **#492**: remove `ai-phase-opus`, add `ai-o-after-1`. (Already has `ai-awaiting-owner` and CI green; merge-ready.)
- **#493**: add `ai-awaiting-owner`. (Both round markers already set; just stops the loop.)
- **#495**: already correctly converged. (No change required; merge-ready.)
- **#496**: remove `ai-phase-opus`, add `ai-o-after-1`, add `ai-awaiting-owner`. (Opus already reviewed per the timeline; just label state is incorrect.)

## Test plan

- [x] YAML syntax validated for all 3 workflows
- [ ] After merge: confirm next dispatch on a non-converged PR still runs Copilot → address → Opus → address → owner-handoff
- [ ] After merge: confirm cold-dispatch skips `ai-cp-after-1 + ai-o-after-1` PRs (would have been #493 / #495 yesterday)
- [ ] Verify per-PR concurrency lets two different PRs review in parallel

---
_Generated by [Claude Code](https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD)_