### PR TITLE
fix(ai-factory): re-establish git auth after claude-code-action before push

### DIFF
--- a/.github/workflows/ai-pr-mergeability.yml
+++ b/.github/workflows/ai-pr-mergeability.yml
@@ -309,8 +309,19 @@ jobs:
           steps.verify_resolve.outputs.resolved == 'true'
         env:
           BRANCH: ${{ steps.pr.outputs.branch }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # claude-code-action runs in the same checkout and can leave the
+          # remote URL or credential helper in a state where the default
+          # actions/checkout `persist-credentials: true` no longer applies
+          # to subsequent pushes (observed on PR #516, run 25601451527 —
+          # `Authentication failed for 'https://github.com/...'` on every
+          # retry). Re-establish GITHUB_TOKEN-based auth on the remote URL
+          # before pushing — `x-access-token` is the canonical username for
+          # token-based git auth on GitHub.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}"
           # force-with-lease guards against clobbering a concurrent push.
           # Retry up to 4 times on transient network failure (per repo guideline).
           for attempt in 1 2 3 4; do

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -630,7 +630,14 @@ jobs:
         if: failure()
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
+          # Re-establish GITHUB_TOKEN-based auth on the remote URL — the
+          # claude-code-action that ran above can leave the credential
+          # helper in a state where the default checkout auth no longer
+          # applies (see ai-pr-mergeability.yml `Push rebased branch` for
+          # the same fix).
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}" || true
           BRANCH=$(git branch --show-current)
           if [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ] && [ -n "$BRANCH" ]; then
             git push origin "$BRANCH" || true


### PR DESCRIPTION
## Summary

\`claude-code-action\` runs in the same checkout as the surrounding workflow steps and can leave the remote URL or credential helper in a state where the default \`actions/checkout@v4\` \`persist-credentials: true\` no longer applies to subsequent pushes.

## Symptom

PR #516, ai-pr-mergeability.yml run [25601451527](https://github.com/alvarolobato/powershop-analytics/actions/runs/25601451527):

\`\`\`
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/alvarolobato/powershop-analytics.git/'

Push attempt 1 failed. Sleeping 2s...
Push attempt 2 failed. Sleeping 4s...
Push attempt 3 failed. Sleeping 8s...
Push attempt 4 failed. Sleeping 16s...
##[error]Process completed with exit code 1.
\`\`\`

The bot rebased and Claude resolved the conflict in \`dashboard/lib/llm.ts\` successfully. The push step then failed on every retry because the auth state never recovered. ~5min of conflict-resolution work was discarded.

## Fix

Re-establish GITHUB_TOKEN-based auth on the remote URL right before pushing. Use \`x-access-token\` as the username (canonical for token-based git auth on GitHub):

\`\`\`bash
git remote set-url origin \"https://x-access-token:\${GH_TOKEN}@github.com/\${REPO}\"
\`\`\`

Applied in two places where a workflow-level \`git push\` runs after \`claude-code-action\`:

1. \`ai-pr-mergeability.yml\` \`Push rebased branch\` — the step that actually broke.
2. \`ai-worker.yml\` \`Push partial work on failure\` — same pattern (post-claude-code-action push).

\`ai-ci-remediation.yml\` only pushes from inside the agent prompt, where claude-code-action manages its own auth — different code path, no fix needed.

## Test plan

- [ ] Once merged, manually create a test conflict on a feature branch and dispatch \`ai-pr-mergeability.yml\`. Verify the bot rebases, Claude resolves, and the push step succeeds (auth no longer the failure mode).
- [ ] Trigger a worker that fails partway through and verify partial-work push succeeds.

## Related

- Builds on #521 (which fixed the upstream \`--depth=0\` bug in the same workflow).

https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD