### PR TITLE
fix(ai-factory): strip stale ai-blocked/ai-auto-retry on Copilot→Opus transition

### DIFF
--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -540,18 +540,29 @@ jobs:
               gh pr edit "$PR" --repo "$REPO" \
                 --remove-label "ai-phase-copilot" \
                 --add-label "ai-phase-opus" \
-                --add-label "ai-ready-for-review" || true
+                --add-label "ai-ready-for-review" \
+                --remove-label "ai-blocked" \
+                --remove-label "ai-auto-retry" || true
               gh pr comment "$PR" --body "🤖 **AI Factory**: Self-healed partial phase transition — cleared \`ai-phase-copilot\`." || true
               exit 0
             fi
             # The label transition is what gates Opus (ai-pr-review now fires
             # only on `ai-ready-for-review` per D-031). If it fails, the chain
             # is broken — let it fail loudly so the watchdog can re-fire.
+            #
+            # Also strip ai-blocked + ai-auto-retry here: when this runs after
+            # recovering from a transient failure, the previous failure handler
+            # stamped those labels. The Opus-round transition below already
+            # clears them; without the same cleanup here the PR moves to
+            # ai-phase-opus but still looks "blocked", and the watchdog
+            # `Stalled ai-ready-for-review` rule skips it (ai-watchdog.yml:263-265).
             gh pr edit "$PR" --repo "$REPO" \
               --add-label "ai-cp-after-1" \
               --remove-label "ai-phase-copilot" \
               --add-label "ai-phase-opus" \
-              --add-label "ai-ready-for-review"
+              --add-label "ai-ready-for-review" \
+              --remove-label "ai-blocked" \
+              --remove-label "ai-auto-retry"
             # Belt-and-braces explicit dispatch (the labeled event above
             # already fires ai-pr-review on a healthy repo, but bot-actor
             # label events can be gated by GitHub as `action_required` —


### PR DESCRIPTION
## Summary

Two-line fix to `ai-address-feedback.yml`: add `--remove-label "ai-blocked" --remove-label "ai-auto-retry"` to the **Copilot→Opus transition path** (main + self-heal sibling). The Opus-round and D-021-converged paths already had the same cleanup.

## The bug

When `ai-address-feedback` hit a transient failure (rate-limit, GraphQL 504), the `Handle failure` step stamped the PR with `ai-blocked + ai-auto-retry`. On retry (manual or via watchdog), the workflow ran successfully through the Copilot-round transition at lines 547–551:

```yaml
gh pr edit "$PR" --repo "$REPO" \
  --add-label "ai-cp-after-1" \
  --remove-label "ai-phase-copilot" \
  --add-label "ai-phase-opus" \
  --add-label "ai-ready-for-review" || true
```

…but never cleaned the stale `ai-blocked`/`ai-auto-retry`. The PR was technically in `ai-phase-opus + ai-ready-for-review`, but the watchdog `Stalled ai-ready-for-review PRs` rule (ai-watchdog.yml:263-265) explicitly skips PRs labelled `ai-blocked`:

```yaml
if echo ",$LABELS," | grep -q ",ai-blocked,"; then
  echo "PR #$NUM: has ai-blocked, skipping ai-ready-for-review check"
```

So the recovery rule that's supposed to dispatch Opus could never see the PR. Silent stall.

## Concrete instance

**PR #588** — `ai-address-feedback` rate-limited at 2026-05-11T15:57Z, stamped `ai-blocked + ai-auto-retry`. Sat for ~2h. Manual re-dispatch at 18:03 succeeded (timeline shows the workflow added `ai-cp-after-1 + ai-phase-opus + ai-ready-for-review` at 18:07:13), but `ai-blocked + ai-auto-retry` remained. Had to be stripped via REST `DELETE …/labels/X` from outside the workflow.

This isn't covered by #604 (which fixes the Opus race and adds strict `gh workflow run` after Copilot). It's a separate gap.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ai-address-feedback.yml'))"` — clean
- [ ] Next time a PR transitions from Copilot round to Opus round, verify `ai-blocked`/`ai-auto-retry` are absent from the resulting label set (currently affects any PR that has gone through a rate-limit retry).
- [ ] Test artificially by adding `ai-blocked` to a PR mid-Copilot phase and triggering address-feedback; the resulting label set should not contain `ai-blocked`.

## Related findings (not in this PR)

Two architectural observations worth a sub-issue / dedicated fix, but out of scope here:

1. **Watchdog can't recover the existing stuck PRs even with this fix.** The `ai-pr-review.yml` workflow has a head-SHA idempotency check; when it re-fires for a PR whose head already has a Claude review (from the Opus race bug #604 fixes), it exits success without posting. The 17:05 watchdog dispatched 4 ai-pr-review runs for stuck PRs — all `success`, none produced new Opus reviews. The fix is #604's `types: [labeled]`-only trigger, which prevents the race from happening in the first place.

2. **Factory manager Pass-2 didn't flag this pattern.** The 17:49 fm run completed `success` but posted no session report on tracking issue #560 — 30-minute Opus session, no visible output, no patterns filed. The 13:06 run did file the watchdog-cadence pattern (#598) but did not detect the bigger pattern: "5 PRs simultaneously stuck in identical post-Copilot state for 3+ hours." That class of finding is exactly what Pass-2 exists for.

https://claude.ai/code/session_01HFoVkgUF87iAW91pYin2wW