### PR TITLE
fix(ai-worker): add workflows: write permission

### DIFF
--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -33,6 +33,16 @@ permissions:
   pull-requests: write
   id-token: write
   actions: read
+  # workflows: write lets the worker create/modify .github/workflows/* files
+  # in PRs (e.g. when implementing a factory enhancement that adds a new
+  # workflow). PR #564 hit this gap when trying to push
+  # ai-factory-manager.yml — the claude-code-action's app token was rejected
+  # with "refusing to allow a GitHub App to create or update workflow ...
+  # without `workflows` permission". Note: standard GITHUB_TOKEN can't push
+  # workflow files even with this permission set; if this still fails after
+  # a real test, the fallback is a fine-grained PAT with `workflow` scope
+  # stored as a secret (see #554's scope-expansion section / decision log).
+  workflows: write
 
 jobs:
   # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- PR #564 (factory-manager #558) silently shipped with **no workflow file** because the worker's push to `.github/workflows/ai-factory-manager.yml` was rejected with `refusing to allow a GitHub App to create or update workflow ... without 'workflows' permission`.
- Add `workflows: write` to ai-worker.yml's permissions block so claude-code-action's app token can push workflow files.

## Caveat
- Standard `GITHUB_TOKEN`-based pushes still cannot create workflow files **even with this scope** (GitHub security constraint). If the next test still fails, the fallback is a fine-grained PAT with `workflow` scope stored as a secret. Per owner's choice in the Path A thread, we try this first; if it doesn't unblock the worker, I'll come back and propose the PAT approach.

## Test plan
- [ ] Re-trigger #558 (or close #564 and let the worker try again on a fresh branch). If the worker successfully pushes `ai-factory-manager.yml`, this fix works.
- [ ] If still rejected, capture the new error message and pivot to PAT.

Path A step 3.

---
_Generated by [Claude Code](https://claude.ai/code/session_018SmXjXvyhGY7M8N34GWAHD)_