### PR TITLE
fix(ai-address-feedback): clean up stale labels in resolve-job D-021 bail

### DIFF
--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -128,13 +128,39 @@ jobs:
             SHOULD_RUN="false"
             REASON="PR #$PR labelled no-address-feedback"
           fi
-          # D-021: don't even kick off the address job for converged PRs.
-          # The address job has its own d021 step as a defence in depth, but
-          # short-circuiting here saves a runner and avoids touching labels.
+          # D-021: don't kick off the address job for converged PRs.
+          # The address job has its own d021 step as defence in depth, but
+          # that step lives INSIDE the address job — which is gated by
+          # `should_run=true`. So if we set should_run=false here without
+          # cleaning up first, any stale phase / blocked / auto-retry labels
+          # stay stuck forever (the address-job d021 cleanup is unreachable).
+          # That's how PRs #513 and #516 ended up with `ai-phase-copilot` set
+          # on top of an already-converged `ai-cp-after-1 + ai-o-after-1`
+          # after the pre-#519 duplicate-Copilot-request bug fired the
+          # worker's `Handle success` a second time.
+          # Fix: do the same cleanup the address-job d021 step would have
+          # done, then short-circuit. Idempotent: removing absent labels and
+          # adding present ones via the REST endpoint is a no-op.
           if echo ",$LABELS," | grep -q ",ai-cp-after-1," \
              && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
             SHOULD_RUN="false"
             REASON="PR #$PR already has ai-cp-after-1 + ai-o-after-1 (D-021 converged)"
+            # Clear stale phase / blocked / auto-retry labels.
+            for stale in ai-ready-for-review ai-phase-copilot ai-phase-opus ai-blocked ai-auto-retry; do
+              gh api "repos/${{ github.repository }}/issues/$PR/labels/$stale" -X DELETE 2>/dev/null || true
+            done
+            # CI-gated owner handoff (matches the address-job d021 step).
+            HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+            CI_STATE=$(gh api "repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs" \
+              --jq '[.check_runs[] | .conclusion] | if length == 0 then "running" elif any(. == null) then "running" elif all(. == "success" or . == "skipped" or . == "neutral") then "ready" else "failing" end' \
+              2>/dev/null || echo "unknown")
+            if echo ",$LABELS," | grep -q ",ai-ci-failing,"; then
+              CI_STATE="failing"
+            fi
+            if [ "$CI_STATE" = "ready" ]; then
+              gh api "repos/${{ github.repository }}/issues/$PR/labels" -X POST \
+                -f 'labels[]=ai-awaiting-owner' 2>/dev/null || true
+            fi
           fi
 
           echo "pr_number=$PR" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The resolve-job's D-021 converge bail short-circuits without cleaning up stale labels. The cleanup logic lives inside the address job's d021 step — but that job is gated by `if: needs.resolve.outputs.should_run == 'true'`, which the bail just set to false. Result: stale labels stay stuck.

## Symptom

PRs #513 and #516 ended up with `ai-phase-copilot` set on top of an already-converged `ai-cp-after-1 + ai-o-after-1`. The pre-#519 duplicate-Copilot bug fired the worker's `Handle success` a second time on those PRs and re-added `ai-phase-copilot`. From then on, every address-feedback dispatch hit the resolve-job converge bail and exited without cleanup. The PRs were stuck in a state the human couldn't merge from (no `ai-awaiting-owner` because the address-job d021 step never ran to add it).

Manual fix was applied today via REST API; this PR is the durable fix so it doesn't happen again.

## Changes

`.github/workflows/ai-address-feedback.yml` (resolve job's D-021 converge bail, lines ~131-138):

- **Before**: set `SHOULD_RUN=false`, no label changes.
- **After**: set `SHOULD_RUN=false`, **also**:
  - Remove `ai-ready-for-review`, `ai-phase-copilot`, `ai-phase-opus`, `ai-blocked`, `ai-auto-retry` (idempotent — DELETE on absent labels returns 404, suppressed).
  - Check CI state via `commits/{sha}/check-runs`. If `ready`, add `ai-awaiting-owner`.

The address-job d021 step is preserved as defence in depth (still useful if labels change between resolve and address phases, e.g. a concurrent run modifies them).

Uses `gh api -X DELETE/POST` instead of `gh pr edit --remove-label/--add-label` because the latter goes through GraphQL and currently fails with the Projects (classic) deprecation error in some environments. REST-API path is reliable.

## Test plan

- [ ] Once merged, dispatch ai-address-feedback on a fresh test PR with `ai-cp-after-1 + ai-o-after-1 + ai-phase-copilot` (simulating the stuck state). Verify the resolve job removes `ai-phase-copilot` and adds `ai-awaiting-owner`.
- [ ] Verify normal Copilot → Opus → converge flow on a fresh PR still works (the address-job d021 step should still trigger correctly when the resolve bail doesn't fire).

## Related

- Builds on #519 which prevented the upstream cause (duplicate Copilot requests from the worker re-running on an existing PR).

https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD