### PR TITLE
fix(ai-worker): implementers read parent comments + self-heal missing ai-work label

### DIFF
--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -262,6 +262,36 @@ jobs:
             echo "status=incomplete" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Self-heal sub-issue labels
+        if: always() && steps.verify_plan.outputs.status == 'planned'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Defense-in-depth: ensure every sub-issue carries BOTH `ai-task` AND
+          # `ai-work`. The planner agent has been observed (e.g. on issue #502)
+          # to add `ai-task` but skip `ai-work`, leaving sub-issues stalled
+          # forever — the implement phase only triggers when `ai-work` is
+          # applied. This step audits every sub-issue and adds whichever
+          # required label is missing.
+          SUB_ISSUES=$(gh issue list --repo "${{ github.repository }}" \
+            --state open --limit 50 \
+            --search "Closes #${ISSUE_NUMBER} in:body" \
+            --json number,labels)
+
+          echo "$SUB_ISSUES" | jq -c '.[]' | while read -r row; do
+            NUM=$(echo "$row" | jq -r '.number')
+            LABELS=$(echo "$row" | jq -r '[.labels[].name] | join(",")')
+            if ! echo ",$LABELS," | grep -q ",ai-task,"; then
+              echo "Sub-issue #$NUM missing 'ai-task' — adding."
+              gh issue edit "$NUM" --add-label "ai-task" || true
+            fi
+            if ! echo ",$LABELS," | grep -q ",ai-work,"; then
+              echo "Sub-issue #$NUM missing 'ai-work' — planner forgot; adding to trigger implementation."
+              gh issue edit "$NUM" --add-label "ai-work" || true
+            fi
+          done
+
       - name: Detect mangled sub-issue bodies
         if: always()
         env:
@@ -377,7 +407,21 @@ jobs:
 
             ## Process
             1. Read sub-task issue #${{ env.ISSUE_NUMBER }}: title, body, acceptance criteria
-            2. Read the PARENT issue (linked in the body) for full context and architecture decisions
+            2. Read the PARENT issue (linked in the body) — **including ALL its comments**.
+               The planner posts the implementation plan (analysis, architecture decisions,
+               dependency order, "what is NOT a sub-task" rules) as a COMMENT, not in the
+               body. Reading just the body misses everything that matters for context.
+               Use this to fetch body + every comment in one shot:
+               ```
+               PARENT=$(gh issue view ${{ env.ISSUE_NUMBER }} --json body --jq .body \
+                 | grep -oE 'Closes #[0-9]+' | head -1 | tr -d '#A-Za-z ')
+               if [ -n "$PARENT" ]; then
+                 gh issue view "$PARENT" --json title,body,comments \
+                   --jq '"# \(.title)\n\n\(.body)\n\n---\n\n" + (.comments | map("## Comment by \(.author.login) at \(.createdAt)\n\n\(.body)") | join("\n\n---\n\n"))'
+               fi
+               ```
+               Read every comment top to bottom — the architecture rationale, dependency
+               graph, and design discussions live there.
             3. Read CLAUDE.md and AGENTS.md
             4. Read relevant skill docs in docs/skills/ for the affected domain
             5. Before starting, run the **sibling-PR pre-flight check** — this is


### PR DESCRIPTION
## Summary

Two related fixes to the AI Factory worker, both surfaced by #502 stalling after planning.

### 1. Implementers now read parent issue **comments**

The implement-phase prompt previously told the worker:

> Read the PARENT issue (linked in the body) for full context and architecture decisions

But \`gh issue view <num>\` returns body only by default — comments are not fetched. The planner posts the implementation plan (analysis, architecture decisions, dependency order, \"what is NOT a sub-task\" rules) as a **comment**, not in the body. So the implementer was getting body-only context and missing everything that mattered.

Step 2 of the implementer prompt now includes an explicit shell command that fetches body **and** every comment, plus a clear instruction: \"Read every comment top to bottom — the architecture rationale, dependency graph, and design discussions live there.\"

### 2. Self-heal step ensures both \`ai-task\` AND \`ai-work\` are present

The planner is told to add both labels (workflow lines 215-217, restated as a rule on 242-243). On #502 it added only \`ai-task\`, leaving #505/506/507/510/511 stalled — the implement phase only fires when \`ai-work\` is added to a sub-task.

New \`Self-heal sub-issue labels\` step audits every sub-issue produced by this run and adds whichever required label is missing.

## Changes

- \`.github/workflows/ai-worker.yml\`:
  - **Implement step** (line 380): step 2 of the prompt rewritten to explicitly fetch parent body + comments via \`gh issue view --json body,comments\` with a worked example.
  - **Plan step** (after \`Verify plan output\`): new \`Self-heal sub-issue labels\` step that lists sub-issues created in this run and adds \`ai-task\` / \`ai-work\` if missing.

## Test plan

- [ ] Once merged, manually add \`ai-work\` to #505/506/507/510/511 to unblock #502 (or open a fresh test issue with \`ai-work\` to exercise the planner self-heal end-to-end).
- [ ] Verify the implementer's first \`gh issue view\` output for #505 includes the planning comments from #502.
- [ ] Verify the planner self-heal logs show \`Sub-issue #N missing 'ai-work' — adding\` if the agent forgets again.

https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD