### PR TITLE
refactor(ai-factory): remove legacy multi-round + auto-merge code paths

### DIFF
--- a/.github/ai-factory/config.yml
+++ b/.github/ai-factory/config.yml
@@ -19,7 +19,6 @@ labels:
   auto_retry: "ai-auto-retry" # Watchdog retries automatically; pairs with ai-blocked
   no_ai: "no-ai"              # Human-only
   no_review: "no-pr-review"   # Skip AI PR review on this PR
-  auto_merge: "auto-merge"    # Auto-merge when CI + review pass (reserved for future)
   awaiting_owner: "ai-awaiting-owner"  # Automated review cycle done — owner merges when ready
   ci_failing: "ai-ci-failing"            # CI workflow red; AI CI remediation may run
   ready_for_review: "ai-ready-for-review"  # Address-feedback finished; trigger next PR review
@@ -46,13 +45,12 @@ labels:
     - "comp-docs"
 
   # AI Factory — phased PR review (see ai-worker / ai-pr-review / ai-address-feedback)
+  # Per D-021, exactly 1 Copilot pass + 1 Opus pass. No multi-round retries.
   review_phases:
     - "ai-phase-copilot"   # Awaiting / in Copilot review (before Opus)
     - "ai-cp-after-1"      # Addressed feedback after Copilot review
     - "ai-phase-opus"      # In Opus review pass
     - "ai-o-after-1"       # Addressed after Opus review (terminal for AI review)
-    - "ai-legacy-opus-1"   # Legacy PRs: first Opus pass recorded
-    - "ai-legacy-opus-2"   # Legacy PRs: second Opus pass — further Opus runs skipped
 
   # Auto-managed by ai-pr-mergeability.yml (created on demand)
   mergeability:
@@ -84,11 +82,9 @@ schedules:
   weekly_friday: "0 10 * * 5"     # Friday 10:00
   weekly_sunday: "0 20 * * 0"     # Sunday 20:00
 
-# Title prefixes for AI-created issues
+# Title prefixes for AI-created issues (only those still produced by an active agent)
 title_prefixes:
   bug_hunter: "[bug-hunter]"
-  security: "[security]"
-  docs_patrol: "[docs-patrol]"
   dashboard_audit: "[dashboard-audit]"
   etl_health: "[etl-health]"
   sql_validator: "[sql-validator]"

--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -379,15 +379,10 @@ jobs:
             - If CI was failing, your commit must fix it. Run the same commands CI runs.
 
             ## Completion
-            - If the PR has labels `ai-phase-copilot` or `ai-phase-opus`, do **NOT** call `requested_reviewers` — the workflow decides the next review step after you push.
-            - Otherwise (legacy PRs), after replying to all threads and committing fixes, re-request Copilot review.
-              GITHUB_TOKEN cannot assign Copilot — prefix the POST with the PAT exposed via `$COPILOT_PAT`
-              (fall back to the default token only if the env var is empty, so the warning path still fires):
-              ```bash
-              GH_TOKEN="${COPILOT_PAT:-$GH_TOKEN}" gh api \
-                repos/${{ github.repository }}/pulls/${{ needs.resolve.outputs.pr_number }}/requested_reviewers \
-                --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
-              ```
+            - Do **NOT** call `requested_reviewers` from this step. Per D-021 the
+              cycle is exactly 1 Copilot pass + 1 Opus pass; the workflow decides
+              the next review step (transition to `ai-phase-opus` or to
+              `ai-awaiting-owner`) after you push.
             - Post a single summary comment listing: threads addressed (with fix), threads skipped
               (with reason), files touched, tests run.
             - If you could NOT address something and need human input, post a comment tagging
@@ -581,18 +576,12 @@ jobs:
             exit 0
           fi
 
-          # Post-terminal guard: if this PR already finished its automated
-          # cycle (ai-o-after-1 set by the Opus branch above), don't fall
-          # through to the legacy path and re-dispatch Opus review.
-          if echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
-            echo "PR #$PR already completed automated review (ai-o-after-1 present) — skipping legacy dispatch."
-            exit 0
-          fi
-
-          # Legacy PRs (no phased labels): same as before — re-dispatch Opus review (capped via ai-legacy-opus-* in ai-pr-review).
-          gh pr edit "$PR" --repo "$REPO" --add-label "ai-ready-for-review" || true
-          gh workflow run ai-pr-review.yml --repo "$REPO" --field pr_number="$PR" || true
-          echo "Dispatched legacy Opus PR review for PR #$PR."
+          # If we got here, the PR has neither phase label nor a round
+          # marker — that's an unexpected state for the post-#519 cycle
+          # (every PR enters review via worker `Handle success` adding
+          # `ai-phase-copilot`). Log and exit; the watchdog cold-dispatch
+          # path will re-enter the flow if appropriate.
+          echo "PR #$PR: no phase label and no round marker — unexpected, leaving for watchdog."
 
       - name: Handle failure
         if: failure()

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -158,33 +158,24 @@ jobs:
             echo 'PR_REVIEW_EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Check Opus review cap (legacy PRs)
+      - name: Workflow-file gate
         id: cap
         if: steps.d021.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          LABELS=$(gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}" --jq '[.labels[].name] | join(",")')
-          SKIP=false
-          SKIP_REASON=""
-
-          if echo ",$LABELS," | grep -q ",ai-legacy-opus-2,"; then
-            SKIP=true
-            SKIP_REASON="legacy-cap-reached"
-          fi
-
           # Claude Code Action's OIDC app-token exchange validates that workflow
           # files on the PR branch match the default branch. If the PR modifies
           # any `.github/workflows/*` file, the exchange fails with 401 and the
           # Claude step hard-errors. Detect that up front and skip cleanly so
           # PRs that edit workflows don't show a spurious red X.
