### PR TITLE
fix(ai-worker): job-level concurrency with cancel-in-progress

### DIFF
--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -16,14 +16,16 @@ on:
           - plan
           - implement
 
-# Don't cancel in-progress workers. GitHub fires a `labeled` event for each
-# label added in rapid succession (e.g. triage applying component/priority labels),
-# which previously cancelled an already-running plan/implement and left the
-# issue stuck in `ai-in-progress`. We'd rather run duplicates and let the
-# inner steps no-op than leave issues orphaned.
-concurrency:
-  group: ai-worker-${{ github.event.issue.number || inputs.issue_number }}
-  cancel-in-progress: false
+# Concurrency is set per-job (not workflow-level) so that `labeled` events
+# for unrelated labels (e.g. triage applying `p1-high`, `comp-dashboard`)
+# don't grab the slot and cancel a running ai-work job. With job-level
+# concurrency, jobs whose `if:` evaluates false are SKIPPED and don't enter
+# the concurrency group — so only an actual ai-work plan/implement run can
+# cancel a prior in-progress run of the same kind on the same issue.
+#
+# When a real new run fires (manual workflow_dispatch, watchdog retry, or
+# a fresh `ai-work` re-add), it cancels the prior run for the same issue —
+# that's the desired behaviour: the latest intent wins, no duplicate work.
 
 permissions:
   contents: write
@@ -50,6 +52,9 @@ jobs:
         github.event_name == 'workflow_dispatch' &&
         inputs.phase == 'plan'
       )
+    concurrency:
+      group: ai-worker-plan-${{ github.event.issue.number || inputs.issue_number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -375,6 +380,9 @@ jobs:
         github.event_name == 'workflow_dispatch' &&
         inputs.phase == 'implement'
       )
+    concurrency:
+      group: ai-worker-implement-${{ github.event.issue.number || inputs.issue_number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:


### PR DESCRIPTION
## Summary

When a new \`ai-work\` plan/implement run fires for an issue, it should cancel any prior in-progress run for that issue. The latest intent wins, no duplicate work, no two workers racing on the same branch.

## Why job-level, not workflow-level

The previous setting was workflow-level \`cancel-in-progress: false\`, with the comment:

> Don't cancel in-progress workers. GitHub fires a \`labeled\` event for each label added in rapid succession (e.g. triage applying component/priority labels), which previously cancelled an already-running plan/implement and left the issue stuck in \`ai-in-progress\`.

That concern is real for **workflow-level** concurrency: any \`labeled\` event briefly starts the workflow, grabs the slot, evaluates job \`if:\`s, and exits — but the brief grab was enough to cancel the running run.

**Job-level** concurrency does not have this problem: jobs whose \`if:\` evaluates false are SKIPPED and never enter the concurrency group. So unrelated label events (\`p1-high\`, \`comp-dashboard\`, etc.) don't touch the running ai-work job. Only an actual \`ai-work\` plan/implement run enters the group — and at that point cancelling the predecessor is the right thing.

## Changes

- \`.github/workflows/ai-worker.yml\`:
  - Remove workflow-level \`concurrency\` block (with the old \"don't cancel\" comment).
  - Add job-level \`concurrency\` to **plan** with group \`ai-worker-plan-<issue>\`, \`cancel-in-progress: true\`.
  - Add job-level \`concurrency\` to **implement** with group \`ai-worker-implement-<issue>\`, \`cancel-in-progress: true\`.
  - Separate groups for plan vs implement so the two phases never cancel each other (they wouldn't share an issue number in practice — plan triggers on parent, implement on sub-task — but explicit is better).

## Test plan

- [ ] Once merged, exercise: add \`ai-work\` to a test issue → plan run starts. Add \`ai-work\` again (or any other label that wouldn't normally re-trigger) — plan run should NOT be cancelled by unrelated label events.
- [ ] Re-add \`ai-work\` while plan is running — the new plan run should cancel the prior one.
- [ ] On an \`ai-task\` issue, re-add \`ai-work\` mid-implement — new implement run cancels prior; partial work pushed to branch via existing \`Push partial work on failure\` step (or the cancel handler).

## Related

- Builds on #517 (which added the read-parent-comments fix and the planner self-heal step).

https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD