### PR TITLE
fix(ai-factory): apply D-030 watchdog YAML — */30 cron + event triggers

### DIFF
--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -7,9 +7,20 @@ name: AI Factory Watchdog
 # owner with `ai-blocked` + a clear explanation.
 on:
   schedule:
-    # Every 15 minutes
-    - cron: "*/15 * * * *"
+    # Every 30 minutes — bumped from */15 because GitHub silently drops runs
+    # when the repo's schedule queue is saturated. With 9+ cron workflows
+    # competing for dispatch slots, */15 was observed firing every 3–4 hours.
+    # See DECISIONS-AND-CHANGES.md D-030.
+    - cron: "*/30 * * * *"
   workflow_dispatch:
+  # Event-driven supplement for the two most time-sensitive rules:
+  # (1) the ai-phase-opus transition after Opus submits a review, and
+  # (2) label/state cleanup on PR close. These rules fire within seconds
+  # of the event rather than waiting for the next cron tick.
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [closed]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Applies the YAML change documented by D-030 (PR #600) to `.github/workflows/ai-watchdog.yml`. #600 itself was doc-only (per D-029 the worker can't write `.github/workflows/`); this PR commits the actual YAML.

## Changes

- `cron: "*/15 * * * *"` → `cron: "*/30 * * * *"`
- Adds `pull_request_review: types: [submitted]` and `pull_request: types: [closed]` triggers

## Why

GitHub silently drops scheduled runs when a repo's cron queue is saturated. With 9+ cron workflows competing for dispatch slots, the watchdog at `*/15` was observed firing every **3–4 hours** instead of every 15 minutes — 1/8 the intended cadence. Concrete consequence today: 5 PRs sat for 3+ hours in identical post-Copilot state with no recovery action.

`*/30` is a known-honored cadence on this repo (`ai-pr-mergeability.yml` already uses it). The two event triggers cover the most time-sensitive recovery paths (Opus review submitted → fire transition rule; PR closed → cleanup).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ai-watchdog.yml'))"` — clean
- [ ] After merge, verify a new watchdog run appears within 30 min on the schedule
- [ ] After merge, submit a test PR review and confirm a `pull_request_review` run of `ai-watchdog.yml` appears within seconds

## Related

- **D-030** documented this fix — see `DECISIONS-AND-CHANGES.md` and #600
- **D-029** is why this couldn't ride in #600
- **D-031** (#604, merged) + #606 (merged) cover the architectural sequencing fix this companion completes

https://claude.ai/code/session_01HFoVkgUF87iAW91pYin2wW