### PR TITLE
fix(ai-factory): mangled-body detector ignores fenced code blocks

### DIFF
--- a/.github/workflows/ai-plan.yml
+++ b/.github/workflows/ai-plan.yml
@@ -158,7 +158,11 @@ jobs:
             rm -f "$TMP_BODY"
 
             # Verify the body is intact — fail loudly if mangled.
-            if gh issue view "$SUB_ISSUE" --json body --jq .body | grep -q '``'; then
+            # PCRE lookaround excludes triple-backtick fences (```sql, ```bash, …);
+            # only flag truly empty inline code spans (`` `` ``). False-positive
+            # observed on issue #536 (2026-05-09) which had ```sql fences and
+            # was falsely flagged by the naive `grep -q '``'`.
+            if gh issue view "$SUB_ISSUE" --json body --jq .body | grep -qP '(?<!`)``(?!`)'; then
               echo "::error::Sub-issue #$SUB_ISSUE body contains empty inline code spans — JSX/generics likely stripped."
               gh issue edit "$SUB_ISSUE" --add-label "ai-needs-rewrite" || true
               exit 1

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -210,7 +210,12 @@ jobs:
             rm -f "$TMP_BODY"
 
             # 3. Verify the body is intact — fail loudly if anything was mangled.
-            if gh issue view "$SUB_ISSUE" --json body --jq .body | grep -q '``'; then
+            # Detect EMPTY inline code spans (`` `` ``) that signal stripped
+            # JSX/generics. Use PCRE lookaround to exclude triple-backtick
+            # fenced code blocks (` ``` `), which would otherwise match any
+            # ```sql/```bash/```json fence opener and false-positive every
+            # body that uses code blocks.
+            if gh issue view "$SUB_ISSUE" --json body --jq .body | grep -qP '(?<!`)``(?!`)'; then
               echo "::error::Sub-issue #$SUB_ISSUE body contains empty inline code spans (\`\`) — likely JSX/generics were stripped. Investigate before continuing."
               gh issue edit "$SUB_ISSUE" --add-label "ai-needs-rewrite" || true
               exit 1
@@ -309,12 +314,20 @@ jobs:
           # — the signature of stripped JSX/generics. Flag them with
           # `ai-needs-rewrite` so a human (or a follow-up worker) can repair
           # the body before the implementation phase tries to act on it.
+          #
+          # The detection regex uses Oniguruma lookaround `(?<!`)``(?!`)`
+          # to match exactly two adjacent backticks NOT inside a triple-
+          # backtick fence. Without the lookaround, every fenced code
+          # block opener (```sql, ```bash, ```json, …) false-positives
+          # the check — observed on issue #536 (2026-05-09) which had a
+          # perfectly intact body but ```sql/``` fences and got falsely
+          # flagged + locked behind ai-needs-rewrite.
           SUB_ISSUES=$(gh issue list --repo "${{ github.repository }}" \
             --state open --limit 50 \
             --search "Closes #${ISSUE_NUMBER} in:body" \
             --json number,body --jq '.[]' || true)
 
-          echo "$SUB_ISSUES" | jq -c 'select(.body | test("``"))' 2>/dev/null | while read -r row; do
+          echo "$SUB_ISSUES" | jq -c 'select(.body | test("(?<!`)``(?!`)"))' 2>/dev/null | while read -r row; do
             NUM=$(echo "$row" | jq -r '.number')
             echo "Sub-issue #$NUM body contains empty backticks — flagging."
             gh issue edit "$NUM" --add-label "ai-needs-rewrite" || true


### PR DESCRIPTION
## Summary

The \"empty inline code span\" detector in \`ai-worker.yml\` and \`ai-plan.yml\` was matching **every fenced code block** (\` \`\`\`sql \`, \` \`\`\`bash \`, \` \`\`\`json \`, …) as a false-positive mangled-body signal, locking sub-issues behind \`ai-needs-rewrite\`.

## Symptom

Issue [#536](https://github.com/alvarolobato/powershop-analytics/issues/536), comment [4413245798](https://github.com/alvarolobato/powershop-analytics/issues/536#issuecomment-4413245798), 2026-05-09T18:04:21Z:

> ⚠️ AI Worker: this sub-issue body contains empty inline code spans (\`\`) — likely JSX components or TypeScript generics were stripped during creation. The implementation phase will not run on it until the body is repaired and \`ai-needs-rewrite\` is removed.

The body was perfectly intact. The only \"two adjacent backticks\" present were the \` \`\`\` \` opening a \` \`\`\`sql \` fence around the schema DDL the spec describes.

## Root cause

The naive grep in \`ai-worker.yml\` and \`ai-plan.yml\`:

\`\`\`bash
gh issue view \"\$SUB_ISSUE\" --json body --jq .body | grep -q '\`\`'
\`\`\`

matches ANY two adjacent backticks, including the opening \` \`\`\` \` of a fenced code block. So \*every\* well-written sub-issue spec (which uses \` \`\`\`sql \`, \` \`\`\`json \`, etc.) gets flagged.

## Fix

Three detection sites updated to use PCRE lookaround so they match exactly two backticks NOT preceded or followed by a third — ignoring triple-backtick fences while still catching true empty inline spans.

| File | Line | Change |
|------|------|--------|
| \`.github/workflows/ai-worker.yml\` | ~213 | \`grep -q '\`\`'\` → \`grep -qP '(?<!\`)\`\`(?!\`)'\` |
| \`.github/workflows/ai-worker.yml\` | ~322 | \`jq … test(\"\`\`\")\` → \`jq … test(\"(?<!\`)\`\`(?!\`)\")\` (Oniguruma supports same lookaround) |
| \`.github/workflows/ai-plan.yml\` | ~161 | Same as site 1 |

Verified with unit regex tests:
- Fenced-only body (\` \`\`\`sql … \`\`\` \`) → no match ✓
- True empty inline span (\` \`\` \`) → match ✓

## Side cleanup

The false-positive \`ai-needs-rewrite\` label was already removed from issue #536 manually via \`gh api .../labels DELETE\` earlier in this session, so the implementation phase can proceed once this PR merges.

## Test plan

- [x] Local regex verification: fenced body doesn't match, empty span does match.
- [x] YAML lint passes on both modified files.
- [ ] After merge, the next planner run that creates a sub-issue with fenced code blocks should NOT add \`ai-needs-rewrite\`. (#536 itself is the canary — its body has fences and was the trigger.)

https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD