### PR TITLE
fix(ai-factory): enforce strict Copilot → address → Opus → address sequencing (D-031)

### DIFF
--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -544,12 +544,19 @@ jobs:
               gh pr comment "$PR" --body "🤖 **AI Factory**: Self-healed partial phase transition — cleared \`ai-phase-copilot\`." || true
               exit 0
             fi
+            # The label transition is what gates Opus (ai-pr-review now fires
+            # only on `ai-ready-for-review` per D-031). If it fails, the chain
+            # is broken — let it fail loudly so the watchdog can re-fire.
             gh pr edit "$PR" --repo "$REPO" \
               --add-label "ai-cp-after-1" \
               --remove-label "ai-phase-copilot" \
               --add-label "ai-phase-opus" \
-              --add-label "ai-ready-for-review" || true
-            gh workflow run ai-pr-review.yml --repo "$REPO" --field pr_number="$PR" || true
+              --add-label "ai-ready-for-review"
+            # Belt-and-braces explicit dispatch (the labeled event above
+            # already fires ai-pr-review on a healthy repo, but bot-actor
+            # label events can be gated by GitHub as `action_required` —
+            # this dispatch is the deterministic path). Loud on failure.
+            gh workflow run ai-pr-review.yml --repo "$REPO" --field pr_number="$PR"
             gh pr comment "$PR" --body "🤖 **AI Factory**: Copilot review addressed — starting **Opus** review." || true
             exit 0
           fi

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,11 +1,17 @@
 name: AI PR Review
 on:
   pull_request:
-    # `synchronize` intentionally omitted — we don't review on every commit.
-    # After address-feedback finishes it adds `ai-ready-for-review`, which
-    # fires the `labeled` event below. This prevents a review storm on every
-    # individual commit pushed during an address-feedback session.
-    types: [opened, reopened, ready_for_review, labeled]
+    # Strict Copilot-then-Opus sequencing (D-031, issue #580 fallout):
+    # this workflow fires ONLY when `ai-ready-for-review` is applied, which
+    # happens at exactly one moment in the lifecycle — when address-feedback
+    # finishes addressing the Copilot review and adds `ai-phase-opus +
+    # ai-ready-for-review`. Previously `opened`/`reopened`/`ready_for_review`
+    # were also in `types:`, which caused Opus to race against Copilot on
+    # fresh PRs (PRs #594, #596 both got an Opus review at PR-open time
+    # before Copilot had even posted, leaving the chain stuck in
+    # `ai-phase-opus` because address-feedback only processed the latest
+    # review). Workflow_dispatch remains for manual re-fires.
+    types: [labeled]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -37,13 +43,12 @@ jobs:
       (
         github.event_name == 'workflow_dispatch'
       ) || (
+        github.event_name == 'pull_request' &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'ai-ready-for-review' &&
         github.event.pull_request.draft == false &&
         !contains(github.event.pull_request.labels.*.name, 'no-pr-review') &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        (
-          github.event.action != 'labeled' ||
-          github.event.label.name == 'ai-ready-for-review'
-        )
+        github.event.pull_request.head.repo.full_name == github.repository
       )
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -286,18 +291,29 @@ jobs:
           echo "Dispatched address-feedback for PR #$PR_NUMBER."
 
       - name: Handle failure
+        # Run even if an earlier step (including checkout) failed, so the
+        # watchdog still gets a marker. `--repo` is mandatory here because
+        # `workflow_dispatch` runs don't always have a working git directory
+        # at this point — the prior bug on PR #595 was a GraphQL 504 in the
+        # review step followed by `gh pr edit` failing with "not a git
+        # repository" because there's no `--repo` fallback. Result: no
+        # ai-blocked / ai-auto-retry labels and a silent 5 h stall.
         if: failure()
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
           RESET_LINE=""
-          if out=$(bash .github/scripts/detect-rate-limit.sh "${{ github.run_id }}" "${{ github.repository }}" 2>/dev/null); then
+          if out=$(bash .github/scripts/detect-rate-limit.sh "${{ github.run_id }}" "$REPO" 2>/dev/null); then
             RESET_ISO=$(echo "$out" | awk -F= '/^rate_limit_reset_iso=/{print $2}')
             if [ -n "$RESET_ISO" ]; then
               RESET_LINE=" ⏳ Rate limit reset at $RESET_ISO — watchdog will wait until then before retrying."
             fi
           fi
-          gh pr comment "$PR_NUMBER" \
-            --body "⚠️ AI PR Review failed. Marked \`ai-ready-for-review\` + \`ai-blocked\` + \`ai-auto-retry\` — watchdog will retry automatically.${RESET_LINE} See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
-          gh pr edit "$PR_NUMBER" \
-            --add-label "ai-ready-for-review" --add-label "ai-blocked" --add-label "ai-auto-retry" || true
+          # No `|| true` on the label add — if THIS fails the watchdog won't
+          # see the retry marker and the PR stalls silently. Let the step go
+          # red so the failure is visible in the Actions UI.
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "⚠️ AI PR Review failed. Marking \`ai-ready-for-review\` + \`ai-blocked\` + \`ai-auto-retry\` — watchdog will retry automatically.${RESET_LINE} See [workflow run](${{ github.server_url }}/$REPO/actions/runs/${{ github.run_id }})."
+          gh pr edit "$PR_NUMBER" --repo "$REPO" \
+            --add-label "ai-ready-for-review" --add-label "ai-blocked" --add-label "ai-auto-retry"