-          if [ "$SKIP" != "true" ]; then
-            WORKFLOW_CHANGES=$(gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/files" --paginate \
-              --jq '[.[] | select(.filename | startswith(".github/workflows/"))] | length' 2>/dev/null || echo "0")
-            if [ "${WORKFLOW_CHANGES:-0}" -gt 0 ]; then
-              SKIP=true
-              SKIP_REASON="workflow-file-change"
-            fi
+          SKIP=false
+          SKIP_REASON=""
+          WORKFLOW_CHANGES=$(gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/files" --paginate \
+            --jq '[.[] | select(.filename | startswith(".github/workflows/"))] | length' 2>/dev/null || echo "0")
+          if [ "${WORKFLOW_CHANGES:-0}" -gt 0 ]; then
+            SKIP=true
+            SKIP_REASON="workflow-file-change"
           fi
 
           echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
@@ -247,53 +238,6 @@ jobs:
         run: |
           gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
             --remove-label "ai-blocked" --remove-label "ai-auto-retry" || true
-
-      - name: Max automated Opus reviews reached (legacy)
-        if: success() && steps.d021.outputs.skip != 'true' && steps.cap.outputs.skip == 'true' && steps.cap.outputs.skip_reason == 'legacy-cap-reached'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR: ${{ env.PR_NUMBER }}
-        run: |
-          set -euo pipefail
-          gh pr edit "$PR" --repo "$REPO" \
-            --remove-label "ai-ready-for-review" \
-            --remove-label "ai-auto-retry" || true
-          HS=$(bash .github/scripts/ci-handoff-state.sh "$REPO" "$PR")
-          gh label create "ai-ci-failing" --color D93F0B --description "CI failed; bot may auto-remediate" 2>/dev/null || true
-          if [ "$HS" = "ready" ]; then
-            gh pr edit "$PR" --repo "$REPO" --remove-label "ai-ci-failing" || true
-            gh pr edit "$PR" --repo "$REPO" --add-label "ai-awaiting-owner" || true
-            gh pr comment "$PR" --repo "$REPO" \
-              --body "✅ **AI Factory**: This PR has reached the maximum number of automated Opus review passes (**2**). No further Opus runs will be dispatched. Merge or continue manually."
-          else
-            gh pr edit "$PR" --repo "$REPO" --remove-label "ai-awaiting-owner" || true
-            gh pr edit "$PR" --repo "$REPO" --add-label "ai-ci-failing" || true
-            if [ "$HS" = "failing" ]; then
-              gh pr comment "$PR" --repo "$REPO" \
-                --body "⚠️ **AI Factory**: Max automated Opus passes reached, but **CI is failing** — not marking \`ai-awaiting-owner\`. Added \`ai-ci-failing\`. **AI CI remediation** will be dispatched." || true
-              gh workflow run ai-ci-remediation.yml --repo "$REPO" --field pr_number="$PR" || true
-            else
-              gh pr comment "$PR" --repo "$REPO" \
-                --body "⏳ **AI Factory**: Max automated Opus passes reached, but **CI is still running** — not marking \`ai-awaiting-owner\` yet." || true
-            fi
-          fi
-
-      - name: Record legacy Opus pass
-        if: success() && steps.d021.outputs.skip != 'true' && steps.cap.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          LABELS=$(gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}" --jq '[.labels[].name] | join(",")')
-          if echo ",$LABELS," | grep -q ",ai-phase-copilot," || echo ",$LABELS," | grep -q ",ai-phase-opus,"; then
-            echo "Phased PR — skip legacy Opus counters."
-            exit 0
-          fi
-          if ! echo ",$LABELS," | grep -q ",ai-legacy-opus-1,"; then
-            gh pr edit "${{ env.PR_NUMBER }}" --add-label "ai-legacy-opus-1" || true
-          elif ! echo ",$LABELS," | grep -q ",ai-legacy-opus-2,"; then
-            gh pr edit "${{ env.PR_NUMBER }}" --add-label "ai-legacy-opus-2" || true
-          fi
 
       - name: Dispatch address-feedback
         if: success() && steps.d021.outputs.skip != 'true' && steps.cap.outputs.skip != 'true'

--- a/.github/workflows/ai-stale-manager.yml
+++ b/.github/workflows/ai-stale-manager.yml
@@ -30,7 +30,7 @@ jobs:
             Use `gh` CLI to list and manage issues/PRs.
 
             ### Issues
-            1. **AI-created issues** (title starts with `[bug-hunter]`, `[security]`, `[docs-patrol]`, `[dashboard-audit]`, `[etl-health]`, `[sql-validator]`, `[feature-ideas]`, `[project-summary]`):
+            1. **AI-created issues** (title starts with `[bug-hunter]`, `[dashboard-audit]`, `[etl-health]`, `[sql-validator]`, `[feature-ideas]`, `[project-summary]`):
                - If no activity for 21 days: close with comment "Closing as stale. This AI-generated finding was not acted upon within 21 days."
                - Exception: issues with `p0-critical` or `p1-high` labels — never auto-close
 

--- a/docs/ai-factory.md
+++ b/docs/ai-factory.md
@@ -65,7 +65,6 @@ When a new issue is opened, the **Issue Triage** workflow runs automatically —
 | `ai-planned` | The `/plan` command has posted an implementation plan (auto-set). |
 | `no-ai` | Human-only. Factory will not touch this issue. |
 | `no-pr-review` | Skip the AI PR review on this PR. |
-| `auto-merge` | Merge automatically when CI passes and review approves *(reserved for future use)*. |
 | `p0-critical` → `p3-low` | Priority — the factory processes higher priorities first. |
 
 ### c) Use slash commands in comments
@@ -417,7 +416,7 @@ Add the `no-ai` label before opening.
 
 - **Read-only SQL policy**: Every AI-generated SQL is validated against the project's read-only rule. `INSERT`/`UPDATE`/`DELETE`/`DROP`/`ALTER`/`CREATE`/`TRUNCATE` are never allowed against the source ERP.
 - **No credentials in code**: The PR Review workflow explicitly checks for leaked secrets.
-- **Human-in-the-loop merges**: Every AI-generated PR requires explicit human approval to merge. There is no auto-merge yet.
+- **Human-in-the-loop merges**: Every AI-generated PR requires explicit human approval to merge.
 - **Author-association gates**: Sensitive workflows (`/ai` command, worker) only respond to `OWNER` / `MEMBER` / `COLLABORATOR`.
 - **Fork safety**: `pull_request_target` workflows guard against running untrusted PR code with access to secrets.
 


### PR DESCRIPTION
## Summary

D-021 (2026-04-24) capped the automated review cycle at exactly 1 Copilot pass + 1 Opus pass. The legacy multi-round code paths that supported 2× Opus passes have been dead code since then — every PR now enters review via the worker's \`Handle success\` step adding \`ai-phase-copilot\`, never via the legacy \"no phased label\" branch.

Removing all of it. **No backwards-compatibility shims** — there are zero open PRs in any legacy state, and only closed-PR labels reference \`ai-legacy-opus-{1,2}\` (purely historical, will go when the labels are deleted from the repo after this merges).

## Removed

### \`ai-pr-review.yml\` (-72 / +21 lines)

- **\`Check Opus review cap (legacy PRs)\`** step — collapsed into a simpler \`Workflow-file gate\` that only handles the OIDC restriction (the only remaining skip reason).
- **\`Max automated Opus reviews reached (legacy)\`** step — the cap it enforced (2 Opus passes) doesn't exist anymore.
- **\`Record legacy Opus pass\`** step — incremented \`ai-legacy-opus-{1,2}\` counters that have no consumer post-D-021.

### \`ai-address-feedback.yml\` (-20 / +9 lines)

- **\"Otherwise (legacy PRs), re-request Copilot review\"** branch in the address-agent prompt — Copilot is requested exactly once by the worker's success path; the agent must never re-request (already established in #519, this removes the dangling instruction).
- **Final fallthrough** that dispatched \`ai-pr-review.yml\` for \"legacy PRs (no phased labels)\" — with D-021, every PR has phase labels from creation; the fallthrough now logs the unexpected state and exits cleanly, leaving recovery to the watchdog.

### \`ai-stale-manager.yml\` (-1 / +1 line)

Dropped \`[security]\` and \`[docs-patrol]\` from the AI-issue prefix list. Underlying agents are \`.disabled\` and no open issues with those prefixes exist.

### \`.github/ai-factory/config.yml\` (-6 / +2 lines)

- \`auto_merge: \"auto-merge\"\` — zero PRs use it; \"reserved for future\" is cruft.
- \`ai-legacy-opus-1\` / \`ai-legacy-opus-2\` from \`review_phases:\`.
- \`security\` and \`docs_patrol\` from \`title_prefixes:\`.

### \`docs/ai-factory.md\` (-2 / +0 lines)

Dropped the \`auto-merge\` row from the user-guide table and \"There is no auto-merge yet\" from Limits and Safety.

## After-merge cleanup (separate, this session)

Three labels become fully unreferenced after this lands and will be deleted from the repo via \`gh api .../labels DELETE\`:

- \`ai-legacy-opus-1\` (currently on 27 closed PRs — historical only)
- \`ai-legacy-opus-2\` (16 closed PRs — same)
- \`auto-merge\` (0 PRs)

## Test plan

- [x] All 4 modified YAMLs pass \`python3 -c \"yaml.safe_load(...)\"\`.
- [ ] After merge, exercise: open a regular PR via the worker. Verify the Copilot → Opus → \`ai-awaiting-owner\` cycle completes without entering any of the removed steps. The watchdog and address-feedback should both still recover from the known stalls (#533).
- [ ] Verify \`gh label list\` after the cleanup shows only labels actually referenced by code or active workflows.

https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD