### PR TITLE
feat(dashboard): OpenRouter provider rows + routing in model picker

### DIFF
--- a/dashboard/app/admin/config/ConfigForm.tsx
+++ b/dashboard/app/admin/config/ConfigForm.tsx
@@ -263,7 +263,7 @@ function ConfigRow({ item, onSaved, llmProvider }: ConfigRowProps) {
         </div>
 
         {/* Value area */}
-        <div className="w-full sm:w-auto sm:min-w-[300px]">
+        <div className="w-full sm:w-auto sm:min-w-[42rem] sm:max-w-[56rem]">
           {isEditing ? (
             <div className="space-y-1">
               {item.sensitive ? (

--- a/dashboard/app/admin/usage/page.tsx
+++ b/dashboard/app/admin/usage/page.tsx
@@ -1,5 +1,6 @@
 import { getLlmUsageAggregates } from "@/lib/llm-usage-stats";
 import { getDashboardLlmDisplayConfig } from "@/lib/llm-model-config";
+import { getEffectiveDashboardModel } from "@/lib/llm-provider/config";
 import {
   formatIntegerEs,
   formatTokensWithCompact,
@@ -15,6 +16,7 @@ export const dynamic = "force-dynamic";
 export default async function AdminUsagePage() {
   const u = await getLlmUsageAggregates();
   const cfg = getDashboardLlmDisplayConfig();
+  const orModelApi = cfg.provider === "openrouter" ? getEffectiveDashboardModel(cfg) : "";
 
   return (
     <div className="space-y-6">
@@ -93,7 +95,7 @@ export default async function AdminUsagePage() {
         <p className="mt-1 leading-relaxed">
           Las filas con proveedor <code className="rounded bg-black/5 px-1 dark:bg-white/10">openrouter</code>{" "}
           guardan tokens y un importe USD <strong>estimado</strong> (tabla de tarifas en código, alineada con el
-          modelo OpenRouter <code className="rounded bg-black/5 px-1 dark:bg-white/10">{cfg.openrouterModel}</code>
+          modelo OpenRouter <code className="rounded bg-black/5 px-1 dark:bg-white/10">{orModelApi}</code>
           ). <strong>No</strong> se consulta la facturación real de OpenRouter.
         </p>
         <p className="mt-2 leading-relaxed">

--- a/dashboard/app/api/admin/openrouter-models/__tests__/route.test.ts
+++ b/dashboard/app/api/admin/openrouter-models/__tests__/route.test.ts
@@ -20,6 +20,7 @@ const SAMPLE_CATALOG = {
       pricing: { prompt: "0.000003", completion: "0.000015" },
       architecture: { modality: "text+image->text" },
       supported_parameters: ["tools", "tool_choice", "temperature"],
+      links: { details: "/api/v1/models/anthropic/claude-sonnet-4/endpoints" },
     },
     {
       id: "obscure/some-model",
@@ -29,6 +30,7 @@ const SAMPLE_CATALOG = {
       pricing: { prompt: "0.0000001", completion: "0.0000002" },
       architecture: { modality: "text->text" },
       supported_parameters: ["temperature"],
+      links: { details: "/api/v1/models/obscure/some-model/endpoints" },
     },
   ],
 };
@@ -40,12 +42,19 @@ describe("GET /api/admin/openrouter-models", () => {
     resetCatalogCache();
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () =>
-        new Response(JSON.stringify(SAMPLE_CATALOG), {
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : (input as Request).url;
+        if (url.includes("/endpoints")) {
+          return new Response(JSON.stringify({ data: { endpoints: [] } }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify(SAMPLE_CATALOG), {
           status: 200,
           headers: { "content-type": "application/json" },
-        }),
-      ),
+        });
+      }),
     );
   });
 
@@ -56,7 +65,10 @@ describe("GET /api/admin/openrouter-models", () => {
   it("normalises pricing to USD per million tokens", async () => {
     const res = await GET(fakeRequest() as never);
     const body = await res.json();
-    const sonnet = body.models.find((m: { id: string }) => m.id === "anthropic/claude-sonnet-4");
+    const sonnet = body.models.find(
+      (m: { model_id: string; is_auto_row: boolean }) =>
+        m.model_id === "anthropic/claude-sonnet-4" && m.is_auto_row,
+    );
     expect(sonnet.prompt_price_per_1m).toBeCloseTo(3, 5);
     expect(sonnet.completion_price_per_1m).toBeCloseTo(15, 5);
   });
@@ -64,8 +76,14 @@ describe("GET /api/admin/openrouter-models", () => {
   it("flags curated popular models", async () => {
     const res = await GET(fakeRequest() as never);
     const body = await res.json();
-    const sonnet = body.models.find((m: { id: string }) => m.id === "anthropic/claude-sonnet-4");
-    const obscure = body.models.find((m: { id: string }) => m.id === "obscure/some-model");
+    const sonnet = body.models.find(
+      (m: { model_id: string; is_auto_row: boolean }) =>
+        m.model_id === "anthropic/claude-sonnet-4" && m.is_auto_row,
+    );
+    const obscure = body.models.find(
+      (m: { model_id: string; is_auto_row: boolean }) =>
+        m.model_id === "obscure/some-model" && m.is_auto_row,
+    );
     expect(sonnet.popular).toBe(true);
     expect(obscure.popular).toBe(false);
   });
@@ -73,8 +91,14 @@ describe("GET /api/admin/openrouter-models", () => {
   it("derives supports_tools from supported_parameters", async () => {
     const res = await GET(fakeRequest() as never);
     const body = await res.json();
-    const sonnet = body.models.find((m: { id: string }) => m.id === "anthropic/claude-sonnet-4");
-    const obscure = body.models.find((m: { id: string }) => m.id === "obscure/some-model");
+    const sonnet = body.models.find(
+      (m: { model_id: string; is_auto_row: boolean }) =>
+        m.model_id === "anthropic/claude-sonnet-4" && m.is_auto_row,
+    );
+    const obscure = body.models.find(
+      (m: { model_id: string; is_auto_row: boolean }) =>
+        m.model_id === "obscure/some-model" && m.is_auto_row,
+    );
     expect(sonnet.supports_tools).toBe(true);
     expect(obscure.supports_tools).toBe(false);
   });
@@ -82,7 +106,10 @@ describe("GET /api/admin/openrouter-models", () => {
   it("trims long descriptions", async () => {
     const res = await GET(fakeRequest() as never);
     const body = await res.json();
-    const obscure = body.models.find((m: { id: string }) => m.id === "obscure/some-model");
+    const obscure = body.models.find(
+      (m: { model_id: string; is_auto_row: boolean }) =>
+        m.model_id === "obscure/some-model" && m.is_auto_row,
+    );
     expect(obscure.description.length).toBeLessThanOrEqual(220);
     expect(obscure.description.endsWith("…")).toBe(true);
   });
@@ -91,7 +118,7 @@ describe("GET /api/admin/openrouter-models", () => {
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     await GET(fakeRequest() as never);
     await GET(fakeRequest() as never);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
 
     const res = await GET(fakeRequest() as never);
     const body = await res.json();
@@ -109,9 +136,19 @@ describe("GET /api/admin/openrouter-models", () => {
     // Re-warm so we have a stale cache on the next failure.
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () =>
-        new Response(JSON.stringify(SAMPLE_CATALOG), { status: 200 }),
-      ),
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : (input as Request).url;
+        if (url.includes("/endpoints")) {
+          return new Response(JSON.stringify({ data: { endpoints: [] } }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify(SAMPLE_CATALOG), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }),
     );
     await GET(fakeRequest() as never);
 

--- a/dashboard/app/api/admin/openrouter-models/catalog.ts
+++ b/dashboard/app/api/admin/openrouter-models/catalog.ts
@@ -4,7 +4,14 @@
  * Lives in a sibling module (not in `route.ts`) because Next.js App
  * Router rejects any non-handler exports from a route file. The route
  * imports `getCachedCatalog()` and `resetCatalogCache()` from here.
+ *
+ * Each catalog row is either:
+ *  - **Auto** — OpenRouter's default multi-provider routing for the model.
+ *  - **Pinned** — a specific upstream endpoint (see `provider_label`), with
+ *    per-endpoint pricing from OpenRouter's `/models/.../endpoints` API.
  */
+
+import { encodeOpenRouterModelValue } from "@/lib/llm-provider/openrouter-selection";
 
 export interface OpenRouterRawPricing {
   prompt?: string | null;
@@ -30,14 +37,25 @@ export interface OpenRouterRawModel {
   pricing?: OpenRouterRawPricing;
   architecture?: OpenRouterRawArchitecture;
   supported_parameters?: string[];
+  links?: { details?: string };
 }
 
 interface OpenRouterRawCatalog {
   data: OpenRouterRawModel[];
 }
 
+/** One row in the admin model combobox (auto-routed or pinned provider). */
 export interface OpenRouterModel {
-  id: string;
+  /** Same as `config_value` — unique key for React. */
+  row_key: string;
+  /** Persisted to `dashboard.llm_model_openrouter*` keys. */
+  config_value: string;
+  /** The `model` field on OpenRouter chat completions. */
+  model_id: string;
+  /** Human-friendly provider / routing label for search + display. */
+  provider_label: string;
+  /** True = OpenRouter default routing; false = pinned `provider` object. */
+  is_auto_row: boolean;
   name: string;
   description: string;
   context_length: number;
@@ -46,10 +64,9 @@ export interface OpenRouterModel {
   /** USD per 1M completion tokens. `null` if pricing is missing. */
   completion_price_per_1m: number | null;
   modality: string;
-  /** True iff the model advertises "tools" in supported_parameters. The
-   *  agentic dashboard flows require this. */
+  /** True iff the row supports tools (required for agentic flows). */
   supports_tools: boolean;
-  /** Belongs to the curated "Populares" set — pin to the top of the UI. */
+  /** Curated auto row pinned in "Populares" (popular model ids only). */
   popular: boolean;
 }
 
@@ -60,12 +77,9 @@ export interface CatalogPayload {
 }
 
 // ---------------------------------------------------------------------------
-// Curated popular set
+// Curated popular set (auto rows only)
 // ---------------------------------------------------------------------------
 
-// Hand-picked canonical ids. The order here is the order they appear in
-// the UI's "Populares" section. Items not present in the live catalog are
-// silently dropped.
 export const POPULAR_IDS: readonly string[] = [
   "anthropic/claude-opus-4",
   "anthropic/claude-sonnet-4",
@@ -93,6 +107,8 @@ const POPULAR_SET: ReadonlySet<string> = new Set(POPULAR_IDS);
 
 const CACHE_TTL_MS = 60 * 60 * 1000;
 
+const ENDPOINT_FETCH_CONCURRENCY = 12;
+
 interface CacheEntry {
   models: OpenRouterModel[];
   fetchedAt: number;
@@ -116,24 +132,106 @@ function priceFromPerToken(raw: string | null | undefined): number | null {
   return n * 1_000_000;
 }
 
-export function normalize(raw: OpenRouterRawModel): OpenRouterModel {
+function trimDescription(raw: string | undefined): string {
+  const description = (raw ?? "").trim();
+  return description.length > 220 ? description.slice(0, 217) + "…" : description;
+}
+
+interface RawEndpoint {
+  provider_name?: string;
+  tag?: string;
+  context_length?: number;
+  pricing?: OpenRouterRawPricing;
+  supported_parameters?: string[];
+}
+
+function providerRoutingForTag(tag: string): Record<string, unknown> {
+  const slug = tag.trim().toLowerCase();
+  return { only: [slug], allow_fallbacks: false };
+}
+
+function endpointLabel(ep: RawEndpoint): string {
+  const name = (ep.provider_name ?? "").trim();
+  const tag = (ep.tag ?? "").trim();
+  if (name && tag) return `${name} · ${tag}`;
+  if (name) return name;
+  if (tag) return tag;
+  return "Endpoint";
+}
+
+async function fetchEndpointsForModel(detailsPath: string): Promise<RawEndpoint[]> {
+  const url = `https://openrouter.ai${detailsPath}`;
+  const res = await fetch(url, {
+    headers: { Accept: "application/json" },
+    cache: "no-store",
+  });
+  if (!res.ok) return [];
+  const json: unknown = await res.json();
+  const data = json as { data?: { endpoints?: RawEndpoint[] } };
+  const eps = data?.data?.endpoints;
+  return Array.isArray(eps) ? eps : [];
+}
+
+function buildAutoRow(raw: OpenRouterRawModel): OpenRouterModel {
   const supportsTools = (raw.supported_parameters ?? []).includes("tools");
-  const description = (raw.description ?? "").trim();
+  const description = trimDescription(raw.description);
+  const modelId = raw.id;
+  const configValue = encodeOpenRouterModelValue(modelId, undefined);
   return {
-    id: raw.id,
+    row_key: configValue,
+    config_value: configValue,
+    model_id: modelId,
+    provider_label: "OpenRouter (automático)",
+    is_auto_row: true,
     name: raw.name ?? raw.id,
-    // Trim long descriptions — full text isn't useful in a picker row.
-    description: description.length > 220 ? description.slice(0, 217) + "…" : description,
+    description,
     context_length: typeof raw.context_length === "number" ? raw.context_length : 0,
     prompt_price_per_1m: priceFromPerToken(raw.pricing?.prompt),
     completion_price_per_1m: priceFromPerToken(raw.pricing?.completion),
     modality: raw.architecture?.modality ?? "text->text",
     supports_tools: supportsTools,
-    popular: POPULAR_SET.has(raw.id),
+    popular: POPULAR_SET.has(modelId),
   };
 }
 
-async function fetchCatalog(): Promise<OpenRouterModel[]> {
+function buildPinnedRow(base: OpenRouterRawModel, ep: RawEndpoint): OpenRouterModel {
+  const supportsTools = (ep.supported_parameters ?? base.supported_parameters ?? []).includes("tools");
+  const description = trimDescription(base.description);
+  const modelId = base.id;
+  const tag = (ep.tag ?? "").trim();
+  const routing = tag ? providerRoutingForTag(tag) : null;
+  const configValue = encodeOpenRouterModelValue(modelId, routing ?? undefined);
+  return {
+    row_key: configValue,
+    config_value: configValue,
+    model_id: modelId,
+    provider_label: endpointLabel(ep),
+    is_auto_row: false,
+    name: base.name ?? base.id,
+    description,
+    context_length:
+      typeof ep.context_length === "number" && ep.context_length > 0
+        ? ep.context_length
+        : typeof base.context_length === "number"
+          ? base.context_length
+          : 0,
+    prompt_price_per_1m: priceFromPerToken(ep.pricing?.prompt ?? base.pricing?.prompt),
+    completion_price_per_1m: priceFromPerToken(ep.pricing?.completion ?? base.pricing?.completion),
+    modality: base.architecture?.modality ?? "text->text",
+    supports_tools: supportsTools,
+    popular: false,
+  };
+}
+
+/**
+ * Test helper — normalise a raw `/models` entry into a single **auto** row
+ * (no endpoint expansion). Matches historical `normalize()` behaviour.
+ */
+export function normalize(raw: OpenRouterRawModel): OpenRouterModel {
+  return buildAutoRow(raw);
+}
+
+async function fetchAndExpandCatalog(): Promise<OpenRouterModel[]> {
   const res = await fetch("https://openrouter.ai/api/v1/models", {
     headers: { Accept: "application/json" },
     cache: "no-store",
@@ -145,7 +243,33 @@ async function fetchCatalog(): Promise<OpenRouterModel[]> {
   if (!Array.isArray(json.data)) {
     throw new Error("OpenRouter /models returned unexpected shape (no data array)");
   }
-  return json.data.map(normalize);
+
+  const rawModels = json.data;
+  const rows: OpenRouterModel[] = [];
+
+  for (let i = 0; i < rawModels.length; i += ENDPOINT_FETCH_CONCURRENCY) {
+    const slice = rawModels.slice(i, i + ENDPOINT_FETCH_CONCURRENCY);
+    const endpointLists = await Promise.all(
+      slice.map(async (raw) => {
+        const path = raw.links?.details;
+        if (!path || typeof path !== "string") return [] as RawEndpoint[];
+        return fetchEndpointsForModel(path);
+      }),
+    );
+
+    for (let j = 0; j < slice.length; j++) {
+      const raw = slice[j];
+      rows.push(buildAutoRow(raw));
+      const eps = endpointLists[j];
+      for (const ep of eps) {
+        const tag = (ep.tag ?? "").trim();
+        if (!tag) continue;
+        rows.push(buildPinnedRow(raw, ep));
+      }
+    }
+  }
+
+  return rows;
 }
 
 /**
@@ -159,7 +283,7 @@ export async function getCachedCatalog(): Promise<CatalogPayload> {
     return { models: cache.models, fetchedAt: cache.fetchedAt, source: "cache" };
   }
   try {
-    const models = await fetchCatalog();
+    const models = await fetchAndExpandCatalog();
     cache = { models, fetchedAt: now };
     return { models, fetchedAt: now, source: "openrouter" };
   } catch (err) {

--- a/dashboard/app/api/admin/openrouter-models/route.ts
+++ b/dashboard/app/api/admin/openrouter-models/route.ts
@@ -3,8 +3,10 @@
  *
  * Returns the OpenRouter model catalog with normalised pricing
  * (USD per 1M tokens), context windows, modality, and a `popular` flag
- * for the curated "Populares" set. Backed by an in-process cache with a
- * 1 h TTL — see `./catalog.ts`.
+ * for the curated "Populares" set. Each logical model has an **auto** row
+ * (OpenRouter default routing) plus one row per upstream **endpoint** from
+ * OpenRouter's `/models/.../endpoints` API (pinned `provider` routing + that
+ * endpoint's list price). Backed by an in-process cache with a 1 h TTL.
  *
  * Why the helpers live in `catalog.ts`: Next.js App Router rejects any
  * non-handler exports from a route file. Tests need a cache-reset hook,

--- a/dashboard/components/admin/OpenRouterModelCombobox.tsx
+++ b/dashboard/components/admin/OpenRouterModelCombobox.tsx
@@ -2,28 +2,24 @@
 
 /**
  * OpenRouterModelCombobox — searchable picker for the OpenRouter model
- * catalog, used by the admin /config form for `dashboard.llm_model_openrouter`.
+ * catalog (including per-endpoint provider + pricing rows), used by the
+ * admin /config form for `dashboard.llm_model_openrouter*`.
  *
- * UX:
- *  - Closed: shows the current model id (or "Selecciona modelo") with a chevron.
- *  - Opens on click → search input + filtered list of model rows.
- *  - "Populares" section is pinned at the top (curated by the API). The
- *    rest are shown alphabetically by id.
- *  - Each row shows: human name (`name`), id, context window, $/M prompt
- *    and completion, modality, and a "Tools" badge when supported (the
- *    agentic dashboard flows require tool calling).
- *  - Keyboard: ArrowUp/ArrowDown move highlight, Enter selects, Esc closes.
- *  - Outside click closes without saving.
+ * Stored value (`config_value`):
+ *  - Auto routing: `vendor/model`
+ *  - Pinned endpoint: `vendor/model\t{"only":["host/quant"],"allow_fallbacks":false}`
  *
- * Catalog data is fetched once per mount from `/api/admin/openrouter-models`
- * (cached server-side for an hour). If the fetch fails, the component
- * degrades to a plain text input so saving still works.
+ * Catalog: `GET /api/admin/openrouter-models` (cached server-side ~1 h).
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface OpenRouterModel {
-  id: string;
+  row_key: string;
+  config_value: string;
+  model_id: string;
+  provider_label: string;
+  is_auto_row: boolean;
   name: string;
   description: string;
   context_length: number;
@@ -53,7 +49,6 @@ interface Props {
 function fmtUSD(n: number | null): string {
   if (n == null) return "–";
   if (n === 0) return "gratis";
-  // Use enough decimals to show small models meaningfully (e.g. $0.06/M).
   const fixed = n >= 10 ? n.toFixed(1) : n >= 1 ? n.toFixed(2) : n.toFixed(3);
   return `$${fixed}`;
 }
@@ -69,10 +64,19 @@ function matches(model: OpenRouterModel, q: string): boolean {
   if (!q) return true;
   const needle = q.toLowerCase();
   return (
-    model.id.toLowerCase().includes(needle) ||
+    model.model_id.toLowerCase().includes(needle) ||
     model.name.toLowerCase().includes(needle) ||
-    model.description.toLowerCase().includes(needle)
+    model.description.toLowerCase().includes(needle) ||
+    model.provider_label.toLowerCase().includes(needle) ||
+    model.modality.toLowerCase().includes(needle)
   );
+}
+
+function sortRestRows(a: OpenRouterModel, b: OpenRouterModel): number {
+  const byModel = a.model_id.localeCompare(b.model_id);
+  if (byModel !== 0) return byModel;
+  if (a.is_auto_row !== b.is_auto_row) return a.is_auto_row ? -1 : 1;
+  return a.provider_label.localeCompare(b.provider_label);
 }
 
 // ---------------------------------------------------------------------------
@@ -89,7 +93,6 @@ export function OpenRouterModelCombobox({ value, onChange, disabled }: Props) {
   const searchRef = useRef<HTMLInputElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
 
-  // Fetch the catalog on first mount. Keep the result for the page lifetime.
   useEffect(() => {
     if (models !== null || error !== null) return;
     let cancelled = false;
@@ -108,7 +111,6 @@ export function OpenRouterModelCombobox({ value, onChange, disabled }: Props) {
     };
   }, [models, error]);
 
-  // Outside-click closes without saving.
   useEffect(() => {
     if (!open) return;
     function onClick(ev: MouseEvent) {
@@ -119,7 +121,6 @@ export function OpenRouterModelCombobox({ value, onChange, disabled }: Props) {
     return () => document.removeEventListener("mousedown", onClick);
   }, [open]);
 
-  // Auto-focus the search input when the panel opens.
   useEffect(() => {
     if (open) searchRef.current?.focus();
   }, [open]);
@@ -130,28 +131,25 @@ export function OpenRouterModelCombobox({ value, onChange, disabled }: Props) {
     const rest: OpenRouterModel[] = [];
     for (const m of models) {
       if (!matches(m, query)) continue;
-      if (m.popular) popular.push(m);
+      if (m.popular && m.is_auto_row) popular.push(m);
       else rest.push(m);
     }
-    // Popular order: keep API order (curated). Rest: alphabetical by id.
-    rest.sort((a, b) => a.id.localeCompare(b.id));
+    rest.sort(sortRestRows);
     return { popular, rest };
   }, [models, query]);
 
-  // Flat list for keyboard navigation (popular first).
   const flat = useMemo(
     () => [...filtered.popular, ...filtered.rest],
     [filtered],
   );
 
-  // Reset highlight when filter changes.
   useEffect(() => {
     setHighlight(0);
   }, [query, models]);
 
   const onPick = useCallback(
-    (id: string) => {
-      onChange(id);
+    (configValue: string) => {
+      onChange(configValue);
       setOpen(false);
       setQuery("");
     },
@@ -176,12 +174,10 @@ export function OpenRouterModelCombobox({ value, onChange, disabled }: Props) {
     if (e.key === "Enter") {
       e.preventDefault();
       const m = flat[highlight];
-      if (m) onPick(m.id);
+      if (m) onPick(m.config_value);
     }
   }
 
-  // If the catalog failed to load, fall back to a plain text input — saving
-  // a custom model id is still possible.
   if (error) {
     return (
       <div className="space-y-1">
@@ -191,7 +187,7 @@ export function OpenRouterModelCombobox({ value, onChange, disabled }: Props) {
           onChange={(e) => onChange(e.target.value)}
           disabled={disabled}
           placeholder="anthropic/claude-sonnet-4"
-          className="w-full rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
+          className="w-full min-w-[min(100%,42rem)] rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
         />
         <p className="text-xs text-amber-700 dark:text-amber-400">
           No se pudo cargar el catálogo de OpenRouter ({error}). Introduce el id manualmente.
@@ -200,25 +196,46 @@ export function OpenRouterModelCombobox({ value, onChange, disabled }: Props) {
     );
   }
 
+  const displaySummary = useMemo(() => {
+    if (!value) return "";
+    const row = models?.find((m) => m.config_value === value);
+    if (row) {
+      return row.is_auto_row ? row.model_id : `${row.model_id} · ${row.provider_label}`;
+    }
+    const tab = value.indexOf("\t");
+    if (tab === -1) return value;
+    return `${value.slice(0, tab)} · ruta personalizada`;
+  }, [value, models]);
+
   return (
-    <div ref={containerRef} className="relative" data-testid="or-model-combobox">
+    <div
+      ref={containerRef}
+      className="relative w-full min-w-[min(100%,42rem)] max-w-[56rem]"
+      data-testid="or-model-combobox"
+    >
       <button
         type="button"
         onClick={() => !disabled && setOpen((o) => !o)}
         disabled={disabled}
-        className="flex w-full items-center justify-between gap-2 rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-3 py-1.5 text-sm text-left focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
+        className="flex w-full min-h-[2.25rem] items-center justify-between gap-2 rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-3 py-1.5 text-sm text-left focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
         aria-haspopup="listbox"
         aria-expanded={open}
       >
-        <span className="truncate font-mono text-xs">
-          {value || <span className="italic text-tremor-content-subtle">Selecciona modelo</span>}
+        <span className="min-w-0 flex-1 break-all font-mono text-xs leading-snug">
+          {value ? (
+            displaySummary
+          ) : (
+            <span className="italic text-tremor-content-subtle">Selecciona modelo y proveedor</span>
+          )}
         </span>
-        <span aria-hidden className="text-tremor-content-subtle">▾</span>
+        <span aria-hidden className="flex-shrink-0 text-tremor-content-subtle">
+          ▾
+        </span>
       </button>
 
       {open && (
         <div
-          className="absolute left-0 right-0 z-30 mt-1 max-h-[420px] overflow-hidden rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background shadow-lg"
+          className="absolute left-0 z-30 mt-1 w-max min-w-full max-w-[min(56rem,calc(100vw-2rem))] max-h-[min(70vh,520px)] overflow-hidden rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background shadow-lg"
           role="listbox"
         >
           <div className="border-b border-tremor-border dark:border-dark-tremor-border p-2">
@@ -228,27 +245,35 @@ export function OpenRouterModelCombobox({ value, onChange, disabled }: Props) {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={onKey}
-              placeholder="Buscar por nombre, id o descripción…"
-              className="w-full rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+              placeholder="Buscar por modelo, proveedor, id o descripción…"
+              className="w-full min-w-[20rem] rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
               data-testid="or-model-combobox-search"
             />
             {models === null && (
-              <p className="mt-1 text-xs text-tremor-content-subtle">Cargando catálogo…</p>
+              <p className="mt-1 text-xs text-tremor-content-subtle">Cargando catálogo (incluye rutas por proveedor)…</p>
             )}
             {models !== null && (
               <p className="mt-1 text-xs text-tremor-content-subtle">
-                {filtered.popular.length + filtered.rest.length} modelos · precios en USD por 1M de tokens
+                {filtered.popular.length + filtered.rest.length} filas · precios USD / 1M tokens (por
+                fila)
               </p>
             )}
           </div>
 
-          <div ref={listRef} className="max-h-[340px] overflow-y-auto">
+          <div ref={listRef} className="max-h-[min(58vh,440px)] overflow-y-auto">
             {filtered.popular.length > 0 && (
-              <Section title="Populares" rows={filtered.popular} indexBase={0} value={value} highlight={highlight} onPick={onPick} />
+              <Section
+                title="Populares (router automático)"
+                rows={filtered.popular}
+                indexBase={0}
+                value={value}
+                highlight={highlight}
+                onPick={onPick}
+              />
             )}
             {filtered.rest.length > 0 && (
               <Section
-                title="Todos"
+                title="Todos los modelos y proveedores"
                 rows={filtered.rest}
                 indexBase={filtered.popular.length}
                 value={value}
@@ -257,9 +282,7 @@ export function OpenRouterModelCombobox({ value, onChange, disabled }: Props) {
               />
             )}
             {models !== null && filtered.popular.length + filtered.rest.length === 0 && (
-              <p className="px-3 py-4 text-sm text-tremor-content-subtle">
-                Ningún modelo coincide con la búsqueda.
-              </p>
+              <p className="px-3 py-4 text-sm text-tremor-content-subtle">Ningún resultado coincide.</p>
             )}
           </div>
         </div>
@@ -285,13 +308,13 @@ function Section({ title, rows, indexBase, value, highlight, onPick }: SectionPr
       </div>
       {rows.map((m, i) => {
         const flatIndex = indexBase + i;
-        const isCurrent = m.id === value;
+        const isCurrent = m.config_value === value;
         const isHighlight = flatIndex === highlight;
         return (
           <button
-            key={m.id}
+            key={m.row_key}
             type="button"
-            onClick={() => onPick(m.id)}
+            onClick={() => onPick(m.config_value)}
             className={
               "block w-full px-3 py-2 text-left text-sm hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle " +
               (isHighlight
@@ -299,11 +322,14 @@ function Section({ title, rows, indexBase, value, highlight, onPick }: SectionPr
                 : "") +
               (isCurrent ? "ring-1 ring-blue-500 ring-inset" : "")
             }
-            data-testid={`or-model-row-${m.id}`}
+            data-testid={`or-model-row-${m.row_key}`}
           >
             <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
               <span className="font-medium">{m.name}</span>
-              <span className="font-mono text-xs text-tremor-content-subtle">{m.id}</span>
+              <span className="rounded bg-black/5 px-1.5 py-0 font-mono text-[11px] text-tremor-content-subtle dark:bg-white/10">
+                {m.provider_label}
+              </span>
+              <span className="font-mono text-xs text-tremor-content-subtle">{m.model_id}</span>
               {m.supports_tools && (
                 <span className="rounded-full bg-emerald-100 px-1.5 py-0 text-[10px] text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300">
                   tools

--- a/dashboard/components/admin/OpenRouterModelCombobox.tsx
+++ b/dashboard/components/admin/OpenRouterModelCombobox.tsx
@@ -156,6 +156,35 @@ export function OpenRouterModelCombobox({ value, onChange, disabled }: Props) {
     [onChange],
   );
 
+  const displaySummary = useMemo(() => {
+    if (!value) return "";
+    const row = models?.find((m) => m.config_value === value);
+    if (row) {
+      return row.is_auto_row ? row.model_id : `${row.model_id} · ${row.provider_label}`;
+    }
+    const tab = value.indexOf("\t");
+    if (tab === -1) return value;
+    return `${value.slice(0, tab)} · ruta personalizada`;
+  }, [value, models]);
+
+  if (error) {
+    return (
+      <div className="space-y-1">
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder="anthropic/claude-sonnet-4"
+          className="w-full min-w-[min(100%,42rem)] rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
+        />
+        <p className="text-xs text-amber-700 dark:text-amber-400">
+          No se pudo cargar el catálogo de OpenRouter ({error}). Introduce el id manualmente.
+        </p>
+      </div>
+    );
+  }
+
   function onKey(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === "Escape") {
       setOpen(false);
@@ -177,35 +206,6 @@ export function OpenRouterModelCombobox({ value, onChange, disabled }: Props) {
       if (m) onPick(m.config_value);
     }
   }
-
-  if (error) {
-    return (
-      <div className="space-y-1">
-        <input
-          type="text"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled}
-          placeholder="anthropic/claude-sonnet-4"
-          className="w-full min-w-[min(100%,42rem)] rounded-md border border-tremor-border dark:border-dark-tremor-border bg-tremor-background dark:bg-dark-tremor-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
-        />
-        <p className="text-xs text-amber-700 dark:text-amber-400">
-          No se pudo cargar el catálogo de OpenRouter ({error}). Introduce el id manualmente.
-        </p>
-      </div>
-    );
-  }
-
-  const displaySummary = useMemo(() => {
-    if (!value) return "";
-    const row = models?.find((m) => m.config_value === value);
-    if (row) {
-      return row.is_auto_row ? row.model_id : `${row.model_id} · ${row.provider_label}`;
-    }
-    const tab = value.indexOf("\t");
-    if (tab === -1) return value;
-    return `${value.slice(0, tab)} · ruta personalizada`;
-  }, [value, models]);
 
   return (
     <div

--- a/dashboard/components/admin/__tests__/OpenRouterModelCombobox.test.tsx
+++ b/dashboard/components/admin/__tests__/OpenRouterModelCombobox.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { cleanup, render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
 import { OpenRouterModelCombobox } from "../OpenRouterModelCombobox";
@@ -146,8 +146,6 @@ describe("OpenRouterModelCombobox", () => {
   });
 
   it("falls back to a plain text input when the catalog fetch fails", async () => {
-    cleanup();
-    vi.unstubAllGlobals();
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response("nope", { status: 502 })),

--- a/dashboard/components/admin/__tests__/OpenRouterModelCombobox.test.tsx
+++ b/dashboard/components/admin/__tests__/OpenRouterModelCombobox.test.tsx
@@ -8,7 +8,11 @@ import { OpenRouterModelCombobox } from "../OpenRouterModelCombobox";
 const SAMPLE = {
   models: [
     {
-      id: "anthropic/claude-sonnet-4",
+      row_key: "anthropic/claude-sonnet-4",
+      config_value: "anthropic/claude-sonnet-4",
+      model_id: "anthropic/claude-sonnet-4",
+      provider_label: "OpenRouter (automático)",
+      is_auto_row: true,
       name: "Anthropic: Claude Sonnet 4",
       description: "Strong reasoning model.",
       context_length: 200_000,
@@ -19,7 +23,26 @@ const SAMPLE = {
       popular: true,
     },
     {
-      id: "openai/gpt-4o-mini",
+      row_key: "anthropic/claude-sonnet-4\t" + JSON.stringify({ only: ["acme/fp8"], allow_fallbacks: false }),
+      config_value: "anthropic/claude-sonnet-4\t" + JSON.stringify({ only: ["acme/fp8"], allow_fallbacks: false }),
+      model_id: "anthropic/claude-sonnet-4",
+      provider_label: "Acme · fp8",
+      is_auto_row: false,
+      name: "Anthropic: Claude Sonnet 4",
+      description: "Strong reasoning model.",
+      context_length: 200_000,
+      prompt_price_per_1m: 2,
+      completion_price_per_1m: 10,
+      modality: "text+image->text",
+      supports_tools: true,
+      popular: false,
+    },
+    {
+      row_key: "openai/gpt-4o-mini",
+      config_value: "openai/gpt-4o-mini",
+      model_id: "openai/gpt-4o-mini",
+      provider_label: "OpenRouter (automático)",
+      is_auto_row: true,
       name: "OpenAI: GPT-4o mini",
       description: "Cheap and fast.",
       context_length: 128_000,
@@ -30,7 +53,11 @@ const SAMPLE = {
       popular: true,
     },
     {
-      id: "obscure/some-model",
+      row_key: "obscure/some-model",
+      config_value: "obscure/some-model",
+      model_id: "obscure/some-model",
+      provider_label: "OpenRouter (automático)",
+      is_auto_row: true,
       name: "Obscure model",
       description: "Not popular.",
       context_length: 8_000,
@@ -74,13 +101,11 @@ describe("OpenRouterModelCombobox", () => {
     fireEvent.click(screen.getByRole("button"));
 
     await waitFor(() => {
-      expect(screen.getByText("Populares")).toBeInTheDocument();
+      expect(screen.getByText("Populares (router automático)")).toBeInTheDocument();
     });
-    // Popular models should be in the list
     expect(screen.getByText("Anthropic: Claude Sonnet 4")).toBeInTheDocument();
     expect(screen.getByText("OpenAI: GPT-4o mini")).toBeInTheDocument();
-    // Non-popular under "Todos"
-    expect(screen.getByText("Todos")).toBeInTheDocument();
+    expect(screen.getByText("Todos los modelos y proveedores")).toBeInTheDocument();
     expect(screen.getByText("Obscure model")).toBeInTheDocument();
   });
 
@@ -97,7 +122,18 @@ describe("OpenRouterModelCombobox", () => {
     expect(screen.queryByText("Anthropic: Claude Sonnet 4")).not.toBeInTheDocument();
   });
 
-  it("calls onChange with the model id when a row is picked", async () => {
+  it("filters by provider label", async () => {
+    render(<OpenRouterModelCombobox value="" onChange={() => {}} />);
+    fireEvent.click(screen.getByRole("button"));
+    const search = await screen.findByTestId("or-model-combobox-search");
+    fireEvent.change(search, { target: { value: "Acme" } });
+    await waitFor(() => {
+      expect(screen.getByText("Acme · fp8")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("OpenAI: GPT-4o mini")).not.toBeInTheDocument();
+  });
+
+  it("calls onChange with the config value when a row is picked", async () => {
     const onChange = vi.fn();
     render(<OpenRouterModelCombobox value="" onChange={onChange} />);
     fireEvent.click(screen.getByRole("button"));

--- a/dashboard/components/admin/__tests__/OpenRouterModelCombobox.test.tsx
+++ b/dashboard/components/admin/__tests__/OpenRouterModelCombobox.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
 import { OpenRouterModelCombobox } from "../OpenRouterModelCombobox";
@@ -103,7 +103,8 @@ describe("OpenRouterModelCombobox", () => {
     await waitFor(() => {
       expect(screen.getByText("Populares (router automático)")).toBeInTheDocument();
     });
-    expect(screen.getByText("Anthropic: Claude Sonnet 4")).toBeInTheDocument();
+    // Same display name appears on the auto row and the pinned-provider row.
+    expect(screen.getAllByText("Anthropic: Claude Sonnet 4").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText("OpenAI: GPT-4o mini")).toBeInTheDocument();
     expect(screen.getByText("Todos los modelos y proveedores")).toBeInTheDocument();
     expect(screen.getByText("Obscure model")).toBeInTheDocument();
@@ -119,7 +120,7 @@ describe("OpenRouterModelCombobox", () => {
     await waitFor(() => {
       expect(screen.getByText("Obscure model")).toBeInTheDocument();
     });
-    expect(screen.queryByText("Anthropic: Claude Sonnet 4")).not.toBeInTheDocument();
+    expect(screen.queryAllByText("Anthropic: Claude Sonnet 4")).toHaveLength(0);
   });
 
   it("filters by provider label", async () => {
@@ -145,6 +146,8 @@ describe("OpenRouterModelCombobox", () => {
   });
 
   it("falls back to a plain text input when the catalog fetch fails", async () => {
+    cleanup();
+    vi.unstubAllGlobals();
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response("nope", { status: 502 })),
@@ -152,10 +155,8 @@ describe("OpenRouterModelCombobox", () => {
     const onChange = vi.fn();
     render(<OpenRouterModelCombobox value="claude" onChange={onChange} />);
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText("anthropic/claude-sonnet-4")).toBeInTheDocument();
-    });
-    const input = screen.getByPlaceholderText("anthropic/claude-sonnet-4") as HTMLInputElement;
-    expect(input.value).toBe("claude");
+    const input = await screen.findByPlaceholderText("anthropic/claude-sonnet-4", { timeout: 5000 });
+    expect(input).toBeInTheDocument();
+    expect((input as HTMLInputElement).value).toBe("claude");
   });
 });

--- a/dashboard/config/schema.yaml
+++ b/dashboard/config/schema.yaml
@@ -37,7 +37,7 @@
   sensitive: false
   default: null
   section: LLM
-  description: "Modelo OpenRouter por defecto para todas las operaciones (generate, modify, analyze). Vacío = usa el fallback 'anthropic/claude-sonnet-4'."
+  description: "Modelo OpenRouter (id vendor/modelo). Opcional: tab + JSON del objeto `provider` de la API (ruta por proveedor); el selector en /admin/config lo rellena. Vacío = anthropic/claude-sonnet-4."
   requires_restart: []
 
 - key: dashboard.llm_model_openrouter_generate
@@ -46,7 +46,7 @@
   sensitive: false
   default: null
   section: LLM
-  description: "Override de modelo OpenRouter para generación de dashboards (vacío = usa llm_model_openrouter)."
+  description: "Override OpenRouter (mismo formato que llm_model_openrouter: id y opcional tab+JSON provider). Vacío = usa llm_model_openrouter."
   requires_restart: []
 
 - key: dashboard.llm_model_openrouter_modify
@@ -55,7 +55,7 @@
   sensitive: false
   default: null
   section: LLM
-  description: "Override de modelo OpenRouter para modificación de dashboards (vacío = usa llm_model_openrouter)."
+  description: "Override OpenRouter para modificación (mismo formato que llm_model_openrouter). Vacío = usa llm_model_openrouter."
   requires_restart: []
 
 - key: dashboard.llm_model_openrouter_analyze
@@ -64,7 +64,7 @@
   sensitive: false
   default: null
   section: LLM
-  description: "Override de modelo OpenRouter para análisis (vacío = usa llm_model_openrouter)."
+  description: "Override OpenRouter para análisis (mismo formato que llm_model_openrouter). Vacío = usa llm_model_openrouter."
   requires_restart: []
 
 - key: dashboard.llm_model_openrouter_weekly
@@ -73,7 +73,7 @@
   sensitive: false
   default: null
   section: LLM
-  description: "Override de modelo OpenRouter para revisiones semanales (vacío = usa llm_model_openrouter)."
+  description: "Override OpenRouter para revisiones semanales (mismo formato que llm_model_openrouter). Vacío = usa llm_model_openrouter."
   requires_restart: []
 
 - key: dashboard.llm_model_cli

--- a/dashboard/lib/__tests__/conversation-context.test.ts
+++ b/dashboard/lib/__tests__/conversation-context.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/lib/llm-circuit-breaker", () => ({
 vi.mock("@/lib/llm-provider/config", () => ({
   loadDashboardLlmConfig: vi.fn(() => ({ provider: "openrouter" })),
   getEffectiveDashboardModel: vi.fn(() => "anthropic/claude-sonnet-4"),
+  getEffectiveOpenRouterProvider: vi.fn(() => undefined),
 }));
 
 vi.mock("@/lib/llm-usage", () => ({

--- a/dashboard/lib/__tests__/llm-provider-config-load.test.ts
+++ b/dashboard/lib/__tests__/llm-provider-config-load.test.ts
@@ -3,6 +3,7 @@ import {
   loadDashboardLlmConfig,
   resetDashboardLlmConfigCache,
   getEffectiveDashboardModel,
+  getEffectiveOpenRouterProvider,
 } from "@/lib/llm-provider/config";
 
 describe("loadDashboardLlmConfig", () => {
@@ -88,6 +89,18 @@ describe("loadDashboardLlmConfig", () => {
       vi.stubEnv("DASHBOARD_LLM_MODEL_OPENROUTER_GENERATE", "claude-sonnet-4");
       const c = loadDashboardLlmConfig();
       expect(getEffectiveDashboardModel(c)).toBe("default-or");
+    });
+
+    it("strips tab-suffixed OpenRouter provider routing from the effective model id", () => {
+      vi.stubEnv("DASHBOARD_LLM_PROVIDER", "openrouter");
+      const suffix = `\t${JSON.stringify({ only: ["deepinfra/fp4"], allow_fallbacks: false })}`;
+      vi.stubEnv("DASHBOARD_LLM_MODEL_OPENROUTER", `deepseek/deepseek-chat${suffix}`);
+      const c = loadDashboardLlmConfig();
+      expect(getEffectiveDashboardModel(c)).toBe("deepseek/deepseek-chat");
+      expect(getEffectiveOpenRouterProvider(c)).toEqual({
+        only: ["deepinfra/fp4"],
+        allow_fallbacks: false,
+      });
     });
   });
 });

--- a/dashboard/lib/conversation-context.ts
+++ b/dashboard/lib/conversation-context.ts
@@ -7,7 +7,7 @@
  */
 
 import { sql } from "@/lib/db-write";
-import { loadDashboardLlmConfig, getEffectiveDashboardModel } from "@/lib/llm-provider/config";
+import { loadDashboardLlmConfig, getEffectiveDashboardModel, getEffectiveOpenRouterProvider } from "@/lib/llm-provider/config";
 import { getOpenRouterClient, openRouterChatCompletion } from "@/lib/llm-provider/openrouter";
 import { claudeCliSingleShot } from "@/lib/llm-provider/cli/claude-code";
 import { callWithCircuitBreaker } from "@/lib/llm-circuit-breaker";
@@ -113,6 +113,7 @@ async function buildSummary(
 
   const cfg = loadDashboardLlmConfig();
   const model = getEffectiveDashboardModel(cfg, channel);
+  const provider = getEffectiveOpenRouterProvider(cfg, channel);
 
   if (cfg.provider === "cli") {
     try {
@@ -133,6 +134,7 @@ async function buildSummary(
         messages: [{ role: "user" as const, content: prompt }],
         temperature: 0.1,
         maxTokens: 200,
+        provider,
       }),
     );
     if (usage) {

--- a/dashboard/lib/llm-client.ts
+++ b/dashboard/lib/llm-client.ts
@@ -13,6 +13,7 @@ import {
   resetOpenRouterClient,
   openRouterChatCompletion,
   buildCachedSystemMessage,
+  openRouterExtras,
 } from "./llm-provider/openrouter";
 import { claudeCliSingleShot } from "./llm-provider/cli/claude-code";
 import { CliRunnerError } from "./llm-provider/cli/errors";
@@ -24,6 +25,7 @@ import {
 import {
   loadDashboardLlmConfig,
   getEffectiveDashboardModel,
+  getEffectiveOpenRouterProvider,
 } from "./llm-provider/config";
 import { createDashboardAgenticAdapter } from "./llm-provider/registry";
 import { logUsage } from "./llm-usage";
@@ -112,6 +114,13 @@ const EMPTY_USAGE: NormalizedUsage = {
   total_tokens: 0,
 };
 
+function narrowDashboardLlmFlow(flow: string | undefined): DashboardLlmFlow | undefined {
+  if (flow === "generate" || flow === "modify" || flow === "analyze" || flow === "weekly") {
+    return flow;
+  }
+  return undefined;
+}
+
 function assembleSystemPrompt(req: LlmRequest): string {
   const { stable, volatile } = req.systemPrompt;
   return volatile ? `${stable}\n\n${volatile}` : stable;
@@ -159,8 +168,9 @@ function buildMessagesPlain(req: LlmRequest): ChatCompletionMessageParam[] {
  */
 export async function llmComplete(req: LlmRequest): Promise<LlmResponse> {
   const cfg = loadDashboardLlmConfig();
-  const flow = req.flow as DashboardLlmFlow | undefined;
-  const model = getEffectiveDashboardModel(cfg, flow);
+  const dFlow = narrowDashboardLlmFlow(req.flow);
+  const model = getEffectiveDashboardModel(cfg, dFlow);
+  const openRouterProvider = getEffectiveOpenRouterProvider(cfg, dFlow);
   const meta = {
     provider: cfg.provider,
     driver: cfg.provider === "cli" ? cfg.cliDriver : null,
@@ -215,7 +225,8 @@ export async function llmComplete(req: LlmRequest): Promise<LlmResponse> {
         temperature,
         max_tokens: maxOutputTokens,
         stream: true,
-      }),
+        ...openRouterExtras(openRouterProvider),
+      } as Parameters<typeof client.chat.completions.create>[0]),
     );
 
     let textContent = "";
@@ -278,6 +289,7 @@ export async function llmComplete(req: LlmRequest): Promise<LlmResponse> {
       messages,
       temperature,
       maxTokens: maxOutputTokens,
+      provider: openRouterProvider,
     }),
   );
 

--- a/dashboard/lib/llm-provider/__tests__/openrouter-selection.test.ts
+++ b/dashboard/lib/llm-provider/__tests__/openrouter-selection.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import {
+  encodeOpenRouterModelValue,
+  parseOpenRouterModelValue,
+} from "../openrouter-selection";
+
+describe("openrouter-selection", () => {
+  it("parses plain model ids (auto routing)", () => {
+    expect(parseOpenRouterModelValue("anthropic/claude-sonnet-4")).toEqual({
+      modelId: "anthropic/claude-sonnet-4",
+      provider: undefined,
+    });
+  });
+
+  it("parses tab-suffixed provider JSON", () => {
+    const stored = `deepseek/deepseek-chat\t${JSON.stringify({ only: ["deepinfra/fp4"], allow_fallbacks: false })}`;
+    const parsed = parseOpenRouterModelValue(stored);
+    expect(parsed.modelId).toBe("deepseek/deepseek-chat");
+    expect(parsed.provider).toEqual({ only: ["deepinfra/fp4"], allow_fallbacks: false });
+  });
+
+  it("strips unknown provider keys when parsing", () => {
+    const stored = `x/y\t${JSON.stringify({ only: ["a"], evil: "payload" })}`;
+    const parsed = parseOpenRouterModelValue(stored);
+    expect(parsed.provider).toEqual({ only: ["a"] });
+  });
+
+  it("encodeOpenRouterModelValue omits tab when provider is empty", () => {
+    expect(encodeOpenRouterModelValue("m", {})).toBe("m");
+    expect(encodeOpenRouterModelValue("m", null)).toBe("m");
+  });
+
+  it("encodeOpenRouterModelValue round-trips with parse", () => {
+    const p = { only: ["nova/fp8"], allow_fallbacks: false };
+    const s = encodeOpenRouterModelValue("openai/gpt-4o", p);
+    expect(parseOpenRouterModelValue(s)).toEqual({ modelId: "openai/gpt-4o", provider: p });
+  });
+});

--- a/dashboard/lib/llm-provider/config.ts
+++ b/dashboard/lib/llm-provider/config.ts
@@ -4,6 +4,7 @@
  */
 
 import { getSystemConfig, resetConfigCache } from "@/lib/system-config/loader";
+import { parseOpenRouterModelValue } from "./openrouter-selection";
 import type {
   DashboardCliDriverId,
   DashboardLlmConfig,
@@ -173,21 +174,43 @@ export function loadDashboardLlmConfig(): DashboardLlmConfig {
 }
 
 /**
- * Effective model id for the configured provider.
+ * Raw stored OpenRouter model value (may include `\t{...}` provider routing).
+ */
+function resolveOpenRouterStoredModel(cfg: DashboardLlmConfig, flow?: DashboardLlmFlow): string {
+  if (flow) {
+    const override = cfg.openrouterModelByFlow[flow];
+    if (override) return override;
+  }
+  return cfg.openrouterModel;
+}
+
+/**
+ * Effective model id for the configured provider (API `model` parameter).
  *
- * For OpenRouter, when `flow` is supplied, a non-empty per-flow override
- * (e.g. `dashboard.llm_model_openrouter_modify`) wins over the default
- * `openrouterModel`. CLI doesn't differentiate by flow — the flat-rate
- * Claude subscription makes per-flow tuning pointless.
+ * For OpenRouter, optional `\t`-suffixed provider JSON is stripped — see
+ * `parseOpenRouterModelValue` / `openrouter-selection.ts`.
+ *
+ * When `flow` is supplied, a non-empty per-flow override wins over the
+ * default `openrouterModel`. CLI doesn't differentiate by flow.
  */
 export function getEffectiveDashboardModel(
   cfg: DashboardLlmConfig,
   flow?: DashboardLlmFlow,
 ): string {
   if (cfg.provider !== "openrouter") return cfg.cliModel;
-  if (flow) {
-    const override = cfg.openrouterModelByFlow[flow];
-    if (override) return override;
-  }
-  return cfg.openrouterModel;
+  const raw = resolveOpenRouterStoredModel(cfg, flow);
+  return parseOpenRouterModelValue(raw).modelId;
+}
+
+/**
+ * OpenRouter `provider` routing object for the active model selection, if any.
+ * Undefined means use OpenRouter's default multi-provider routing.
+ */
+export function getEffectiveOpenRouterProvider(
+  cfg: DashboardLlmConfig,
+  flow?: DashboardLlmFlow,
+): Record<string, unknown> | undefined {
+  if (cfg.provider !== "openrouter") return undefined;
+  const raw = resolveOpenRouterStoredModel(cfg, flow);
+  return parseOpenRouterModelValue(raw).provider;
 }

--- a/dashboard/lib/llm-provider/openrouter-selection.ts
+++ b/dashboard/lib/llm-provider/openrouter-selection.ts
@@ -1,0 +1,93 @@
+/**
+ * Encode / decode optional OpenRouter `provider` routing alongside the model id
+ * in a single config string (e.g. `dashboard.llm_model_openrouter`).
+ *
+ * Format:
+ *   - Auto routing (OpenRouter default): `vendor/model`
+ *   - Pinned provider / endpoint: `vendor/model\t{...JSON...}` (tab separator)
+ *
+ * The JSON body is passed (after sanitisation) as the `provider` field on
+ * `chat.completions` requests — see OpenRouter provider routing docs.
+ */
+
+const ROUTING_SEP = "\t";
+
+/** Keys OpenRouter documents for the `provider` object on chat completions. */
+const ALLOWED_PROVIDER_KEYS = new Set([
+  "order",
+  "only",
+  "ignore",
+  "allow_fallbacks",
+  "require_parameters",
+  "data_collection",
+  "zdr",
+  "enforce_distillable_text",
+  "quantizations",
+  "sort",
+  "max_price",
+  "preferred_min_throughput",
+  "preferred_max_latency",
+]);
+
+export interface ParsedOpenRouterModelValue {
+  /** Model id sent as the `model` parameter (no routing suffix). */
+  modelId: string;
+  /** When set, forwarded as `provider` on OpenRouter chat completions. */
+  provider?: Record<string, unknown>;
+}
+
+function sanitizeProviderObject(raw: unknown): Record<string, unknown> | undefined {
+  if (raw === null || raw === undefined || typeof raw !== "object" || Array.isArray(raw)) {
+    return undefined;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (!ALLOWED_PROVIDER_KEYS.has(k)) continue;
+    out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Parse a stored dashboard OpenRouter model value into API model id + optional
+ * `provider` preferences.
+ */
+export function parseOpenRouterModelValue(stored: string): ParsedOpenRouterModelValue {
+  const s = (stored ?? "").trim();
+  if (!s) return { modelId: "" };
+
+  const tab = s.indexOf(ROUTING_SEP);
+  if (tab === -1) {
+    return { modelId: s };
+  }
+
+  const modelId = s.slice(0, tab).trim();
+  const jsonPart = s.slice(tab + ROUTING_SEP.length).trim();
+  if (!jsonPart) {
+    return { modelId: modelId || s };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(jsonPart);
+    const provider = sanitizeProviderObject(parsed);
+    return { modelId: modelId || s, provider };
+  } catch {
+    // Malformed suffix — treat whole string as model id for resilience.
+    return { modelId: s.split(ROUTING_SEP)[0].trim() || s };
+  }
+}
+
+/**
+ * Build the value persisted in config from a model id and optional OpenRouter
+ * `provider` object.
+ */
+export function encodeOpenRouterModelValue(
+  modelId: string,
+  provider: Record<string, unknown> | null | undefined,
+): string {
+  const id = (modelId ?? "").trim();
+  if (!id) return "";
+  const p = sanitizeProviderObject(provider);
+  if (!p) return id;
+  return `${id}${ROUTING_SEP}${JSON.stringify(p)}`;
+}

--- a/dashboard/lib/llm-provider/openrouter.ts
+++ b/dashboard/lib/llm-provider/openrouter.ts
@@ -161,6 +161,11 @@ export function resetOpenRouterClient(): void {
   _client = null;
 }
 
+export function openRouterExtras(provider?: Record<string, unknown>): { provider?: Record<string, unknown> } {
+  if (!provider || Object.keys(provider).length === 0) return {};
+  return { provider };
+}
+
 export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdapter {
   return {
     async runStep(input): Promise<AgenticStepResult> {
@@ -174,7 +179,8 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
           temperature: input.temperature,
           max_tokens: input.maxTokens,
           stream: true,
-        }),
+          ...openRouterExtras(input.openRouterProvider),
+        } as Parameters<typeof client.chat.completions.create>[0]),
       );
 
       // Accumulate content and tool_call deltas.
@@ -272,6 +278,8 @@ export async function openRouterChatCompletion(params: {
   messages: ChatCompletionMessageParam[];
   temperature: number;
   maxTokens: number;
+  /** Optional OpenRouter `provider` routing object. */
+  provider?: Record<string, unknown>;
 }): Promise<{
   content: string;
   usage: OpenRouterCacheUsage | null;
@@ -282,7 +290,8 @@ export async function openRouterChatCompletion(params: {
       messages: params.messages,
       temperature: params.temperature,
       max_tokens: params.maxTokens,
-    }),
+      ...openRouterExtras(params.provider),
+    } as Parameters<typeof params.client.chat.completions.create>[0]),
   );
   const content = response.choices[0]?.message?.content;
   if (!content) {

--- a/dashboard/lib/llm-tools/runner-types.ts
+++ b/dashboard/lib/llm-tools/runner-types.ts
@@ -43,6 +43,8 @@ export interface AgenticRunStepInput {
   messages: ChatCompletionMessageParam[];
   tools: ChatCompletionTool[];
   model: string;
+  /** OpenRouter-only: forwarded as the `provider` object on chat completions. */
+  openRouterProvider?: Record<string, unknown>;
   temperature: number;
   maxTokens: number;
   /** Optional callback invoked as the model streams text chunks. `chars` is the

--- a/dashboard/lib/llm-tools/runner.ts
+++ b/dashboard/lib/llm-tools/runner.ts
@@ -102,6 +102,8 @@ export class AgenticRunnerError extends Error {
 export interface AgenticRunParams {
   adapter: AgenticModelAdapter;
   model: string;
+  /** OpenRouter-only: `provider` routing preferences for this run. */
+  openRouterProvider?: Record<string, unknown>;
   systemPrompt: string;
   /**
    * Optional pre-built system message with provider-specific extensions (e.g.
@@ -205,6 +207,7 @@ export async function runAgenticChat(params: AgenticRunParams): Promise<AgenticR
   const {
     adapter,
     model,
+    openRouterProvider,
     systemPrompt,
     cachedSystemMessage,
     userContent,
@@ -283,6 +286,7 @@ export async function runAgenticChat(params: AgenticRunParams): Promise<AgenticR
         messages,
         tools,
         model,
+        openRouterProvider,
         temperature,
         maxTokens,
         onTextDelta: (chars, totalChars) => {

--- a/dashboard/lib/llm.ts
+++ b/dashboard/lib/llm.ts
@@ -21,6 +21,7 @@ import { logUsage, checkDailyBudget } from "./llm-usage";
 import {
   loadDashboardLlmConfig,
   getEffectiveDashboardModel,
+  getEffectiveOpenRouterProvider,
 } from "./llm-provider/config";
 import type { DashboardLlmConfig, DashboardLlmFlow } from "./llm-provider/types";
 import { isAgenticToolsEnabled, getAgenticConfig } from "./llm-tools/config";
@@ -191,6 +192,7 @@ export async function generateDashboard(
   if (isAgenticToolsEnabled()) {
     const adapter = createDashboardAgenticAdapter();
     const model = getEffectiveDashboardModel(cfg, "generate");
+    const openRouterProvider = getEffectiveOpenRouterProvider(cfg, "generate");
     const agenticPreamble = buildAgenticToolPreamble();
     const promptSplit = buildGeneratePromptSplit();
     const stableWithPreamble = `${promptSplit.stable}\n\n${agenticPreamble}`;
@@ -202,6 +204,7 @@ export async function generateDashboard(
       runAgenticChat({
         adapter,
         model,
+        openRouterProvider,
         systemPrompt: stableWithPreamble,
         cachedSystemMessage: cachedMsg,
         userContent: userPrompt,
@@ -272,6 +275,7 @@ export async function modifyDashboard(
   if (isAgenticToolsEnabled()) {
     const adapter = createDashboardAgenticAdapter();
     const model = getEffectiveDashboardModel(cfg, "modify");
+    const openRouterProvider = getEffectiveOpenRouterProvider(cfg, "modify");
     const agenticPreamble = buildAgenticToolPreamble();
     const promptSplit = buildModifyPromptSplit(currentSpec, true);
     const stableWithPreamble = `${promptSplit.stable}\n\n${agenticPreamble}`;
@@ -283,6 +287,7 @@ export async function modifyDashboard(
       runAgenticChat({
         adapter,
         model,
+        openRouterProvider,
         systemPrompt: `${promptSplit.stable}\n\n${agenticPreamble}\n\n${promptSplit.volatile}`,
         cachedSystemMessage: cachedMsg,
         userContent: userPrompt,
@@ -436,10 +441,12 @@ export async function analyzeDashboard(
     })}\n\n${buildAgenticToolPreamble()}`;
     const adapter = createDashboardAgenticAdapter();
     const model = getEffectiveDashboardModel(cfg, "analyze");
+    const openRouterProvider = getEffectiveOpenRouterProvider(cfg, "analyze");
     const { content, usage } = await callWithCircuitBreaker(() =>
       runAgenticChat({
         adapter,
         model,
+        openRouterProvider,
         systemPrompt,
         userContent: userPrompt,
         ctx: requestCtx,
@@ -499,11 +506,13 @@ export async function generateReviewAgentic(
 
   const adapter = createDashboardAgenticAdapter();
   const model = getEffectiveDashboardModel(cfg, "weekly");
+  const openRouterProvider = getEffectiveOpenRouterProvider(cfg, "weekly");
 
   const { content: finalMessage, usage } = await callWithCircuitBreaker(() =>
     runAgenticChat({
       adapter,
       model,
+      openRouterProvider,
       systemPrompt,
       userContent: "Genera la revisión semanal ahora.",
       ctx,


### PR DESCRIPTION
## Summary
Improves the admin OpenRouter model selector and wires pinned upstream providers into API calls.

### Model catalog (`/api/admin/openrouter-models`)
- After loading `/api/v1/models`, the server fetches each model`s `/endpoints` page (batched concurrency 12) and returns **one auto row** per model (OpenRouter default routing, aggregate list pricing) plus **one row per endpoint** (host/quant tag, endpoint-specific `$ / 1M` prices).
- Cached together for **1 hour** (same TTL as before; first refresh does more HTTP work).

### Stored config format
- **Auto:** `vendor/model` (unchanged).
- **Pinned provider:** `vendor/model` + **TAB** + JSON for OpenRouter`s `provider` object, e.g. `{"only":["deepinfra/fp4"],"allow_fallbacks":false}` (generated by the combobox when you pick a provider row).
- Parsed by `parseOpenRouterModelValue` / `getEffectiveDashboardModel` strips the suffix for the `model` parameter; `getEffectiveOpenRouterProvider` supplies the `provider` field on chat completions.

### UI
- Combobox is **~2× wider** (`min-w` ~42rem on the value column + list `max-w` ~56rem).
- Single searchable list: filter matches **model id, name, description, modality, provider label**.
- `dashboard/config/schema.yaml` descriptions updated for operators.

### Runtime
- `llm-client`, agentic runner, and conversation summarisation pass `provider` when configured.

### Tests
- Updated route + combobox tests; added `openrouter-selection` unit tests.

## Worktree
Developed in worktree `../powershop-analytics-openrouter-provider`, branch `feature/openrouter-provider-picker`.

## How to verify
```bash
cd dashboard && npm test -- --run
```

(CI should run the same.)

Docs: [OpenRouter provider routing](https://openrouter.ai/docs/guides/routing/provider-selection)


Made with [Cursor](https://cursor.com)