### PR TITLE
fix(ai-factory): address Copilot review on #614 — accurate label-stamp audit + clearer marker rationale

### DIFF
--- a/.github/ai-factory/prompts/factory-manager.md
+++ b/.github/ai-factory/prompts/factory-manager.md
@@ -103,7 +103,7 @@ The `<!-- manager-run: <ISO date> -->` HTML comment is the idempotency marker. B
 
 **Example — branch 2 (delta append):**
 
-The delta block goes **before** the marker, keeping `<!-- manager-run: YYYY-MM-DD -->` as the literal last line (so the marker stays findable by `grep` / the idempotency-check substring match in this prompt's branch-1 check):
+The delta block goes **before** the marker, keeping `<!-- manager-run: YYYY-MM-DD -->` as the literal last line. This matches the original session-report template above ("Use exactly this structure" with the marker as the trailing line) so manual readers, future tooling, and any anchor-based diffing stay consistent across single-pass and multi-delta same-day comments:
 
 ```
 ## 🏭 Factory Manager — 2026-05-11

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -345,10 +345,20 @@ jobs:
               # escalation path inside a per-PR loop under `set -euo pipefail`;
               # one PR's label-stamp failure (rate limit, transient) shouldn't
               # abort the loop and skip the escalation comment + remaining PRs.
-              gh api -X DELETE "repos/$REPO_FULL/issues/$NUM/labels/ai-ready-for-review" >/dev/null 2>&1 || true
-              gh api -X POST "repos/$REPO_FULL/issues/$NUM/labels" -f "labels[]=ai-blocked" >/dev/null 2>&1 || true
+              # We capture the exit status so the escalation comment can
+              # accurately report what actually happened (instead of a false
+              # "Added ai-blocked" audit trail when the API call failed).
+              gh api -X DELETE "repos/$REPO_FULL/issues/$NUM/labels/ai-ready-for-review" >/dev/null 2>&1 \
+                && RFR_REMOVED=true || RFR_REMOVED=false
+              gh api -X POST "repos/$REPO_FULL/issues/$NUM/labels" -f "labels[]=ai-blocked" >/dev/null 2>&1 \
+                && BLOCKED_ADDED=true || BLOCKED_ADDED=false
+              if $BLOCKED_ADDED; then
+                LABEL_REPORT="Removed \`ai-ready-for-review\` (success=$RFR_REMOVED), added \`ai-blocked\`."
+              else
+                LABEL_REPORT="**Tried to remove \`ai-ready-for-review\` (success=$RFR_REMOVED) and add \`ai-blocked\` but the API POST failed** — please add the label manually."
+              fi
               gh pr comment "$NUM" --repo "$REPO_FULL" \
-                --body "🚨 @$OWNER_HANDLE — pr-review has been stalled for this PR after $MAX_STALL_RETRIES watchdog re-dispatch attempts. Removed \`ai-ready-for-review\`, added \`ai-blocked\`. Please investigate." || true
+                --body "🚨 @$OWNER_HANDLE — pr-review has been stalled for this PR after $MAX_STALL_RETRIES watchdog re-dispatch attempts. ${LABEL_REPORT} Please investigate." || true
               continue
             fi
 
@@ -459,9 +469,17 @@ jobs:
               # Defensive `|| true` — escalation path in a per-PR loop under
               # set -euo pipefail; a single PR's label-stamp failure shouldn't
               # abort the rest of the loop or skip the escalation comment.
-              gh api -X POST "repos/$REPO_FULL/issues/$NUM/labels" -f "labels[]=ai-blocked" >/dev/null 2>&1 || true
+              # Capture exit status so the comment accurately reports whether
+              # the label actually landed.
+              gh api -X POST "repos/$REPO_FULL/issues/$NUM/labels" -f "labels[]=ai-blocked" >/dev/null 2>&1 \
+                && BLOCKED_ADDED=true || BLOCKED_ADDED=false
+              if $BLOCKED_ADDED; then
+                LABEL_REPORT="Added \`ai-blocked\`."
+              else
+                LABEL_REPORT="**Tried to add \`ai-blocked\` but the API POST failed** — please add the label manually."
+              fi
               gh pr comment "$NUM" --repo "$REPO_FULL" \
-                --body "🚨 @$OWNER_HANDLE — pr-review never ran for this PR (likely cancelled by the global concurrency group) and $MAX_COLD_RETRIES watchdog re-dispatches still produced no completed review. Added \`ai-blocked\`. Please investigate." || true
+                --body "🚨 @$OWNER_HANDLE — pr-review never ran for this PR (likely cancelled by the global concurrency group) and $MAX_COLD_RETRIES watchdog re-dispatches still produced no completed review. ${LABEL_REPORT} Please investigate." || true
               continue
             fi
 


### PR DESCRIPTION
Addresses the 3 Copilot inline comments on #614 (which merged before this could land on the same branch — proxy ref block).

## Changes

### 1 + 2. ai-watchdog.yml — accurate escalation comment

#614 made the watchdog escalation POST defensive (`|| true`) for in-loop safety. Copilot correctly pointed out that the **escalation comment** then claims the label was added regardless of whether the underlying API call succeeded — a false audit trail if the POST silently failed.

Fix at both call sites (stalled-path line ~350 and cold-retry-path line ~470): capture the exit status and word the comment based on it:

```bash
gh api -X POST .../labels -f "labels[]=ai-blocked" >/dev/null 2>&1 \
  && BLOCKED_ADDED=true || BLOCKED_ADDED=false
if $BLOCKED_ADDED; then
  LABEL_REPORT="Added \`ai-blocked\`."
else
  LABEL_REPORT="**Tried to add \`ai-blocked\` but the API POST failed** — please add the label manually."
fi
```

The stalled-path comment also tracks the `ai-ready-for-review` DELETE status separately and includes both in the report.

### 3. factory-manager.md — accurate marker-placement rationale

The previous text claimed the marker stays last for "grep-findability" / a "branch-1 check". Both are wrong — `grep` doesn't care about position and "branch-1" wasn't defined upstream. The real reason is **consistency with the original session-report template** ("Use exactly this structure" with the marker as the trailing line) so manual readers and future tooling stay consistent across single-pass and multi-delta comments. Rewrote the sentence.

## Test plan

- [x] YAML parse clean
- [ ] Next time the watchdog escalates a stuck PR with a failing API call, the comment should accurately say "Tried to add ai-blocked but the API POST failed" instead of falsely claiming success.

## Refs

- Copilot review on #614 — see the 3 inline replies on #614 confirming this is the fix.
- #614 is the parent PR (now merged).

https://claude.ai/code/session_01HFoVkgUF87iAW91pYin2wW