### PR TITLE
fix(ai-pr-mergeability): --depth=0 is invalid; use --unshallow

### DIFF
--- a/.github/workflows/ai-pr-mergeability.yml
+++ b/.github/workflows/ai-pr-mergeability.yml
@@ -183,7 +183,11 @@ jobs:
           BRANCH: ${{ steps.pr.outputs.branch }}
         run: |
           set -euo pipefail
-          git fetch origin "$BASE" --depth=0
+          # `--depth=0` is invalid (`fatal: depth 0 is not a positive number`)
+          # and was preventing the bot from ever rebasing. The intent here is
+          # a full-history fetch so rebase can find the merge base. Use
+          # `--unshallow` (no-op if already unshallow, full fetch if shallow).
+          git fetch origin "$BASE" --unshallow 2>/dev/null || git fetch origin "$BASE"
           BEFORE=$(git rev-parse HEAD)
           echo "before=$BEFORE" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

\`ai-pr-mergeability.yml\` line 186 fetched the base branch with \`git fetch origin \"\$BASE\" --depth=0\`, which git rejects: \`fatal: depth 0 is not a positive number\`. The whole \`remediate\` job exited 128, so the bot has never successfully rebased through this path.

Discovered while running ai-pr-mergeability for PR #516 (run [25601363505](https://github.com/alvarolobato/powershop-analytics/actions/runs/25601363505)) — the PR has a real conflict between #514's central LLM client refactor and #516's prompt caching, but the bot couldn't even start because of this invalid fetch.

## Fix

Replace \`--depth=0\` with \`--unshallow\` plus a fallback to a plain fetch when the checkout is already unshallow (\`--unshallow\` errors in that case). Full-history fetch is what the rebase needs anyway — shallow doesn't make sense for a rebase operation.

## Test plan

- [ ] Once merged, redispatch \`ai-pr-mergeability.yml\` with \`pr_number=516\` and verify the rebase step starts and Claude resolves the conflict in \`dashboard/lib/llm.ts\`.

https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD