### PR TITLE
fix(ai-factory): four follow-ups — Pass-4 delta reports, per-PR concurrency, ci-failing gate, REST label ops (full sweep)

### DIFF
--- a/.github/ai-factory/prompts/factory-manager.md
+++ b/.github/ai-factory/prompts/factory-manager.md
@@ -90,7 +90,39 @@ Post a **single** comment on the tracking issue (the issue number is in `MANAGER
 <!-- manager-run: <ISO date> -->
 ```
 
-The `<!-- manager-run: <ISO date> -->` HTML comment is the idempotency marker. Before posting, check if a comment from today (same ISO date) already exists with this marker on the tracking issue. If it does, **do not post a duplicate** — instead, update the existing comment if you took new actions, or skip the report entirely.
+The `<!-- manager-run: <ISO date> -->` HTML comment is the idempotency marker. Before posting, check if a comment from today (same ISO date) already exists with this marker on the tracking issue, then apply this three-branch decision:
+
+1. **No same-day marker.** Post a brand-new session report with the marker. Status quo.
+2. **Same-day marker exists AND there is new evidence not already in the existing report.** *Edit the existing comment* by appending a clearly-delimited `### Delta — HH:MM UTC` block with the new findings. Do **not** post a second comment. Leave the original marker in place.
+3. **Same-day marker exists AND there is no new evidence.** Skip silently. Don't comment, don't edit.
+
+**"New evidence" definition** (any of these qualify; the absence of all three is what selects branch 3):
+- A pattern issue you filed in *this* session (not pre-existing).
+- An autonomous action you took in *this* session (label change, issue close, workflow dispatch — anything in your boundary matrix you actually executed this run, not just considered).
+- A new decision-request you raised in *this* session (comment with the "Awaiting your approval to" header).
+
+**Example — branch 2 (delta append):**
+
+```
+## 🏭 Factory Manager — 2026-05-11
+
+[…original report posted at 13:12 by an earlier run on the same date…]
+
+<!-- manager-run: 2026-05-11 -->
+
+### Delta — 17:50 UTC
+
+#### Autonomous actions taken (since last update)
+- Dispatched `ai-pr-review.yml` for #N — head-SHA dedup blocked the prior watchdog dispatch.
+
+#### Patterns observed (new this update)
+- 5 PRs stuck in identical `ai-cp-after-1 + ai-phase-opus + ai-ready-for-review` for 3+ h — filed pattern issue #609.
+
+#### Decisions awaiting owner (new)
+- [ ] (none)
+```
+
+> **Why this matters:** The 2026-05-11 17:49 UTC run completed `success` but posted nothing on the tracking issue, because the 13:06 run had already stamped today's marker and Pass 4 took the "skip the report entirely" branch. The 17:49 run also missed filing a Pass-2 pattern issue (5 PRs simultaneously stuck), the exact class of cross-cutting finding Pass 2 exists for. Branch 2 above forces those new findings to surface.
 
 > **Scope note:** This marker prevents duplicate session reports. Passes 1–3 actions (closing issues, toggling labels) are naturally idempotent — re-running them on an already-closed issue or an already-labelled PR has no effect. Pass 2 issue-filing requires the deduplication check in step 1 above to stay idempotent.
 

--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -21,12 +21,20 @@ on:
         default: "manual dispatch"
 
 concurrency:
-  # Global group: only one address-feedback session runs at a time across all PRs.
-  # Others queue (cancel-in-progress: false). This prevents rate-limit storms when
-  # multiple PRs are unblocked simultaneously (e.g. after a rate-limit recovery).
-  # Trade-off: PRs are processed serially, not in parallel — acceptable because
-  # each session can take many minutes anyway.
-  group: ai-address-feedback-global
+  # Per-PR group: serialise runs for the SAME PR (prevents two address-feedback
+  # sessions racing on a single PR's labels and commits), but allow runs for
+  # different PRs to proceed in parallel.
+  #
+  # Why not global: GitHub Actions with `cancel-in-progress: false` keeps the
+  # in-progress run alive but **cancels older queued runs** when newer ones
+  # arrive in the same group. With a global group, 5 dispatches arriving in
+  # seconds collapsed to 1 effective run (issue #609). Per-PR avoids the
+  # cross-PR cancellation cascade entirely.
+  #
+  # Rate-limit storms (the original motivation for the global group) are bounded
+  # by the worker token's own rate-limit handling and the GitHub Actions
+  # concurrent-jobs-per-repo limit, not by serialisation here.
+  group: ai-address-feedback-${{ github.event.inputs.pr_number || github.event.pull_request.number }}
   cancel-in-progress: false
 
 permissions:
@@ -200,16 +208,29 @@ jobs:
           set -euo pipefail
           LABELS=$(gh pr view "$PR" --repo "$REPO" --json labels \
             --jq '[.labels[].name] | join(",")')
+          # Label-ops helpers — use REST API instead of `gh pr edit` because the
+          # latter exits non-zero on a Projects(classic) GraphQL deprecation
+          # warning even on success, hiding real failures behind `|| true`.
+          # See issue #611. POSTs are strict (real failures fail loud);
+          # DELETEs are idempotent (404 on absent label is OK).
+          labels_add() {
+            local pr="$1"; shift
+            for l in "$@"; do
+              gh api -X POST "repos/$REPO/issues/$pr/labels" -f "labels[]=$l" >/dev/null
+            done
+          }
+          labels_remove() {
+            local pr="$1"; shift
+            for l in "$@"; do
+              gh api -X DELETE "repos/$REPO/issues/$pr/labels/$l" >/dev/null 2>&1 || true
+            done
+          }
+
           if echo ",$LABELS," | grep -q ",ai-cp-after-1," \
              && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
             echo "PR #$PR has both rounds addressed — D-021 converged."
             # Cosmetic-only label cleanup (always safe).
-            gh pr edit "$PR" --repo "$REPO" \
-              --remove-label "ai-ready-for-review" \
-              --remove-label "ai-phase-copilot" \
-              --remove-label "ai-phase-opus" \
-              --remove-label "ai-blocked" \
-              --remove-label "ai-auto-retry" || true
+            labels_remove "$PR" ai-ready-for-review ai-phase-copilot ai-phase-opus ai-blocked ai-auto-retry
             # Owner handoff is CI-gated to match the rest of this file
             # (see `owner_handoff_or_ci_gate` below). Don't claim merge-ready
             # if CI is failing or still running.
@@ -221,7 +242,7 @@ jobs:
               CI_STATE="failing"
             fi
             if [ "$CI_STATE" = "ready" ]; then
-              gh pr edit "$PR" --repo "$REPO" --add-label "ai-awaiting-owner" || true
+              labels_add "$PR" ai-awaiting-owner
               gh pr comment "$PR" --repo "$REPO" \
                 --body "ℹ️ **AI Factory**: D-021 — both Copilot and Opus rounds already addressed. Skipping address-feedback. Awaiting owner merge decision." || true
             else
@@ -253,11 +274,15 @@ jobs:
         if: steps.d021.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ needs.resolve.outputs.pr_number }}
         run: |
-          gh pr edit ${{ needs.resolve.outputs.pr_number }} \
-            --remove-label "ai-awaiting-owner" \
-            --remove-label "ai-ci-failing" || true
-          gh pr comment ${{ needs.resolve.outputs.pr_number }} \
+          # Idempotent label removals via REST (avoids gh pr edit's
+          # projectCards deprecation false-failure — see issue #611).
+          for l in ai-awaiting-owner ai-ci-failing; do
+            gh api -X DELETE "repos/$REPO/issues/$PR/labels/$l" >/dev/null 2>&1 || true
+          done
+          gh pr comment "$PR" --repo "$REPO" \
             --body "🤖 Addressing review feedback automatically (${{ needs.resolve.outputs.reason }}). See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
 
       # Claude Code Action's OIDC app-token exchange validates that workflow
@@ -299,9 +324,9 @@ jobs:
           set -euo pipefail
           MSG="ℹ️ **AI Factory**: Skipping automated address-feedback — this PR modifies files under \`.github/workflows/\`. The Claude Code Action's OIDC app-token exchange validates that workflow files on the PR branch match \`$DEFAULT_BRANCH\`, so Claude can't push fixes from a PR that changes workflows. **Please address Copilot's inline comments manually** (reply + commit + re-request review), then merge."
           gh pr comment "$PR" --repo "$REPO" --body "$MSG" || true
-          gh pr edit "$PR" --repo "$REPO" \
-            --remove-label "ai-ready-for-review" \
-            --add-label "ai-awaiting-owner" || true
+          # Label transition via REST (avoids gh pr edit's projectCards deprecation — see #611).
+          gh api -X DELETE "repos/$REPO/issues/$PR/labels/ai-ready-for-review" >/dev/null 2>&1 || true
+          gh api -X POST "repos/$REPO/issues/$PR/labels" -f "labels[]=ai-awaiting-owner" >/dev/null
 
       - name: Address Review Feedback
         id: address
@@ -426,6 +451,25 @@ jobs:
 
           ci_state() { bash .github/scripts/ci-handoff-state.sh "$REPO" "$PR"; }
 
+          # Label-ops helpers — use REST API instead of `gh pr edit` because
+          # the latter exits non-zero on a Projects(classic) GraphQL
+          # deprecation warning even on success, forcing every call to be
+          # `|| true`-swallowed and hiding real failures. See issue #611.
+          # POST is strict (real failures fail loud); DELETE is idempotent
+          # (404 on absent label is OK and silenced).
+          labels_add() {
+            local pr="$1"; shift
+            for l in "$@"; do
+              gh api -X POST "repos/$REPO/issues/$pr/labels" -f "labels[]=$l" >/dev/null
+            done
+          }
+          labels_remove() {
+            local pr="$1"; shift
+            for l in "$@"; do
+              gh api -X DELETE "repos/$REPO/issues/$pr/labels/$l" >/dev/null 2>&1 || true
+            done
+          }
+
           # Did a non-claude, non-github-actions reviewer actually submit a review?
           # Copilot posts as `Copilot` (user) or `copilot-pull-request-reviewer[bot]`.
           # A human is anything else that isn't claude[bot]/github-actions[bot].
@@ -466,34 +510,42 @@ jobs:
               if [ "${copilot_added:-0}" -gt 0 ]; then
                 gh pr comment "$PR" --repo "$REPO" --body "🔁 **AI Factory**: No Copilot/human review found on PR — re-requested **Copilot** review before converging." || true
               else
-                gh pr edit "$PR" --repo "$REPO" --add-label "ai-blocked" || true
+                labels_add "$PR" ai-blocked
                 gh pr comment "$PR" --repo "$REPO" --body "⚠️ **AI Factory**: No Copilot/human review found **and** re-requesting Copilot returned no reviewer. This happens when \`secrets.COPILOT_PAT\` is missing (GITHUB_TOKEN cannot assign Copilot) or the PAT lacks \`pull_requests: write\`. Not marking \`ai-awaiting-owner\`. cc @alvarolobato — set \`COPILOT_PAT\` or request the review manually." || true
               fi
               return 0
             fi
 
+            # Tri-state ci_state returns one of: ready | failing | running | unknown.
+            # Each branch handles its own label state. Crucially, `ai-ci-failing`
+            # is added **only** when state is `failing` — never when it is
+            # `running` or `unknown`. Adding it prematurely while checks are
+            # still in progress makes the PR look broken in dashboards, triggers
+            # the watchdog's CI-failing handler, and forces a later cleanup.
+            # See issue #610.
             if [ "$hs" = "ready" ]; then
-              gh pr edit "$PR" --repo "$REPO" --remove-label "ai-ci-failing" || true
-              gh pr edit "$PR" --repo "$REPO" --add-label "ai-awaiting-owner" || true
+              labels_remove "$PR" ai-ci-failing
+              labels_add "$PR" ai-awaiting-owner
               gh pr comment "$PR" --repo "$REPO" --body "$1" || true
               return 0
             fi
-            gh pr edit "$PR" --repo "$REPO" --remove-label "ai-awaiting-owner" || true
-            gh pr edit "$PR" --repo "$REPO" --add-label "ai-ci-failing" || true
+            labels_remove "$PR" ai-awaiting-owner
             if [ "$hs" = "failing" ]; then
+              labels_add "$PR" ai-ci-failing
               gh pr comment "$PR" --repo "$REPO" \
                 --body "⚠️ **AI Factory**: Automated review is done, but **CI is failing** — not marking \`ai-awaiting-owner\`. Added \`ai-ci-failing\`. An **AI CI remediation** workflow will run (or re-run \`ai-ci-remediation.yml\` manually)." || true
               gh workflow run ai-ci-remediation.yml --repo "$REPO" --field pr_number="$PR" || true
             else
+              # hs is "running" or "unknown" — do NOT add ai-ci-failing.
+              # Leave the label as-is (if previously set by a real failure, it
+              # stays; if not, we don't stamp it speculatively).
               gh pr comment "$PR" --repo "$REPO" \
                 --body "⏳ **AI Factory**: Automated review is done, but **CI is still running or not reported yet** — not marking \`ai-awaiting-owner\`. Re-check after CI finishes." || true
             fi
           }
 
           converge_comment() {
-            gh pr edit "$PR" --repo "$REPO" --remove-label "ai-ready-for-review" || true
-            gh pr edit "$PR" --repo "$REPO" \
-              --remove-label "ai-blocked" --remove-label "ai-auto-retry" || true
+            labels_remove "$PR" ai-ready-for-review ai-blocked ai-auto-retry
             owner_handoff_or_ci_gate "✅ Review cycle converged — no new changes required. PR is ready for human merge decision."
           }
 
@@ -523,12 +575,7 @@ jobs:
           if echo ",$LABELS," | grep -q ",ai-cp-after-1," \
              && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
             echo "Both ai-cp-after-1 + ai-o-after-1 set — D-021 converged."
-            gh pr edit "$PR" --repo "$REPO" \
-              --remove-label "ai-phase-copilot" \
-              --remove-label "ai-phase-opus" \
-              --remove-label "ai-ready-for-review" \
-              --remove-label "ai-blocked" \
-              --remove-label "ai-auto-retry" || true
+            labels_remove "$PR" ai-phase-copilot ai-phase-opus ai-ready-for-review ai-blocked ai-auto-retry
             owner_handoff_or_ci_gate "✅ **AI Factory**: Both review rounds (Copilot + Opus) addressed. PR is ready for human merge decision."
             exit 0
           fi
@@ -537,12 +584,8 @@ jobs:
             if echo ",$LABELS," | grep -q ",ai-cp-after-1,"; then
               # Self-heal: a prior transition partially applied (both labels present).
               # Complete the label move without re-dispatching Opus review.
-              gh pr edit "$PR" --repo "$REPO" \
-                --remove-label "ai-phase-copilot" \
-                --add-label "ai-phase-opus" \
-                --add-label "ai-ready-for-review" \
-                --remove-label "ai-blocked" \
-                --remove-label "ai-auto-retry" || true
+              labels_add "$PR" ai-phase-opus ai-ready-for-review
+              labels_remove "$PR" ai-phase-copilot ai-blocked ai-auto-retry
               gh pr comment "$PR" --body "🤖 **AI Factory**: Self-healed partial phase transition — cleared \`ai-phase-copilot\`." || true
               exit 0
             fi
@@ -556,13 +599,8 @@ jobs:
             # clears them; without the same cleanup here the PR moves to
             # ai-phase-opus but still looks "blocked", and the watchdog
             # `Stalled ai-ready-for-review` rule skips it (ai-watchdog.yml:263-265).
-            gh pr edit "$PR" --repo "$REPO" \
-              --add-label "ai-cp-after-1" \
-              --remove-label "ai-phase-copilot" \
-              --add-label "ai-phase-opus" \
-              --add-label "ai-ready-for-review" \
-              --remove-label "ai-blocked" \
-              --remove-label "ai-auto-retry"
+            labels_add "$PR" ai-cp-after-1 ai-phase-opus ai-ready-for-review
+            labels_remove "$PR" ai-phase-copilot ai-blocked ai-auto-retry
             # Belt-and-braces explicit dispatch (the labeled event above
             # already fires ai-pr-review on a healthy repo, but bot-actor
             # label events can be gated by GitHub as `action_required` —
@@ -576,20 +614,12 @@ jobs:
             if echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
               # Self-heal: prior handoff partially applied. Finish clearing phase labels
               # and re-run the handoff gate — it's idempotent (label + comment only).
-              gh pr edit "$PR" --repo "$REPO" \
-                --remove-label "ai-phase-opus" \
-                --remove-label "ai-ready-for-review" \
-                --remove-label "ai-blocked" \
-                --remove-label "ai-auto-retry" || true
+              labels_remove "$PR" ai-phase-opus ai-ready-for-review ai-blocked ai-auto-retry
               owner_handoff_or_ci_gate "✅ **AI Factory**: Self-healed partial phase transition — automated reviews complete (Copilot + Opus). PR is ready for human merge decision."
               exit 0
             fi
-            gh pr edit "$PR" --repo "$REPO" \
-              --add-label "ai-o-after-1" \
-              --remove-label "ai-phase-opus" \
-              --remove-label "ai-ready-for-review" \
-              --remove-label "ai-blocked" \
-              --remove-label "ai-auto-retry" || true
+            labels_add "$PR" ai-o-after-1
+            labels_remove "$PR" ai-phase-opus ai-ready-for-review ai-blocked ai-auto-retry
             owner_handoff_or_ci_gate "✅ **AI Factory**: Automated reviews complete (Copilot + Opus). PR is ready for human merge decision."
             exit 0
           fi
@@ -605,15 +635,21 @@ jobs:
         if: failure()
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ needs.resolve.outputs.pr_number }}
         run: |
           RESET_LINE=""
-          if out=$(bash .github/scripts/detect-rate-limit.sh "${{ github.run_id }}" "${{ github.repository }}" 2>/dev/null); then
+          if out=$(bash .github/scripts/detect-rate-limit.sh "${{ github.run_id }}" "$REPO" 2>/dev/null); then
             RESET_ISO=$(echo "$out" | awk -F= '/^rate_limit_reset_iso=/{print $2}')
             if [ -n "$RESET_ISO" ]; then
               RESET_LINE=" ⏳ Rate limit reset at $RESET_ISO — watchdog will wait until then before retrying."
             fi
           fi
-          gh pr comment ${{ needs.resolve.outputs.pr_number }} \
+          gh pr comment "$PR" --repo "$REPO" \
             --body "❌ AI Address Feedback failed (rate limit or transient error). Marked \`ai-blocked\` + \`ai-auto-retry\` — watchdog will retry automatically.${RESET_LINE} See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
-          gh pr edit ${{ needs.resolve.outputs.pr_number }} \
-            --add-label "ai-blocked" --add-label "ai-auto-retry" || true
+          # REST API for label adds (see #611). Strict — if the bot can't even
+          # stamp ai-blocked, the watchdog has nothing to retry; we want the
+          # failure visible in the Actions UI rather than silently swallowed.
+          for l in ai-blocked ai-auto-retry; do
+            gh api -X POST "repos/$REPO/issues/$PR/labels" -f "labels[]=$l" >/dev/null
+          done

--- a/.github/workflows/ai-ci-remediation.yml
+++ b/.github/workflows/ai-ci-remediation.yml
@@ -114,9 +114,9 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh label create "ai-ci-failing" --color D93F0B --description "CI failed; bot may auto-remediate" 2>/dev/null || true
-          gh pr edit "$PR_NUMBER" --repo "$REPO" \
-            --remove-label "ai-awaiting-owner" \
-            --add-label "ai-ci-failing" || true
+          # REST API for label ops — see #611.
+          gh api -X DELETE "repos/$REPO/issues/$PR_NUMBER/labels/ai-awaiting-owner" >/dev/null 2>&1 || true
+          gh api -X POST "repos/$REPO/issues/$PR_NUMBER/labels" -f "labels[]=ai-ci-failing" >/dev/null
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ai-pr-mergeability.yml
+++ b/.github/workflows/ai-pr-mergeability.yml
@@ -342,13 +342,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           MARKER: ${{ steps.dedup.outputs.marker }}
         run: |
-          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "ai-stale-base" || true
+          # REST API for label ops — see #611 (gh pr edit exits non-zero on
+          # Projects(classic) GraphQL deprecation even on success).
+          gh api -X POST "repos/$REPO/issues/$PR_NUMBER/labels" -f "labels[]=ai-stale-base" >/dev/null
           # Also clear ai-blocked + ai-merge-conflict — a prior cycle on this PR
           # may have set them when the LLM step couldn't finish; now that the
           # rebase is clean, both are stale.
-          gh pr edit "$PR_NUMBER" --repo "$REPO" \
-            --remove-label "ai-merge-conflict" \
-            --remove-label "ai-blocked" || true
+          for l in ai-merge-conflict ai-blocked; do
+            gh api -X DELETE "repos/$REPO/issues/$PR_NUMBER/labels/$l" >/dev/null 2>&1 || true
+          done
           BEFORE="${{ steps.rebase.outputs.before }}"
           AFTER="${{ steps.rebase.outputs.after }}"
           BASE="${{ steps.pr.outputs.base }}"
@@ -360,8 +362,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           MARKER: ${{ steps.dedup.outputs.marker }}
         run: |
-          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "ai-stale-base" || true
-          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "ai-merge-conflict" --remove-label "ai-blocked" || true
+          # REST API — see #611.
+          gh api -X POST "repos/$REPO/issues/$PR_NUMBER/labels" -f "labels[]=ai-stale-base" >/dev/null
+          for l in ai-merge-conflict ai-blocked; do
+            gh api -X DELETE "repos/$REPO/issues/$PR_NUMBER/labels/$l" >/dev/null 2>&1 || true
+          done
           BEFORE="${{ steps.rebase.outputs.before }}"
           AFTER="${{ steps.verify_resolve.outputs.after }}"
           BASE="${{ steps.pr.outputs.base }}"
@@ -374,9 +379,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           MARKER: ${{ steps.dedup.outputs.marker }}
         run: |
-          gh pr edit "$PR_NUMBER" --repo "$REPO" \
-            --add-label "ai-blocked" --add-label "ai-merge-conflict" \
-            --remove-label "ai-awaiting-owner" || true
+          # REST API — see #611.
+          for l in ai-blocked ai-merge-conflict; do
+            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/labels" -f "labels[]=$l" >/dev/null
+          done
+          gh api -X DELETE "repos/$REPO/issues/$PR_NUMBER/labels/ai-awaiting-owner" >/dev/null 2>&1 || true
           BASE="${{ steps.pr.outputs.base }}"
           UNMERGED="${{ steps.rebase.outputs.unmerged_files }}"
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body "⚠️ **AI Mergeability**: \`${{ steps.pr.outputs.branch }}\` conflicts with \`origin/$BASE\` and the PR modifies files under \`.github/workflows/\` — the Claude Code Action's OIDC app-token exchange would 401 on this branch, so the LLM resolution step is skipped by design. Conflicted files: \`${UNMERGED}\`. Marked \`ai-blocked\` + \`ai-merge-conflict\`. cc @$OWNER_HANDLE — resolve locally. $MARKER" || true
@@ -387,9 +394,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           MARKER: ${{ steps.dedup.outputs.marker }}
         run: |
-          gh pr edit "$PR_NUMBER" --repo "$REPO" \
-            --add-label "ai-blocked" --add-label "ai-merge-conflict" \
-            --remove-label "ai-awaiting-owner" || true
+          # REST API — see #611.
+          for l in ai-blocked ai-merge-conflict; do
+            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/labels" -f "labels[]=$l" >/dev/null
+          done
+          gh api -X DELETE "repos/$REPO/issues/$PR_NUMBER/labels/ai-awaiting-owner" >/dev/null 2>&1 || true
           BASE="${{ steps.pr.outputs.base }}"
           UNMERGED="${{ steps.rebase.outputs.unmerged_files }}"
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body "⚠️ **AI Mergeability**: \`${{ steps.pr.outputs.branch }}\` has real conflicts with \`origin/$BASE\` and Claude's auto-resolution attempt didn't complete the rebase (likely an ambiguous semantic conflict). Conflicted files: \`${UNMERGED}\`. Marked \`ai-blocked\` + \`ai-merge-conflict\`. cc @$OWNER_HANDLE — resolve locally. $MARKER" || true

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -104,10 +104,10 @@ jobs:
              && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
             echo "PR #$PR_NUMBER already has ai-cp-after-1 + ai-o-after-1 — D-021 converged."
             # Always clean up phase labels (cosmetic; safe).
-            gh pr edit "$PR_NUMBER" --repo "$REPO" \
-              --remove-label "ai-ready-for-review" \
-              --remove-label "ai-phase-copilot" \
-              --remove-label "ai-phase-opus" || true
+            # REST API — see #611.
+            for l in ai-ready-for-review ai-phase-copilot ai-phase-opus; do
+              gh api -X DELETE "repos/$REPO/issues/$PR_NUMBER/labels/$l" >/dev/null 2>&1 || true
+            done
             # Owner-handoff label is CI-gated, mirroring `owner_handoff_or_ci_gate`
             # in ai-address-feedback.yml: only mark `ai-awaiting-owner` when CI
             # is green for the head SHA. If `ai-ci-failing` is already set or CI
@@ -121,7 +121,8 @@ jobs:
               CI_STATE="failing"
             fi
             if [ "$CI_STATE" = "ready" ]; then
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "ai-awaiting-owner" || true
+              # REST API — see #611 (gh pr edit exits non-zero on projectCards deprecation).
+              gh api -X POST "repos/$REPO/issues/$PR_NUMBER/labels" -f "labels[]=ai-awaiting-owner" >/dev/null
               gh pr comment "$PR_NUMBER" --repo "$REPO" \
                 --body "ℹ️ **AI Factory**: D-021 — both Copilot and Opus rounds already addressed (\`ai-cp-after-1\` + \`ai-o-after-1\`). Skipping additional review. Awaiting owner merge decision." || true
             else
@@ -143,9 +144,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
-            --remove-label "ai-ready-for-review" \
-            --remove-label "ai-ci-failing" || true
+          # REST API — see #611.
+          for l in ai-ready-for-review ai-ci-failing; do
+            gh api -X DELETE "repos/${{ github.repository }}/issues/$PR_NUMBER/labels/$l" >/dev/null 2>&1 || true
+          done
 
       - name: Resolve PR ref and title
         id: resolve
@@ -223,8 +225,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
-            --remove-label "ai-ready-for-review" || true
+          # REST API — see #611.
+          gh api -X DELETE "repos/${{ github.repository }}/issues/$PR_NUMBER/labels/ai-ready-for-review" >/dev/null 2>&1 || true
           # Don't re-request Copilot here — the dispatcher already did. Just
           # explain why Claude can't review this PR so nobody thinks it failed.
           MSG="ℹ️ **AI Factory**: Skipping Claude PR review — this PR modifies files under \`.github/workflows/\`. The Claude Code Action's OIDC app-token exchange validates that workflow files on the PR branch match \`main\`, so self-reviewing a workflow change is blocked by design. **Copilot review still runs** (no such restriction). Merge with human + Copilot review."
@@ -272,8 +274,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
-            --remove-label "ai-blocked" --remove-label "ai-auto-retry" || true
+          # REST API — see #611.
+          for l in ai-blocked ai-auto-retry; do
+            gh api -X DELETE "repos/${{ github.repository }}/issues/$PR_NUMBER/labels/$l" >/dev/null 2>&1 || true
+          done
 
       - name: Dispatch address-feedback
         if: success() && steps.d021.outputs.skip != 'true' && steps.cap.outputs.skip != 'true'
@@ -315,5 +319,9 @@ jobs:
           # red so the failure is visible in the Actions UI.
           gh pr comment "$PR_NUMBER" --repo "$REPO" \
             --body "⚠️ AI PR Review failed. Marking \`ai-ready-for-review\` + \`ai-blocked\` + \`ai-auto-retry\` — watchdog will retry automatically.${RESET_LINE} See [workflow run](${{ github.server_url }}/$REPO/actions/runs/${{ github.run_id }})."
-          gh pr edit "$PR_NUMBER" --repo "$REPO" \
-            --add-label "ai-ready-for-review" --add-label "ai-blocked" --add-label "ai-auto-retry"
+          # REST API — see #611. Strict (no || true) — if the bot can't even
+          # stamp the retry markers, the watchdog has nothing to recover from
+          # and the failure must be visible in the Actions UI (D-031).
+          for l in ai-ready-for-review ai-blocked ai-auto-retry; do
+            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/labels" -f "labels[]=$l" >/dev/null
+          done

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -284,14 +284,13 @@ jobs:
             if echo ",$LABELS," | grep -q ",ai-cp-after-1," \
                && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
               echo "PR #$NUM: D-021 converged (both ai-cp-after-1 + ai-o-after-1) — clearing stale ai-ready-for-review and skipping"
-              gh pr edit "$NUM" --repo "$REPO_FULL" \
-                --remove-label "ai-ready-for-review" || true
+              # REST API — see #611 (gh pr edit exits non-zero on projectCards deprecation).
+              gh api -X DELETE "repos/$REPO_FULL/issues/$NUM/labels/ai-ready-for-review" >/dev/null 2>&1 || true
               # Owner-handoff label is CI-gated to match owner_handoff_or_ci_gate
               # in ai-address-feedback.yml: don't claim merge-ready when CI is
               # failing. If `ai-ci-failing` is set, leave label state alone.
               if ! echo ",$LABELS," | grep -q ",ai-ci-failing,"; then
-                gh pr edit "$NUM" --repo "$REPO_FULL" \
-                  --add-label "ai-awaiting-owner" || true
+                gh api -X POST "repos/$REPO_FULL/issues/$NUM/labels" -f "labels[]=ai-awaiting-owner" >/dev/null 2>&1 || true
               fi
               continue
             fi
@@ -342,8 +341,9 @@ jobs:
 
             if [ "$STALL_RETRY_COUNT" -ge "$MAX_STALL_RETRIES" ]; then
               echo "PR #$NUM: hit MAX_STALL_RETRIES ($MAX_STALL_RETRIES) — escalating."
-              gh pr edit "$NUM" --repo "$REPO_FULL" --remove-label "ai-ready-for-review" || true
-              gh pr edit "$NUM" --repo "$REPO_FULL" --add-label "ai-blocked" || true
+              # REST API — see #611.
+              gh api -X DELETE "repos/$REPO_FULL/issues/$NUM/labels/ai-ready-for-review" >/dev/null 2>&1 || true
+              gh api -X POST "repos/$REPO_FULL/issues/$NUM/labels" -f "labels[]=ai-blocked" >/dev/null
               gh pr comment "$NUM" --repo "$REPO_FULL" \
                 --body "🚨 @$OWNER_HANDLE — pr-review has been stalled for this PR after $MAX_STALL_RETRIES watchdog re-dispatch attempts. Removed \`ai-ready-for-review\`, added \`ai-blocked\`. Please investigate." || true
               continue
@@ -406,8 +406,8 @@ jobs:
                && echo ",$LABELS," | grep -q ",ai-o-after-1,"; then
               echo "PR #$NUM has both ai-cp-after-1 + ai-o-after-1 — D-021 converged, skipping cold-dispatch."
               if ! echo ",$LABELS," | grep -q ",ai-ci-failing,"; then
-                gh pr edit "$NUM" --repo "$REPO_FULL" \
-                  --add-label "ai-awaiting-owner" || true
+                # REST API — see #611.
+                gh api -X POST "repos/$REPO_FULL/issues/$NUM/labels" -f "labels[]=ai-awaiting-owner" >/dev/null 2>&1 || true
               fi
               continue
             fi
@@ -453,7 +453,7 @@ jobs:
 
             if [ "$COLD_RETRY_COUNT" -ge "$MAX_COLD_RETRIES" ]; then
               echo "PR #$NUM hit MAX_COLD_RETRIES ($MAX_COLD_RETRIES) — escalating."
-              gh pr edit "$NUM" --repo "$REPO_FULL" --add-label "ai-blocked" || true
+              gh api -X POST "repos/$REPO_FULL/issues/$NUM/labels" -f "labels[]=ai-blocked" >/dev/null
               gh pr comment "$NUM" --repo "$REPO_FULL" \
                 --body "🚨 @$OWNER_HANDLE — pr-review never ran for this PR (likely cancelled by the global concurrency group) and $MAX_COLD_RETRIES watchdog re-dispatches still produced no completed review. Added \`ai-blocked\`. Please investigate." || true
               continue
@@ -620,7 +620,7 @@ jobs:
               fi
               if [ "${RETRY_COUNT_OPUS:-0}" -ge "$MAX_OPUS_STALL_RETRIES" ]; then
                 echo "PR #$NUM: hit $RETRY_COUNT_OPUS Opus-dispatch retries (cap=$MAX_OPUS_STALL_RETRIES) — escalating to ai-blocked."
-                gh pr edit "$NUM" --repo "$REPO_FULL" --add-label "ai-blocked" 2>/dev/null || true
+                gh api -X POST "repos/$REPO_FULL/issues/$NUM/labels" -f "labels[]=ai-blocked" >/dev/null 2>&1 || true
                 gh pr comment "$NUM" --repo "$REPO_FULL" --body \
                   "🚨 **AI Watchdog**: \`ai-phase-opus\` is set but Opus never ran (after $RETRY_COUNT_OPUS direct dispatches of \`ai-pr-review.yml\`). Adding \`ai-blocked\` and handing off — please dispatch manually or merge as-is. cc @${OWNER_HANDLE:-alvarolobato}" 2>/dev/null || true
                 continue
@@ -655,7 +655,7 @@ jobs:
             fi
             if [ "${RETRY_COUNT:-0}" -ge "$MAX_OPUS_STALL_RETRIES" ]; then
               echo "PR #$NUM: hit $RETRY_COUNT retries (cap=$MAX_OPUS_STALL_RETRIES) — escalating to ai-blocked."
-              gh pr edit "$NUM" --repo "$REPO_FULL" --add-label "ai-blocked" 2>/dev/null || true
+              gh api -X POST "repos/$REPO_FULL/issues/$NUM/labels" -f "labels[]=ai-blocked" >/dev/null 2>&1 || true
               gh pr comment "$NUM" --repo "$REPO_FULL" --body \
                 "🚨 **AI Watchdog**: stuck in \`ai-phase-opus\` after $RETRY_COUNT auto-recovery attempts. Adding \`ai-blocked\` and handing off — please dispatch \`ai-address-feedback.yml\` manually or merge as-is. cc @${OWNER_HANDLE:-alvarolobato}" 2>/dev/null || true
               continue
@@ -734,7 +734,7 @@ jobs:
 
             if [ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
               echo "PR #$NUM hit max retries — escalating to human."
-              gh pr edit "$NUM" --repo "$REPO_FULL" --remove-label "ai-auto-retry" || true
+              gh api -X DELETE "repos/$REPO_FULL/issues/$NUM/labels/ai-auto-retry" >/dev/null 2>&1 || true
               gh pr comment "$NUM" --repo "$REPO_FULL" \
                 --body "🚨 @$OWNER_HANDLE — PR #$NUM address-feedback has failed $RETRY_COUNT times and will NOT be retried automatically. Please investigate." || true
               continue
@@ -762,8 +762,10 @@ jobs:
             fi
 
             echo "Retrying $RETRY_LABEL_DESC for PR #$NUM — attempt $(( RETRY_COUNT + 1 )) of $MAX_RETRIES"
-            gh pr edit "$NUM" --repo "$REPO_FULL" \
-              --remove-label "ai-blocked" --remove-label "ai-auto-retry" || true
+            # REST API — see #611.
+            for l in ai-blocked ai-auto-retry; do
+              gh api -X DELETE "repos/$REPO_FULL/issues/$NUM/labels/$l" >/dev/null 2>&1 || true
+            done
             gh pr comment "$NUM" --repo "$REPO_FULL" \
               --body "🔄 Watchdog: auto-retrying $RETRY_LABEL_DESC (attempt $(( RETRY_COUNT + 1 )) of $MAX_RETRIES). See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})." || true
 
@@ -945,7 +947,7 @@ jobs:
           gh pr list --repo "$REPO_FULL" --state open --label "ai-ci-failing" --json number --jq '.[].number' | while read -r NUM; do
             hs=$(bash .github/scripts/ci-handoff-state.sh "$REPO_FULL" "$NUM")
             if [ "$hs" = "ready" ]; then
-              gh pr edit "$NUM" --repo "$REPO_FULL" --remove-label "ai-ci-failing" || true
+              gh api -X DELETE "repos/$REPO_FULL/issues/$NUM/labels/ai-ci-failing" >/dev/null 2>&1 || true
             fi
           done
 

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -617,7 +617,8 @@ jobs:
           gh label create "ai-phase-copilot" --color "0052cc" --description "AI Factory: Copilot review in progress" 2>/dev/null || true
           gh label create "ai-phase-opus" --color "6f42c1" --description "AI Factory: Opus review in progress" 2>/dev/null || true
 
-          gh pr edit "$PR_NUM" --add-label "ai-phase-copilot" || true
+          # REST API for label adds — see #611 (gh pr edit exits non-zero on projectCards deprecation).
+          gh api -X POST "repos/$REPO_NAME/issues/$PR_NUM/labels" -f "labels[]=ai-phase-copilot" >/dev/null
 
           # Request Copilot with the PAT-capable token and verify the request
           # actually landed. If COPILOT_PAT is unset the fallback GITHUB_TOKEN
@@ -632,7 +633,7 @@ jobs:
               --body "🤖 **AI Factory**: Automated review starts with **Copilot**, then **Opus** (one pass each). Labels: \`ai-phase-copilot\` → \`ai-phase-opus\`." || true
           else
             # Silent failure — don't advertise a review cycle that didn't start.
-            gh pr edit "$PR_NUM" --add-label "ai-blocked" || true
+            gh api -X POST "repos/$REPO_NAME/issues/$PR_NUM/labels" -f "labels[]=ai-blocked" >/dev/null
             gh pr comment "$PR_NUM" \
               --body "⚠️ **AI Factory**: Requested Copilot review but the API returned no reviewer. This happens when \`secrets.COPILOT_PAT\` is missing (GITHUB_TOKEN cannot assign Copilot) or the PAT lacks \`pull_requests: write\`. **Copilot review has NOT started.** cc @alvarolobato — set \`COPILOT_PAT\` (fine-grained PAT, Pull requests: Read and write) or request the review manually." || true
             echo "::warning::Copilot reviewer request silently failed on PR #$PR_NUM"


### PR DESCRIPTION
Closes #607, #609, #610, #611. **Replaces #612** which got stuck on a proxy-side write-block to its branch ref.

## What's in this PR — all 4 follow-ups, complete

| Issue | Files | Status |
|---|---|---|
| **#607** factory-manager Pass-4 delta reports | \`.github/ai-factory/prompts/factory-manager.md\` | ✅ |
| **#609** ai-address-feedback per-PR concurrency | \`.github/workflows/ai-address-feedback.yml\` (concurrency block) | ✅ |
| **#610** ai-ci-failing gated on \`failing\` only | \`.github/workflows/ai-address-feedback.yml\` (\`owner_handoff_or_ci_gate\`) | ✅ |
| **#611** \`gh pr edit\` → REST API, complete sweep | All 6 workflow files (see below) | ✅ Fully addressed |

### #611 — complete sweep across 6 workflow files

| File | Single-line | Multi-line | Total |
|---|---|---|---|
| \`ai-address-feedback.yml\` | 11 | 7 | 18 |
| \`ai-watchdog.yml\` | 7 | 4 | 11 |
| \`ai-pr-review.yml\` | 1 | 5 | 6 |
| \`ai-pr-mergeability.yml\` | 3 | 2 | 5 |
| \`ai-worker.yml\` | 2 | 0 | 2 |
| \`ai-ci-remediation.yml\` | 0 | 1 | 1 |
| **Total** | **24** | **19** | **43** |

After this PR: \`grep -rnE "gh pr edit.*--add-label|gh pr edit.*--remove-label" .github/workflows/\` returns no matches.

POSTs are strict (real failures fail loud); DELETEs are idempotent (404 on absent label silenced). Helper functions \`labels_add\` / \`labels_remove\` defined in \`ai-address-feedback.yml\` where there are many call sites; other workflows use inline \`gh api\` calls.

## Why all 6 files in one PR

The previous attempt (#612) scoped #611 to ai-address-feedback.yml only, deferring the other 5. Owner correctly pointed out that was unjustified — the mechanical replacement pattern is identical for every site. This PR completes the sweep.

## Test plan

- [x] All 6 YAML files parse cleanly with PyYAML
- [x] \`grep -rnE "gh pr edit.*--add-label|gh pr edit.*--remove-label" .github/workflows/\` returns 0 matches
- [ ] Post-merge **concurrency check (#609)**: dispatch 5 address-feedback runs for 5 different open PRs within 10 seconds. With the fix, all 5 complete; without it, only 1–2 do.
- [ ] Post-merge **ci-failing check (#610)**: push a commit to a PR in \`ai-phase-copilot\`; confirm \`ai-ci-failing\` is NOT added while \`dashboard-test\` is still running.
- [ ] Post-merge **REST sweep check (#611)**: tail any factory workflow run logs — the Projects(classic) deprecation warning should no longer appear in label-edit steps.

## Related (all merged earlier today)

- #604 — D-031, Opus race + strict dispatch
- #606 — Copilot→Opus label cleanup
- #608 — D-030 watchdog YAML

## Note on PR #612

#612 is being closed as superseded. Its commits (\`5306ff6\` and \`59f1565\`) are the same as the first two commits here; the proxy started returning HTTP 403 on every push to its branch ref after the first commit. Pushing to a fresh ref (\`fix/factory-followups-v2\`) works cleanly with the same authentication. Filing a follow-up to investigate the proxy-side block isn't useful since it doesn't affect production behavior.

https://claude.ai/code/session_01HFoVkgUF87iAW91pYin2wW