### PR TITLE
fix(ai-factory): three stall recoveries — stop the babysitting

### DIFF
--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -155,7 +155,16 @@ jobs:
               --jq '[.check_runs[] | .conclusion] | if length == 0 then "running" elif any(. == null) then "running" elif all(. == "success" or . == "skipped" or . == "neutral") then "ready" else "failing" end' \
               2>/dev/null || echo "unknown")
             if echo ",$LABELS," | grep -q ",ai-ci-failing,"; then
-              CI_STATE="failing"
+              # If CI is actually green now, the label is stale — drop it
+              # before computing the gate, otherwise the legitimate green
+              # state can't reach `ai-awaiting-owner`. PR #530 hit this on
+              # 2026-05-09: ai-ci-remediation fixed CI but the label
+              # lingered and blocked the converge handoff.
+              if [ "$CI_STATE" = "ready" ]; then
+                gh api "repos/${{ github.repository }}/issues/$PR/labels/ai-ci-failing" -X DELETE 2>/dev/null || true
+              else
+                CI_STATE="failing"
+              fi
             fi
             if [ "$CI_STATE" = "ready" ]; then
               gh api "repos/${{ github.repository }}/issues/$PR/labels" -X POST \

--- a/.github/workflows/ai-ci-remediation.yml
+++ b/.github/workflows/ai-ci-remediation.yml
@@ -179,15 +179,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          set -euo pipefail
-          # Without this step, `ai-ci-failing` lingers on PRs whose CI was
-          # successfully remediated, blocking the address-feedback workflow's
-          # CI-gated owner handoff (see ai-address-feedback.yml ~line 187,
-          # which treats ai-ci-failing presence as CI_STATE='failing').
-          # Watchdog also cleans it but only every 15 min; clear eagerly
-          # here so the converge → ai-awaiting-owner can advance immediately
-          # on the next address-feedback dispatch.
-          HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          # Best-effort cleanup. Without this step, `ai-ci-failing` lingers on
+          # PRs whose CI was successfully remediated, blocking the
+          # address-feedback workflow's CI-gated owner handoff (see
+          # ai-address-feedback.yml ~line 187, which treats ai-ci-failing
+          # presence as CI_STATE='failing'). Watchdog also cleans it but only
+          # every 15 min; clear eagerly here so the converge →
+          # ai-awaiting-owner can advance immediately on the next
+          # address-feedback dispatch.
+          #
+          # Deliberately NOT using `set -euo pipefail` and explicit `|| true`
+          # on every API call: this step runs on `if: always()`, so a transient
+          # GitHub API failure must not flip the whole `ai-ci-remediation`
+          # job to failed when the underlying remediation succeeded. Watchdog
+          # is the catch-all if we couldn't clear here.
+          HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha' 2>/dev/null || echo "")
+          if [ -z "$HEAD_SHA" ]; then
+            echo "Could not resolve head SHA for PR #$PR_NUMBER — leaving label cleanup to watchdog."
+            exit 0
+          fi
           # Wait briefly for any pending check-runs from the remediation push
           # to register; otherwise we'll see "running" and hold the label.
           sleep 30
@@ -196,9 +206,12 @@ jobs:
             2>/dev/null || echo "unknown")
           echo "PR #$PR_NUMBER head=$HEAD_SHA CI_STATE=$CI_STATE"
           if [ "$CI_STATE" = "ready" ]; then
-            gh api "repos/$REPO/issues/$PR_NUMBER/labels/ai-ci-failing" -X DELETE 2>/dev/null \
-              && echo "Cleared ai-ci-failing on PR #$PR_NUMBER (CI now green)." \
-              || echo "ai-ci-failing was not present on PR #$PR_NUMBER (no-op)."
+            if gh api "repos/$REPO/issues/$PR_NUMBER/labels/ai-ci-failing" -X DELETE >/dev/null 2>&1; then
+              echo "Cleared ai-ci-failing on PR #$PR_NUMBER (CI now green)."
+            else
+              echo "ai-ci-failing was not present on PR #$PR_NUMBER (or API hiccup) — no-op."
+            fi
           else
-            echo "CI is $CI_STATE — leaving ai-ci-failing in place."
+            echo "CI is $CI_STATE — leaving ai-ci-failing in place; watchdog will revisit."
           fi
+          exit 0

--- a/.github/workflows/ai-ci-remediation.yml
+++ b/.github/workflows/ai-ci-remediation.yml
@@ -172,3 +172,33 @@ jobs:
           SERVER="${{ github.server_url }}"
           gh pr comment "$PR_NUMBER" --repo "$REPO" \
             --body "🔧 **AI CI remediation** finished for failed CI [run $RID]($SERVER/$REPO/actions/runs/$RID). Bot workflow: [run ${{ github.run_id }}]($SERVER/$REPO/actions/runs/${{ github.run_id }}). CI remediation attempted for run $RID" || true
+
+      - name: Clear `ai-ci-failing` if CI is now green
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Without this step, `ai-ci-failing` lingers on PRs whose CI was
+          # successfully remediated, blocking the address-feedback workflow's
+          # CI-gated owner handoff (see ai-address-feedback.yml ~line 187,
+          # which treats ai-ci-failing presence as CI_STATE='failing').
+          # Watchdog also cleans it but only every 15 min; clear eagerly
+          # here so the converge → ai-awaiting-owner can advance immediately
+          # on the next address-feedback dispatch.
+          HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          # Wait briefly for any pending check-runs from the remediation push
+          # to register; otherwise we'll see "running" and hold the label.
+          sleep 30
+          CI_STATE=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
+            --jq '[.check_runs[] | .conclusion] | if length == 0 then "running" elif any(. == null) then "running" elif all(. == "success" or . == "skipped" or . == "neutral") then "ready" else "failing" end' \
+            2>/dev/null || echo "unknown")
+          echo "PR #$PR_NUMBER head=$HEAD_SHA CI_STATE=$CI_STATE"
+          if [ "$CI_STATE" = "ready" ]; then
+            gh api "repos/$REPO/issues/$PR_NUMBER/labels/ai-ci-failing" -X DELETE 2>/dev/null \
+              && echo "Cleared ai-ci-failing on PR #$PR_NUMBER (CI now green)." \
+              || echo "ai-ci-failing was not present on PR #$PR_NUMBER (no-op)."
+          else
+            echo "CI is $CI_STATE — leaving ai-ci-failing in place."
+          fi

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -449,6 +449,76 @@ jobs:
             fi
           done
 
