### PR TITLE
docs(ai-factory): sync config.yml label registry with actual repo state

### DIFF
--- a/.github/ai-factory/config.yml
+++ b/.github/ai-factory/config.yml
@@ -9,16 +9,20 @@ claude:
 
 # Label system
 labels:
-  # Execution control
+  # Execution control (issue-level)
   trigger: "ai-work"          # AI should implement this issue
   blocked: "ai-blocked"       # AI is blocked, needs human input
   planned: "ai-planned"       # AI has posted a plan
   in_progress: "ai-in-progress" # AI is currently working
+  task: "ai-task"             # Sub-task created by planner (with ai-work, triggers implement phase)
+  needs_rewrite: "ai-needs-rewrite"  # Sub-issue body mangled (JSX/generics stripped) — repair before acting
+  auto_retry: "ai-auto-retry" # Watchdog retries automatically; pairs with ai-blocked
   no_ai: "no-ai"              # Human-only
-  no_review: "no-pr-review"   # Skip AI PR review
-  auto_merge: "auto-merge"    # Auto-merge when CI + review pass
+  no_review: "no-pr-review"   # Skip AI PR review on this PR
+  auto_merge: "auto-merge"    # Auto-merge when CI + review pass (reserved for future)
   awaiting_owner: "ai-awaiting-owner"  # Automated review cycle done — owner merges when ready
   ci_failing: "ai-ci-failing"            # CI workflow red; AI CI remediation may run
+  ready_for_review: "ai-ready-for-review"  # Address-feedback finished; trigger next PR review
 
   # Priority (highest first)
   priorities:
@@ -27,14 +31,10 @@ labels:
     - "p2-medium"
     - "p3-low"
 
-  # Categories (AI-discovered issues)
+  # Categories (only labels emitted by an active discovery agent today)
   categories:
-    - "ai-bug"
-    - "ai-security"
-    - "ai-perf"
-    - "ai-docs"
-    - "ai-idea"
-    - "ai-quality"
+    - "ai-bug"     # ai-bug-hunter.yml
+    - "ai-idea"    # ai-feature-ideas.yml
 
   # Components
   components:
@@ -53,6 +53,11 @@ labels:
     - "ai-o-after-1"       # Addressed after Opus review (terminal for AI review)
     - "ai-legacy-opus-1"   # Legacy PRs: first Opus pass recorded
     - "ai-legacy-opus-2"   # Legacy PRs: second Opus pass — further Opus runs skipped
+
+  # Auto-managed by ai-pr-mergeability.yml (created on demand)
+  mergeability:
+    - "ai-merge-conflict"  # PR has unresolvable merge conflict
+    - "ai-stale-base"      # PR was rebased onto latest main
 
   # PR size
   sizes:


### PR DESCRIPTION
## Summary

The label registry in \`.github/ai-factory/config.yml\` had drifted from the labels actually present on the repo and used by the workflows on \`main\`. Cleaned up.

## Drift summary

**Removed 4 stale categories** (no agent emits these today):
- \`ai-security\`, \`ai-perf\`, \`ai-docs\`, \`ai-quality\`

Today only \`ai-bug\` (from \`ai-bug-hunter.yml\`) and \`ai-idea\` (from \`ai-feature-ideas.yml\`) are emitted by an active discovery agent. The repo labels for the 4 dead ones were deleted today via \`gh api .../labels DELETE\` — this PR brings the in-tree registry in sync.

**Added 4 actively-used state-machine labels** that were missing from the registry:
- \`ai-task\` — sub-task marker created by the planner
- \`ai-needs-rewrite\` — mangled-body marker (also created the missing label on the repo via \`gh api .../labels POST\` — \`ai-plan.yml\` and \`ai-worker.yml\` reference it but it had never been created)
- \`ai-auto-retry\` — watchdog retry marker (pairs with \`ai-blocked\`)
- \`ai-ready-for-review\` — post-address-feedback trigger

**Added a \`mergeability:\` section** listing labels that \`ai-pr-mergeability.yml\` creates on demand: \`ai-merge-conflict\`, \`ai-stale-base\`. They're created by \`gh label create … || true\` inside the workflow, so they don't need pre-registration, but listing them in the registry makes it clear they exist.

## What's intentionally NOT changed

- \`title_prefixes\` (incl. \`[security]\`, \`[docs-patrol]\`) — \`ai-stale-manager.yml\` uses these prefixes to identify legacy AI-generated issues that may still exist for cleanup. Removing would break that path.
- \`ai-legacy-opus-1\` and \`ai-legacy-opus-2\` — still referenced by \`ai-pr-review.yml\` for the legacy multi-round capped path on old PRs. The labels remain on the repo and in the \`review_phases:\` list.

## Test plan

- [x] \`python3 -c "import yaml; yaml.safe_load(open('.github/ai-factory/config.yml'))"\` passes.
- [ ] After merge, the next planner run on a fresh issue should see \`ai-task\` + \`ai-needs-rewrite\` referenced from the registry consistently with the workflow code.

## Repo-side label state (already done, for context)

- 8 labels deleted earlier today: \`ai-perf\`, \`ai-security\`, \`ai-quality\`, \`ai-docs\`, \`ai-cp-after-2\`, \`ai-o-after-2\`, \`bug-hunter\`, \`needs-human\`
- 1 label created earlier today: \`ai-needs-rewrite\` (color #D93F0B, description matches the lifecycle doc in #519)

https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD