### PR TITLE
fix(ai-plan): bump planner max-turns 40 → 80

### DIFF
--- a/.github/workflows/ai-plan.yml
+++ b/.github/workflows/ai-plan.yml
@@ -45,7 +45,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-opus-4-6 --permission-mode bypassPermissions --max-turns 40"
+          claude_args: "--model claude-opus-4-6 --permission-mode bypassPermissions --max-turns 80"
           prompt: |
             You are the AI Planner. Generate a comprehensive implementation plan for this issue.
 


### PR DESCRIPTION
## Summary
- Planner was hitting `Reached maximum number of turns (40)` on multi-domain issues — confirmed for #504 (Weekly business summary), which spans ETL freshness + sales/wholesale/stock/compras KPIs + scheduling + delivery channel.
- The planner spends turns reading `CLAUDE.md`, `AGENTS.md`, and every relevant `docs/skills/*` MD before posting the plan; large-scope issues run out of budget before reaching the comment-write step.
- Worker already runs at 60 turns. Bumping the planner to 80 covers the long tail without affecting the cheap path (most plans finish in 15–25 turns).

## Test plan
- [x] Planner workflow yaml valid (single-line change)
- [ ] Re-dispatch planner on #504 after merge — expect a plan comment + sub-issues created
- [ ] Cheap path unaffected (small issues still finish well under 80 turns)

Follow-up candidate: trim the planner's pre-read list so it loads skill docs lazily based on labels rather than always reading every relevant MD.

Closes diagnostic for #504 planner stall.

---
_Generated by [Claude Code](https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD)_