### PR TITLE
fix(ai-pr-review): head-SHA idempotency to prevent duplicate Opus reviews

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -54,14 +54,45 @@ jobs:
       # addressed, this PR is converged. Don't run a third review — it will
       # surface nit-picks that loop with address-feedback (PRs #493 / #495
       # had 4+ Copilot rounds and 5+ Opus rounds before this guard existed).
+      #
+      # Head-SHA idempotency: prevents duplicate Claude/Opus reviews on the
+      # same commit. PR #561 received THREE Claude reviews on the same head
+      # SHA (11:54, 11:55, 12:45 on 2026-05-10) because:
+      #   - ai-pr-review fires on `opened`, `reopened`, `ready_for_review`,
+      #     and `labeled (ai-ready-for-review)`. Each can re-fire while the
+      #     prior run hasn't finished tagging `ai-o-after-1`.
+      #   - The watchdog `Stuck ai-phase-opus` step (D-021 recovery) can
+      #     dispatch ai-pr-review again before the prior workflow has
+      #     finished posting its review.
+      # Per-PR concurrency does NOT prevent this — it only serializes; the
+      # second run still executes and posts a duplicate review. The fix is
+      # to detect "claude[bot] already reviewed this exact head SHA" and
+      # exit before invoking the LLM.
+      #
       # Runs first so we can also short-circuit later steps via this output.
-      - name: D-021 — short-circuit when both rounds done
+      - name: D-021 + head-SHA idempotency — short-circuit
         id: d021
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .headRefOid)
+
+          # Head-SHA idempotency: if claude[bot] already submitted a review
+          # on this exact commit, skip silently. The first-fired run will
+          # post the review and labels; subsequent re-fires must be no-ops.
+          EXISTING_CLAUDE_REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
+            --jq "[.[] | select(.user.login == \"claude[bot]\" and .commit_id == \"$HEAD_SHA\")] | length" 2>/dev/null || echo "0")
+          if ! [[ "$EXISTING_CLAUDE_REVIEWS" =~ ^[0-9]+$ ]]; then
+            EXISTING_CLAUDE_REVIEWS=0
+          fi
+          if [ "${EXISTING_CLAUDE_REVIEWS:-0}" -gt 0 ]; then
+            echo "PR #$PR_NUMBER: claude[bot] already submitted $EXISTING_CLAUDE_REVIEWS review(s) on $HEAD_SHA — skipping (head-SHA idempotency, prevents duplicate reviews)."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
             --json labels --jq '[.labels[].name] | join(",")')
           if echo ",$LABELS," | grep -q ",ai-cp-after-1," \


### PR DESCRIPTION
## Summary
- PR #561 had **3+ duplicate Claude/Opus reviews on the same head SHA** (11:54, 11:55, 12:45 on 2026-05-10). The 11:54+11:55 pair is identical content one minute apart.
- Root cause: `ai-pr-review` fires on `opened`, `reopened`, `ready_for_review`, and `labeled (ai-ready-for-review)`. Each can re-fire while the prior run hasn't finished tagging `ai-o-after-1`. The watchdog's `Stuck ai-phase-opus` step (added in #552) can also dispatch a second `ai-pr-review` if it doesn't see an Opus run on the head SHA yet — and per-PR concurrency only serializes, doesn't deduplicate.
- Fix: extend the existing D-021 short-circuit step with a head-SHA idempotency check **before** the converged-labels check. If `claude[bot]` already submitted any review on the current head SHA, exit with `skip=true`. All downstream steps already gate on `steps.d021.outputs.skip != 'true'` so no other changes needed.
- Skip is silent (no comment) — the first-fired run already posted the review.

## Test plan
- [x] YAML lint passes (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Verify on next address-feedback cycle: the second `ai-pr-review` fire on a new head SHA should still produce one review (it's a different SHA — idempotency doesn't block new commits)
- [ ] Verify on a stale dispatch: re-dispatching `ai-pr-review` on a PR that already has a `claude[bot]` review on its head SHA should exit at the d021 step with no review posted

Path A step 2 (per assessment thread). Step 3 (workflows: write decision), step 4 (dashboard-test triage), step 5 (clear stale labels) follow.

---
_Generated by [Claude Code](https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD)_