--- a/DECISIONS-AND-CHANGES.md
+++ b/DECISIONS-AND-CHANGES.md
@@ -4,6 +4,27 @@
 
 ## Decision Log
 
+### D-031: Strict Copilot → address → Opus → address sequencing — 2026-05-11
+**Context**: PRs #594 and #596 (sub-tasks of #580) sat for 3.5 h with both reviews posted but the lifecycle labels stuck in `ai-cp-after-1 + ai-phase-opus + ai-ready-for-review`. PR #595 sat for 5 h in `ai-phase-copilot` after a GraphQL 504 in `ai-pr-review.yml`. Owner observation (paraphrased): *"why are PRs not progressing through reviews? neither the watchdog nor the factory manager should have to intervene."* Trace showed three concrete bugs:
+
+1. **Out-of-order race**: `ai-pr-review.yml` fired on `pull_request: types: [opened, reopened, ready_for_review, labeled]`. On a fresh PR Opus posted a review at 12:26 (PR #594) and 12:27 (PR #596), BEFORE Copilot finished posting (12:28 / 12:30). Address-feedback then processed only the Copilot review (its most recent fire), transitioned the PR to `ai-phase-opus`, and the orphaned Opus review never advanced the chain. The head-SHA idempotency check inside the workflow was designed to prevent **duplicate** reviews but cannot fix the **sequencing** problem.
+2. **Silent failure on transient errors**: `ai-pr-review.yml`'s `Handle failure` step ran `gh pr edit "$PR_NUMBER" --add-label ai-ready-for-review --add-label ai-blocked --add-label ai-auto-retry || true` without `--repo`. On PR #595 the prior step crashed on `HTTP 504 GraphQL`, then this label-add itself errored with `failed to run git: fatal: not a git repository`. The `|| true` swallowed it; no retry marker landed; the watchdog had nothing to retry. Silent 5 h stall.
+3. **Critical-dispatch swallow**: `ai-address-feedback.yml` at the Copilot→Opus transition ran `gh workflow run ai-pr-review.yml ... || true`. If the dispatch failed (rate limit, action_required gate, transient), the PR sat in `ai-phase-opus` with no further events, waiting on a watchdog cycle whose actual cadence is ~3 h (issue #598).
+
+**Decision**:
+- **Tighten `ai-pr-review.yml`'s trigger to `types: [labeled]` only** — gated by `if: github.event.action == 'labeled' && github.event.label.name == 'ai-ready-for-review'`. The label is added at exactly one point in the lifecycle (when address-feedback finishes addressing the Copilot review), enforcing **Copilot → address → Opus → address → owner-merge** as a strict sequence. `workflow_dispatch` remains available for manual re-fires from the watchdog or owner.
+- **Failure handler in `ai-pr-review.yml` gets `--repo` and loses `|| true` on the label-add** — when adding the `ai-blocked + ai-auto-retry` retry marker fails, the step goes red and the failure is visible. Belt: pass `--repo "$REPO"` so the call doesn't depend on a working git checkout (workflow_dispatch runs aren't guaranteed to land in the repo dir at this point).
+- **Critical Copilot→Opus dispatch in `ai-address-feedback.yml` loses `|| true`** — both the label transition and the `gh workflow run ai-pr-review.yml` dispatch are now strict. If either fails the workflow goes red, the watchdog sees the marker (or the owner sees the run failure in the UI). Belt-and-braces: the label add IS the trigger now (per D-031), but the dispatch remains as a deterministic backup against GitHub's `action_required` gating of bot-actor label events.
+
+**Alternatives rejected**:
+- **Keep all four trigger types and rely on the head-SHA idempotency to dedupe**: doesn't address the sequencing — the FIRST Opus review still happens out of order; idempotency only stops the SECOND one.
+- **Add a separate "is Copilot done?" check at the top of ai-pr-review.yml**: harder to reason about than a clean trigger. Bug-prone if Copilot's review state is ambiguous (e.g., PRs created with the `request reviewer` API but never actually reviewed).
+- **Remove the `Handle failure` step entirely and let the watchdog detect failed runs**: the watchdog's actual cadence (#598) is too slow; we'd trade a 5 h stall for a ~3 h stall.
+
+**Rationale**: The factory should self-drive through review rounds without the watchdog or Factory Manager intervening; their job is recovery for genuine failures, not papering over architectural races. D-031 is the architectural fix; #598 (watchdog cadence) is the recovery-layer fix; both ship in parallel.
+
+**See**: `.github/workflows/ai-pr-review.yml` (trigger + failure handler), `.github/workflows/ai-address-feedback.yml` (Copilot→Opus transition), PRs #594, #595, #596 (the casualties), #600 (D-030 watchdog cadence companion fix).
+
 ### D-029: Worker must not write to `.github/workflows/` — 2026-05-11
 **Context**: Issue #558 asked the worker to land `.github/workflows/ai-factory-manager.yml`. PR #564 was rejected by GitHub: *"refusing to allow a GitHub App to create or update workflow ... without 'workflows' permission"*. PR #568 (merged `7fba1c3`, 2026-05-10 13:55 UTC) tried to fix this by adding `workflows: write` to `ai-worker.yml`'s `permissions:` block. The fix was based on a misreading of GitHub's permission model and silently broke the entire factory for ~21 hours.
 **Root cause** (two confused identity systems):


### PR DESCRIPTION
## Why

Owner observation today: *"why do we have so many PRs that have been 3 hours there and don't seem to be progressing through the reviews? neither the watchdog nor the factory manager should have to intervene for a PR to progress to the end of the reviews."*

Correct. Tracing PRs **#594, #595, #596** (all sub-tasks of #580) found three concrete bugs in the review pipeline — none of which the watchdog can fix architecturally; it can only paper over them on its (currently ~3 h, see #598) cadence.

## Bug 1 — Opus races Copilot on PR-open

`ai-pr-review.yml` fired on `pull_request: types: [opened, reopened, ready_for_review, labeled]`. On fresh PRs Opus posted reviews BEFORE Copilot finished:

| PR | Opus posted | Copilot posted |
|---|---|---|
| #594 | 12:26:13 | 12:28:16 |
| #596 | 12:27:34 | 12:30:59 |

`ai-address-feedback.yml` then processed only the **latest** review (Copilot), transitioned to `ai-phase-opus`, and the orphaned Opus review never advanced the chain. The existing head-SHA idempotency check stops **duplicates** but cannot fix **sequencing**.

**Fix**: `types: [labeled]` only, gated by `github.event.label.name == 'ai-ready-for-review'`. That label is added at exactly one point in the lifecycle (when address-feedback finishes the Copilot round). Result: **Copilot → address → Opus → address → owner-merge** is now strict.

## Bug 2 — Failure handler in `ai-pr-review.yml` silently failed on PR #595

GraphQL 504 in the review step → `Handle failure` step tried `gh pr edit ... --add-label ai-blocked --add-label ai-auto-retry || true` without `--repo` → call errored with `failed to run git: fatal: not a git repository` → `|| true` swallowed it → no retry marker → watchdog had nothing to retry → silent 5 h stall.

**Fix**: pass `--repo "$REPO"` on both the comment and the label-add; drop `|| true` on the label-add so the failure is visible in the Actions UI.

## Bug 3 — Critical Copilot→Opus dispatch in `ai-address-feedback.yml` swallowed errors

The label transition and explicit dispatch into `ai-pr-review.yml` both had `|| true`. Any transient (rate-limit, `action_required` gating of bot-actor label events, network) silently broke the chain.

**Fix**: strict on both. Belt-and-braces keep the explicit dispatch even though the label add IS the trigger now (D-031), because bot-actor label events can still be gated by GitHub.

## Companion to PR #600 (D-030, watchdog cadence)

| PR | Layer | What it fixes |
|---|---|---|
| **This PR (D-031)** | Architecture | Chain self-drives without watchdog intervention |
| **PR #600 (D-030)** | Recovery | Watchdog cadence: configured 15 min → actual ~3 h |

Both should land. D-031 prevents the failures from happening; D-030 makes recovery fast when they do.

## Already done out of band

I unstuck the three casualties manually before opening this PR:

- **#594, #596** — flipped labels to `ai-o-after-1 + ai-awaiting-owner` (both reviews were done; only the label transition was orphaned by Bug 1).
- **#595** — re-dispatched address-feedback. It processed the orphaned Copilot review and is now correctly in `ai-phase-opus + ai-ready-for-review`, waiting for Opus to fire.

## Test plan

- [x] Both modified YAML files parse (`ruby -ryaml -e 'YAML.load_file …'`)
- [ ] After merge, open a throwaway test PR (or watch the next real one). Expected timeline:
  - T+0: PR opens, worker adds `ai-phase-copilot`, requests Copilot. **No Opus review yet.**
  - T+~2 min: Copilot review posts.
  - T+~3 min: address-feedback fires on `pull_request_review`, replies, transitions to `ai-cp-after-1 + ai-phase-opus + ai-ready-for-review`, explicitly dispatches `ai-pr-review.yml`.
  - T+~4 min: Opus review posts.
  - T+~6 min: address-feedback fires again, replies, transitions to `ai-o-after-1 + ai-awaiting-owner`. Done.
- [ ] Negative test: cause a transient failure in `ai-pr-review.yml` (e.g. `workflow_dispatch` with a non-existent `pr_number`). Confirm the failure handler now lands `ai-blocked + ai-auto-retry` on the (real) PR so the watchdog picks it up.

## Refs

Closes pattern documented in #570. Casualties: #594, #595, #596 (all unstuck). Companion: #600 (D-030 watchdog cadence). Slow-recovery context: #598 (watchdog effective cadence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)