+      - name: Stuck `ai-phase-opus` PRs (Opus reviewed but address-feedback didn't transition)
+        run: |
+          set -euo pipefail
+          # PRs that received an Opus review but never transitioned to
+          # `ai-cp-after-1 + ai-o-after-1 + ai-awaiting-owner` indicate the
+          # `Dispatch address-feedback` step in `ai-pr-review.yml` succeeded
+          # but the dispatched run was cancelled (the global concurrency
+          # group `ai-address-feedback-global` cancelled it under load — the
+          # `cancel-in-progress: false` setting queues but the GHA scheduler
+          # has been observed to mark queued runs `cancelled` instead).
+          # The cold-dispatch path ABOVE (line ~290) explicitly skips PRs
+          # with `ai-phase-opus`, so without this step a PR can sit in
+          # `ai-phase-opus` forever.
+          #
+          # Detection: PR has `ai-phase-opus` AND a recent successful
+          # ai-pr-review run (within 60 min) AND no successful
+          # ai-address-feedback run on the same head SHA after that
+          # ai-pr-review. Re-dispatch address-feedback to advance the cycle.
+          STUCK_AGE_SECS=900   # 15 min — give the post-Opus dispatch a chance
+          NOW=$(date -u +%s)
+
+          gh pr list --repo "$REPO_FULL" --state open --label "ai-phase-opus" \
+            --json number,headRefOid,labels,updatedAt | jq -c '.[]' | while read -r pr; do
+            NUM=$(echo "$pr" | jq -r '.number')
+            HEAD=$(echo "$pr" | jq -r '.headRefOid')
+            LABELS=$(echo "$pr" | jq -r '[.labels[].name] | join(",")')
+
+            # Already converged on Opus pass — Address-feedback skipped or finished.
+            if echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
+              continue
+            fi
+            # Still has the in-progress marker — needs ai-cp-after-1 to even be in opus.
+            if ! echo ",$LABELS," | grep -q ",ai-cp-after-1,"; then
+              echo "PR #$NUM: ai-phase-opus without ai-cp-after-1 — unusual, leaving for cold-dispatch."
+              continue
+            fi
+
+            # Look for the most recent successful ai-pr-review on this head SHA.
+            LAST_OPUS_AT=$(gh api "repos/$REPO_FULL/actions/workflows/ai-pr-review.yml/runs?per_page=20" \
+              --jq "[.workflow_runs[] | select(.head_sha == \"$HEAD\" and .conclusion == \"success\")] | first | .updated_at // empty")
+            if [ -z "$LAST_OPUS_AT" ]; then
+              echo "PR #$NUM: no successful ai-pr-review on head $HEAD yet — skipping."
+              continue
+            fi
+            LAST_OPUS_TS=$(date -u -d "$LAST_OPUS_AT" +%s 2>/dev/null || echo 0)
+            AGE=$(( NOW - LAST_OPUS_TS ))
+            if [ "$AGE" -lt "$STUCK_AGE_SECS" ]; then
+              echo "PR #$NUM: Opus reviewed ${AGE}s ago — give the post-review dispatch more time."
+              continue
+            fi
+
+            # Has any address-feedback run completed for this PR after the Opus run?
+            AF_AFTER=$(gh api "repos/$REPO_FULL/actions/workflows/ai-address-feedback.yml/runs?per_page=30" \
+              --jq "[.workflow_runs[] | select(.conclusion == \"success\" and .updated_at > \"$LAST_OPUS_AT\")] | length")
+            if [ "${AF_AFTER:-0}" -gt 0 ]; then
+              # An address-feedback run completed after Opus, but the PR still has
+              # ai-phase-opus and lacks ai-o-after-1. That run was for a different
+              # PR (the global queue serializes them). Re-dispatch for THIS PR.
+              echo "PR #$NUM: address-feedback ran after Opus but didn't progress this PR — re-dispatching."
+            else
+              echo "PR #$NUM: no address-feedback run after Opus — re-dispatching."
+            fi
+
+            gh workflow run ai-address-feedback.yml --repo "$REPO_FULL" \
+              --field pr_number="$NUM" \
+              --field reason="watchdog: stuck in ai-phase-opus for ${AGE}s after successful Opus review" || true
+            gh pr comment "$NUM" --repo "$REPO_FULL" \
+              --body "🔁 **AI Watchdog**: detected stuck \`ai-phase-opus\` after successful Opus review (${AGE}s ago). Re-dispatched \`ai-address-feedback.yml\` to advance the cycle." || true
+          done
+
       - name: Auto-retry blocked PRs (address-feedback failures)
         run: |
           set -euo pipefail

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -451,7 +451,7 @@ jobs:
 
       - name: Stuck `ai-phase-opus` PRs (Opus reviewed but address-feedback didn't transition)
         run: |
-          set -euo pipefail
+          set -uo pipefail
           # PRs that received an Opus review but never transitioned to
           # `ai-cp-after-1 + ai-o-after-1 + ai-awaiting-owner` indicate the
           # `Dispatch address-feedback` step in `ai-pr-review.yml` succeeded
@@ -463,20 +463,27 @@ jobs:
           # with `ai-phase-opus`, so without this step a PR can sit in
           # `ai-phase-opus` forever.
           #
-          # Detection: PR has `ai-phase-opus` AND a recent successful
-          # ai-pr-review run (within 60 min) AND no successful
-          # ai-address-feedback run on the same head SHA after that
-          # ai-pr-review. Re-dispatch address-feedback to advance the cycle.
-          STUCK_AGE_SECS=900   # 15 min — give the post-Opus dispatch a chance
+          # Detection: PR has `ai-phase-opus` + `ai-cp-after-1` AND the most
+          # recent successful ai-pr-review on its head SHA finished between
+          # STUCK_AGE_SECS and STUCK_MAX_AGE_SECS ago AND the PR has fewer
+          # than MAX_OPUS_STALL_RETRIES re-dispatches from this step
+          # (counted from the marker in the comment body). Re-dispatch
+          # address-feedback. After MAX retries, give up: add `ai-blocked`
+          # and surface to the owner instead of spamming the timeline.
+          STUCK_AGE_SECS=900       # 15 min — give the post-Opus dispatch a chance
+          STUCK_MAX_AGE_SECS=3600  # 60 min — older = human problem, not auto-recoverable
+          MAX_OPUS_STALL_RETRIES=3
+          MARKER="🔁 **AI Watchdog**: stuck \`ai-phase-opus\`"
           NOW=$(date -u +%s)
 
-          gh pr list --repo "$REPO_FULL" --state open --label "ai-phase-opus" \
-            --json number,headRefOid,labels,updatedAt | jq -c '.[]' | while read -r pr; do
+          PRS_JSON=$(gh pr list --repo "$REPO_FULL" --state open --label "ai-phase-opus" \
+            --json number,headRefOid,labels,updatedAt 2>/dev/null || echo "[]")
+          echo "$PRS_JSON" | jq -c '.[]' | while read -r pr; do
             NUM=$(echo "$pr" | jq -r '.number')
             HEAD=$(echo "$pr" | jq -r '.headRefOid')
             LABELS=$(echo "$pr" | jq -r '[.labels[].name] | join(",")')
 
-            # Already converged on Opus pass — Address-feedback skipped or finished.
+            # Already converged on Opus pass — address-feedback skipped or finished.
             if echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
               continue
             fi
@@ -485,12 +492,18 @@ jobs:
               echo "PR #$NUM: ai-phase-opus without ai-cp-after-1 — unusual, leaving for cold-dispatch."
               continue
             fi
+            # Already escalated — owner is on the hook now, don't spam.
+            if echo ",$LABELS," | grep -q ",ai-blocked,"; then
+              echo "PR #$NUM: ai-blocked already set — leaving for the owner."
+              continue
+            fi
 
             # Look for the most recent successful ai-pr-review on this head SHA.
+            # Best-effort; skip silently on API hiccup.
             LAST_OPUS_AT=$(gh api "repos/$REPO_FULL/actions/workflows/ai-pr-review.yml/runs?per_page=20" \
-              --jq "[.workflow_runs[] | select(.head_sha == \"$HEAD\" and .conclusion == \"success\")] | first | .updated_at // empty")
+              --jq "[.workflow_runs[] | select(.head_sha == \"$HEAD\" and .conclusion == \"success\")] | first | .updated_at // empty" 2>/dev/null || echo "")
             if [ -z "$LAST_OPUS_AT" ]; then
-              echo "PR #$NUM: no successful ai-pr-review on head $HEAD yet — skipping."
+              echo "PR #$NUM: no successful ai-pr-review on head $HEAD yet (or API hiccup) — skipping."
               continue
             fi
             LAST_OPUS_TS=$(date -u -d "$LAST_OPUS_AT" +%s 2>/dev/null || echo 0)
@@ -499,24 +512,34 @@ jobs:
               echo "PR #$NUM: Opus reviewed ${AGE}s ago — give the post-review dispatch more time."
               continue
             fi
-
-            # Has any address-feedback run completed for this PR after the Opus run?
-            AF_AFTER=$(gh api "repos/$REPO_FULL/actions/workflows/ai-address-feedback.yml/runs?per_page=30" \
-              --jq "[.workflow_runs[] | select(.conclusion == \"success\" and .updated_at > \"$LAST_OPUS_AT\")] | length")
-            if [ "${AF_AFTER:-0}" -gt 0 ]; then
-              # An address-feedback run completed after Opus, but the PR still has
-              # ai-phase-opus and lacks ai-o-after-1. That run was for a different
-              # PR (the global queue serializes them). Re-dispatch for THIS PR.
-              echo "PR #$NUM: address-feedback ran after Opus but didn't progress this PR — re-dispatching."
-            else
-              echo "PR #$NUM: no address-feedback run after Opus — re-dispatching."
+            if [ "$AGE" -gt "$STUCK_MAX_AGE_SECS" ]; then
+              echo "PR #$NUM: Opus reviewed ${AGE}s ago (>${STUCK_MAX_AGE_SECS}s) — too old for auto-recovery, owner problem."
+              continue
             fi
 
+            # Retry cap: count past marker comments from this step (best-effort).
+            RETRY_COUNT=$(gh api "repos/$REPO_FULL/issues/$NUM/comments?per_page=100" \
+              --jq "[.comments[]?, .[]? | select(.body? | test(\"$MARKER\"; \"i\"))] | length" 2>/dev/null || echo "0")
+            # `gh api` on issues/comments returns a bare array; the jq above tolerates either shape.
+            # Fallback: simpler query if the above failed.
+            if ! [[ "$RETRY_COUNT" =~ ^[0-9]+$ ]]; then
+              RETRY_COUNT=$(gh api "repos/$REPO_FULL/issues/$NUM/comments?per_page=100" \
+                --jq "[.[] | select(.body | contains(\"AI Watchdog\") and contains(\"ai-phase-opus\"))] | length" 2>/dev/null || echo "0")
+            fi
+            if [ "${RETRY_COUNT:-0}" -ge "$MAX_OPUS_STALL_RETRIES" ]; then
+              echo "PR #$NUM: hit $RETRY_COUNT retries (cap=$MAX_OPUS_STALL_RETRIES) — escalating to ai-blocked."
+              gh pr edit "$NUM" --repo "$REPO_FULL" --add-label "ai-blocked" 2>/dev/null || true
+              gh pr comment "$NUM" --repo "$REPO_FULL" --body \
+                "🚨 **AI Watchdog**: stuck in \`ai-phase-opus\` after $RETRY_COUNT auto-recovery attempts. Adding \`ai-blocked\` and handing off — please dispatch \`ai-address-feedback.yml\` manually or merge as-is. cc @${OWNER_HANDLE:-alvarolobato}" 2>/dev/null || true
+              continue
+            fi
+
+            echo "PR #$NUM: re-dispatching address-feedback (retry $((RETRY_COUNT + 1))/$MAX_OPUS_STALL_RETRIES, Opus ${AGE}s ago)."
             gh workflow run ai-address-feedback.yml --repo "$REPO_FULL" \
               --field pr_number="$NUM" \
-              --field reason="watchdog: stuck in ai-phase-opus for ${AGE}s after successful Opus review" || true
-            gh pr comment "$NUM" --repo "$REPO_FULL" \
-              --body "🔁 **AI Watchdog**: detected stuck \`ai-phase-opus\` after successful Opus review (${AGE}s ago). Re-dispatched \`ai-address-feedback.yml\` to advance the cycle." || true
+              --field reason="watchdog: stuck in ai-phase-opus for ${AGE}s after successful Opus review (retry $((RETRY_COUNT + 1))/$MAX_OPUS_STALL_RETRIES)" 2>/dev/null || true
+            gh pr comment "$NUM" --repo "$REPO_FULL" --body \
+              "$MARKER detected ${AGE}s after Opus success. Re-dispatched \`ai-address-feedback.yml\` (retry $((RETRY_COUNT + 1))/$MAX_OPUS_STALL_RETRIES)." 2>/dev/null || true
           done
 
       - name: Auto-retry blocked PRs (address-feedback failures)


### PR DESCRIPTION
## Summary

Today's session needed manual intervention three times for the same class of bug — labels going stale or workflow runs getting cancelled mid-cycle, leaving PRs stuck in interim states (\`ai-phase-opus\`, \`ai-ci-failing\`). Closing the structural gaps so this stops happening.

## Three fixes

### 1. \`ai-address-feedback.yml\` D-021 converge bail clears stale \`ai-ci-failing\` when CI is green

#520 added cleanup for \`ai-phase-*\` / \`ai-blocked\` / \`ai-auto-retry\` / \`ai-ready-for-review\` in the resolve-job converge bail. This adds the same fix for \`ai-ci-failing\`, but only when CI is provably green — don't paper over real failures.

**Without this**: \`ai-ci-failing\` short-circuits the CI gate to \`CI_STATE='failing'\` even when CI is actually green, blocking \`ai-awaiting-owner\` forever. PR #530 hit this today — ai-ci-remediation fixed CI but the label lingered.

### 2. \`ai-watchdog.yml\` new step: detect stuck \`ai-phase-opus\` PRs

The flow path: Opus reviews post as \`claude[bot]\`. The \`pull_request_review\` event in \`ai-address-feedback.yml\` ignores \`[bot]\` actors. \`ai-pr-review.yml\` line 298-311 explicitly dispatches \`ai-address-feedback.yml\` after Opus to compensate, BUT the global concurrency group \`ai-address-feedback-global\` (\`cancel-in-progress: false\`) has been observed cancelling queued runs under load — three of four runs cancelled today on PRs #530/#531.

The cold-dispatch path in this workflow already exists but explicitly skips PRs with \`ai-phase-opus\` (\"pr-review flow already handled it\"). When pr-review's dispatch is cancelled, no one rescues the PR.

**New step**: detect PRs that have \`ai-phase-opus\` + \`ai-cp-after-1\` + a successful \`ai-pr-review\` run on their head SHA from >15min ago, and have NOT transitioned to \`ai-o-after-1\`. Re-dispatch address-feedback. Watchdog runs every 15 min, so worst-case the PR sits stuck for ~30 min before recovery.

### 3. \`ai-ci-remediation.yml\` eagerly clears \`ai-ci-failing\` after successful remediation

Watchdog already does this on a 15-min cycle (\`Clear ai-ci-failing when CI is green\` step). Adding it eagerly at the end of a successful remediation run avoids the lag — important because address-feedback's converge handoff also gates on \`ai-ci-failing\`, so a stale label can hold up the whole cycle.

A 30s sleep gives the remediation push's check-runs time to register before we evaluate CI state. Watchdog remains the catch-all for missed cases.

## Test plan

- [ ] Once merged, observe the next PR that hits \`ai-phase-opus\` legitimately. If the dispatch fires through cleanly, this code is dormant — verify by checking watchdog logs that the new step found no candidates. If the dispatch gets cancelled again, watchdog should detect within 15 min and re-dispatch — verify in the comment trail.
- [ ] Trigger a CI failure intentionally, let \`ai-ci-remediation\` fix it, verify \`ai-ci-failing\` is cleared at end of run (no need to wait for watchdog).
- [ ] Manually re-create the convergence stuck-state on a test PR (set \`ai-cp-after-1 + ai-o-after-1 + ai-ci-failing\` while CI is green), dispatch \`ai-address-feedback.yml\`, verify the bail clears \`ai-ci-failing\` and adds \`ai-awaiting-owner\`.

## Related

- Builds on #517 (parent comment reading), #518 (job-level concurrency), #519 (Handle success idempotency), #520 (D-021 bail cleanup), #521 (depth=0 fix), #522 (push auth fix). Together these eliminate the manual-intervention paths I hit during the #502 batch.

https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD