### PR TITLE
fix(dashboard): show model text streaming for OpenRouter + fix generate log flood

### DIFF
--- a/dashboard/app/__tests__/view-page.test.tsx
+++ b/dashboard/app/__tests__/view-page.test.tsx
@@ -320,23 +320,10 @@ describe("ViewDashboard page", () => {
     expect(screen.getByTestId("dashboard-renderer")).toBeInTheDocument();
   });
 
-  it("AnalyzeLauncher creates a conversation and navigates to /k/<id>", async () => {
-    // First call: dashboard load; second call: POST /api/conversations
-    let callCount = 0;
-    globalThis.fetch = vi.fn().mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(dashboardRecord),
-        });
-      }
-      // POST /api/conversations
-      return Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({ id: "abc123def456", c_url: "/c/abc123def456", k_url: "/k/abc123def456" }),
-      });
+  it("AnalyzeLauncher opens chat sidebar in analyze mode without creating a conversation", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(dashboardRecord),
     });
 
     render(<ViewDashboard />);
@@ -345,24 +332,30 @@ describe("ViewDashboard page", () => {
       expect(screen.getByText("Mi Dashboard")).toBeInTheDocument();
     });
 
-    // Chat sidebar should not be visible initially
-    expect(screen.queryByTestId("chat-sidebar")).not.toBeInTheDocument();
-
-    // AnalyzeLauncher is visible when sidebar is closed
+    // Chat sidebar should not be open initially
     const launcher = screen.getByLabelText("Analizar con IA");
     expect(launcher).toBeInTheDocument();
 
-    // Click launcher — action-to-chat: creates conversation, navigates
+    // Click launcher — opens the sidebar in analyze mode (no navigation, no
+    // conversation created — that happens lazily when the user sends a message)
     await act(async () => {
       fireEvent.click(launcher);
     });
 
+    // The launcher should no longer be visible once the sidebar opens
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith("/k/abc123def456");
+      expect(screen.queryByLabelText("Analizar con IA")).not.toBeInTheDocument();
     });
 
-    // Chat sidebar does NOT open directly — navigation takes the user to /k/<id>
-    expect(screen.queryByTestId("chat-sidebar")).not.toBeInTheDocument();
+    // No navigation should have occurred
+    expect(mockPush).not.toHaveBeenCalled();
+
+    // No POST to /api/conversations should have been made
+    const fetchCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const postCalls = fetchCalls.filter(
+      ([, opts]: [unknown, RequestInit]) => opts?.method === "POST",
+    );
+    expect(postCalls).toHaveLength(0);
   });
 
   it("shows error state on fetch failure", async () => {

--- a/dashboard/app/dashboard/new/page.tsx
+++ b/dashboard/app/dashboard/new/page.tsx
@@ -179,8 +179,16 @@ export default function NewDashboard() {
           setAgenticRequestId(rid);
           setAgenticLines((prev) => [...prev, ...lines]);
         },
-        onLine: (line) => {
-          setAgenticLines((prev) => [...prev, line]);
+        onLine: (line, replace) => {
+          setAgenticLines((prev) => {
+            if (replace && prev.length > 0) {
+              // Coalesce: replace the last line in place so streaming ticks
+              // (e.g. "Modelo respondiendo · N caracteres") show as one
+              // growing entry instead of one per token.
+              return [...prev.slice(0, -1), line];
+            }
+            return [...prev, line];
+          });
         },
       });
 

--- a/dashboard/lib/format-agentic-progress.ts
+++ b/dashboard/lib/format-agentic-progress.ts
@@ -11,8 +11,10 @@ export interface TimedEvent {
  * Returns null for event types that don't produce visible log lines
  * (e.g. `round` with round=1, `assistant_tools`, `tool_start`).
  *
- * For `model_text_delta`: returns a special line with kind="default" so the
- * caller can coalesce repeated deltas by replacing the last line of that kind.
+ * For `model_text_delta` and `model_thinking_delta`: returns a line whose
+ * `body` carries the cumulative text so the caller can coalesce repeated
+ * deltas into a single growing log entry (replacing the last line of that
+ * label). The `body` is only populated when the event carries a `text` field.
  */
 export function agenticEventToLogLine(event: AgenticProgressEvent, ms: number): LogLine | null {
   const ts = `+${(ms / 1000).toFixed(1)}s`;
@@ -32,16 +34,16 @@ export function agenticEventToLogLine(event: AgenticProgressEvent, ms: number): 
     case "model_step_start":
       return { timestamp: ts, kind: "reason", label: "Modelo pensando…", detail: undefined };
     case "model_text_delta":
-      // The streaming "text" in agentic flows is the JSON tool-protocol payload
-      // (e.g. submit_weekly_review with the full spec inlined) — not human
-      // prose. Showing it as a body floods the log with unreadable JSON, so we
-      // only show the progress count here. Readable reasoning lives in the
-      // thinking block (model_thinking_delta) below.
+      // Show the cumulative text as `body` when available so the user can
+      // read the model's response as it streams. During tool-calling rounds
+      // the text is JSON arguments (not prose) but showing it is still more
+      // informative than just a character count.
       return {
         timestamp: ts,
         kind: "reason",
         label: "Modelo respondiendo",
         detail: `${event.totalChars} caracteres`,
+        body: event.text,
       };
     case "model_thinking_delta":
       return {
@@ -134,14 +136,18 @@ function eventsToLogLines(events: TimedEvent[]): LogLine[] {
     if (!line) continue;
     // Coalesce consecutive streaming ticks of the same eligible label so
     // LogBlock shows one growing line per kind instead of one per chunk.
-    // Reuses COALESCEABLE_LABELS so the post-run collector and the live
-    // streaming helpers stay aligned.
     appendCoalescedLogLine(lines, line);
   }
   return lines;
 }
 
-/** Human-readable line (Spanish) for dashboard generation UI + logs. */
+/**
+ * Human-readable line (Spanish) for dashboard generation UI + logs.
+ * Used by the generate route which streams raw events (not LogLines).
+ * NOTE: This function is called once per event — callers that want coalescing
+ * must deduplicate consecutive identical labels themselves (see
+ * run-dashboard-generate-stream.ts).
+ */
 export function formatAgenticProgressLineEs(event: AgenticProgressEvent): string {
   switch (event.type) {
     case "round":

--- a/dashboard/lib/format-agentic-progress.ts
+++ b/dashboard/lib/format-agentic-progress.ts
@@ -156,6 +156,8 @@ export function formatAgenticProgressLineEs(event: AgenticProgressEvent): string
       return `Modelo pensando… (${event.provider}${event.driver ? `/${event.driver}` : ""})`;
     case "model_text_delta":
       return `Modelo respondiendo · ${event.totalChars} caracteres`;
+    case "model_thinking_delta":
+      return `Claude está razonando · ${event.totalChars} caracteres`;
     case "assistant_tools":
       return `Herramientas solicitadas: ${event.tools.join(", ")}`;
     case "tool_start": {

--- a/dashboard/lib/llm-provider/openrouter.ts
+++ b/dashboard/lib/llm-provider/openrouter.ts
@@ -172,12 +172,12 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
       // Use streaming so we can emit model_text_delta and model_thinking_delta
       // events while tokens arrive.
       //
-      // We merge `reasoning: { effort: "medium" }` via Object.assign so
-      // OpenRouter enables extended thinking for capable models (Claude 3.7+,
-      // o3, Gemini 3, DeepSeek R1, etc.). Models that don't support reasoning
-      // silently ignore the parameter. We avoid TypeScript type assertions here
-      // because some build tools (OXC) fail to parse `as X` or `: Type<>` in
-      // certain positions inside .ts files.
+      // Merge `reasoning: { effort: "medium" }` only when the caller opts in
+      // via input.enableReasoning. This activates extended thinking for capable
+      // models (Claude 3.7+, o3, DeepSeek R1, Gemini 3, etc.) but causes extra
+      // token spend and latency, so it should not be forced on every request.
+      // We use Object.assign to avoid TypeScript type assertions that some build
+      // tools (OXC) fail to parse in certain positions inside .ts files.
       const baseParams = {
         model: input.model,
         messages: input.messages,
@@ -188,10 +188,11 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
         stream: true,
         ...openRouterExtras(input.openRouterProvider),
       };
+      const finalParams = input.enableReasoning
+        ? Object.assign(baseParams, { reasoning: { effort: "medium" } })
+        : baseParams;
       const stream = await withOpenRouterRetry(() =>
-        client.chat.completions.create(
-          Object.assign(baseParams, { reasoning: { effort: "medium" } }),
-        ),
+        client.chat.completions.create(finalParams),
       ) as import("openai/streaming").Stream<import("openai/resources/chat/completions").ChatCompletionChunk>;
 
       // Accumulate content, tool_call, and reasoning/thinking deltas.

--- a/dashboard/lib/llm-provider/openrouter.ts
+++ b/dashboard/lib/llm-provider/openrouter.ts
@@ -188,22 +188,25 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
       // Enable reasoning/thinking for capable models.
       // OpenRouter normalizes this across Anthropic, OpenAI, Google, etc.
       // For models that don't support reasoning it is silently ignored.
-      // Cast via unknown to avoid TypeScript complaining about the non-standard
-      // `reasoning` field not being in the OpenAI SDK's type definitions.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const reasoningParam = { reasoning: { effort: "medium" } } as any;
+      // We spread via a plain JS object to avoid TypeScript complaining about
+      // the non-standard `reasoning` field not being in the OpenAI SDK types.
+      const extraParams = Object.assign({}, { reasoning: { effort: "medium" } });
       const stream = await withOpenRouterRetry(() =>
-        client.chat.completions.create({
-          model: input.model,
-          messages: input.messages,
-          tools: input.tools,
-          tool_choice: "auto",
-          temperature: input.temperature,
-          max_tokens: input.maxTokens,
-          stream: true as const,
-          ...reasoningParam,
-          ...openRouterExtras(input.openRouterProvider),
-        } as Parameters<typeof client.chat.completions.create>[0]),
+        client.chat.completions.create(
+          Object.assign(
+            {
+              model: input.model,
+              messages: input.messages,
+              tools: input.tools,
+              tool_choice: "auto",
+              temperature: input.temperature,
+              max_tokens: input.maxTokens,
+              stream: true,
+              ...openRouterExtras(input.openRouterProvider),
+            },
+            extraParams,
+          ),
+        ),
       ) as import("openai/streaming").Stream<import("openai/resources/chat/completions").ChatCompletionChunk>;
 
       // Accumulate content, tool_call, and reasoning deltas.

--- a/dashboard/lib/llm-provider/openrouter.ts
+++ b/dashboard/lib/llm-provider/openrouter.ts
@@ -169,7 +169,13 @@ export function openRouterExtras(provider?: Record<string, unknown>): { provider
 export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdapter {
   return {
     async runStep(input): Promise<AgenticStepResult> {
-      // Use streaming so we can emit model_text_delta events while tokens arrive.
+      // Use streaming so we can emit model_text_delta and model_thinking_delta
+      // events while tokens arrive.
+      //
+      // `reasoning: { effort: "medium" }` activates extended thinking for
+      // models that support it (Claude 3.7+, o3, Gemini 3, DeepSeek R1, etc.)
+      // via OpenRouter's unified reasoning parameter. For models that don't
+      // support reasoning this parameter is silently ignored by OpenRouter.
       const stream = await withOpenRouterRetry(() =>
         client.chat.completions.create({
           model: input.model,
@@ -179,13 +185,30 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
           temperature: input.temperature,
           max_tokens: input.maxTokens,
           stream: true as const,
+      // Enable reasoning/thinking for capable models.
+      // OpenRouter normalizes this across Anthropic, OpenAI, Google, etc.
+      // For models that don't support reasoning it is silently ignored.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const reasoningParam: Record<string, unknown> = { reasoning: { effort: "medium" } };
+      const stream = await withOpenRouterRetry(() =>
+        client.chat.completions.create({
+          model: input.model,
+          messages: input.messages,
+          tools: input.tools,
+          tool_choice: "auto",
+          temperature: input.temperature,
+          max_tokens: input.maxTokens,
+          stream: true as const,
+          ...reasoningParam,
           ...openRouterExtras(input.openRouterProvider),
-        }),
+        } as Parameters<typeof client.chat.completions.create>[0]),
       ) as import("openai/streaming").Stream<import("openai/resources/chat/completions").ChatCompletionChunk>;
 
-      // Accumulate content and tool_call deltas.
+      // Accumulate content, tool_call, and reasoning deltas.
       let textContent = "";
       let totalCharsEmitted = 0;
+      let thinkingContent = "";    // cumulative reasoning/thinking text
+      let totalThinkingChars = 0;
       // tool_calls deltas: indexed by delta.index
       const toolCallAccum: Record<
         number,
@@ -194,10 +217,46 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
       let usage: OpenRouterCacheUsage | null = null;
 
       for await (const chunk of stream) {
-        const delta = chunk.choices[0]?.delta;
-        if (delta?.content) {
-          textContent += delta.content;
-          const deltaChars = delta.content.length;
+        const delta = chunk.choices[0]?.delta as Record<string, unknown> | undefined;
+
+        // ── Reasoning / thinking tokens ─────────────────────────────────────
+        // OpenRouter surfaces reasoning in two ways depending on the model:
+        //   1. delta.reasoning (string) — legacy field (DeepSeek R1, some others)
+        //   2. delta.reasoning_details (array) — structured form with type:
+        //      "reasoning.text" | "reasoning.summary" | "reasoning.encrypted"
+        // We coalesce both into the cumulative thinkingContent string.
+        const reasoningStr = typeof delta?.reasoning === "string" ? delta.reasoning : "";
+        const reasoningDetails = Array.isArray(delta?.reasoning_details)
+          ? (delta!.reasoning_details as Array<{ type?: string; text?: string; summary?: string }>)
+          : [];
+
+        let thinkingChunk = reasoningStr;
+        for (const detail of reasoningDetails) {
+          if (detail.type === "reasoning.text" && typeof detail.text === "string") {
+            thinkingChunk += detail.text;
+          } else if (detail.type === "reasoning.summary" && typeof detail.summary === "string") {
+            thinkingChunk += detail.summary;
+          }
+          // reasoning.encrypted: skip — content is [REDACTED] or opaque bytes
+        }
+
+        if (thinkingChunk) {
+          thinkingContent += thinkingChunk;
+          totalThinkingChars += thinkingChunk.length;
+          if (input.onThinkingDelta) {
+            try {
+              input.onThinkingDelta(thinkingChunk.length, totalThinkingChars, thinkingContent);
+            } catch {
+              /* ignore callback errors */
+            }
+          }
+        }
+
+        // ── Text content ─────────────────────────────────────────────────────
+        const contentStr = typeof delta?.content === "string" ? delta.content : null;
+        if (contentStr) {
+          textContent += contentStr;
+          const deltaChars = contentStr.length;
           totalCharsEmitted += deltaChars;
           if (input.onTextDelta) {
             try {
@@ -207,24 +266,31 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
             }
           }
         }
+        // ── Tool call deltas ──────────────────────────────────────────────────
         // Accumulate tool_call chunks (OpenAI streaming tool call pattern).
-        if (delta?.tool_calls) {
-          for (const tc of delta.tool_calls) {
-            const idx = tc.index ?? 0;
-            if (!toolCallAccum[idx]) {
-              toolCallAccum[idx] = {
-                id: tc.id ?? "",
-                type: "function",
-                function: { name: tc.function?.name ?? "", arguments: tc.function?.arguments ?? "" },
-              };
-            } else {
-              const acc = toolCallAccum[idx];
-              if (tc.id) acc.id = tc.id;
-              if (tc.function?.name) acc.function.name += tc.function.name;
-              if (tc.function?.arguments) acc.function.arguments += tc.function.arguments;
-            }
+        const toolCallsArr = Array.isArray(delta?.tool_calls)
+          ? (delta!.tool_calls as Array<{
+              index?: number;
+              id?: string;
+              function?: { name?: string; arguments?: string };
+            }>)
+          : [];
+        for (const tc of toolCallsArr) {
+          const idx = tc.index ?? 0;
+          if (!toolCallAccum[idx]) {
+            toolCallAccum[idx] = {
+              id: tc.id ?? "",
+              type: "function",
+              function: { name: tc.function?.name ?? "", arguments: tc.function?.arguments ?? "" },
+            };
+          } else {
+            const acc = toolCallAccum[idx];
+            if (tc.id) acc.id = tc.id;
+            if (tc.function?.name) acc.function.name += tc.function.name;
+            if (tc.function?.arguments) acc.function.arguments += tc.function.arguments;
           }
         }
+        // ── Usage (last chunk) ────────────────────────────────────────────────
         // Usage is typically in the last chunk. Cast to extended type to
         // capture Anthropic cache token fields forwarded by OpenRouter.
         if (chunk.usage) {

--- a/dashboard/lib/llm-provider/openrouter.ts
+++ b/dashboard/lib/llm-provider/openrouter.ts
@@ -172,49 +172,33 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
       // Use streaming so we can emit model_text_delta and model_thinking_delta
       // events while tokens arrive.
       //
-      // `reasoning: { effort: "medium" }` activates extended thinking for
-      // models that support it (Claude 3.7+, o3, Gemini 3, DeepSeek R1, etc.)
-      // via OpenRouter's unified reasoning parameter. For models that don't
-      // support reasoning this parameter is silently ignored by OpenRouter.
-      const stream = await withOpenRouterRetry(() =>
-        client.chat.completions.create({
-          model: input.model,
-          messages: input.messages,
-          tools: input.tools,
-          tool_choice: "auto",
-          temperature: input.temperature,
-          max_tokens: input.maxTokens,
-          stream: true as const,
-      // Enable reasoning/thinking for capable models.
-      // OpenRouter normalizes this across Anthropic, OpenAI, Google, etc.
-      // For models that don't support reasoning it is silently ignored.
-      // We spread via a plain JS object to avoid TypeScript complaining about
-      // the non-standard `reasoning` field not being in the OpenAI SDK types.
-      const extraParams = Object.assign({}, { reasoning: { effort: "medium" } });
+      // We merge `reasoning: { effort: "medium" }` via Object.assign so
+      // OpenRouter enables extended thinking for capable models (Claude 3.7+,
+      // o3, Gemini 3, DeepSeek R1, etc.). Models that don't support reasoning
+      // silently ignore the parameter. We avoid TypeScript type assertions here
+      // because some build tools (OXC) fail to parse `as X` or `: Type<>` in
+      // certain positions inside .ts files.
+      const baseParams = {
+        model: input.model,
+        messages: input.messages,
+        tools: input.tools,
+        tool_choice: "auto",
+        temperature: input.temperature,
+        max_tokens: input.maxTokens,
+        stream: true,
+        ...openRouterExtras(input.openRouterProvider),
+      };
       const stream = await withOpenRouterRetry(() =>
         client.chat.completions.create(
-          Object.assign(
-            {
-              model: input.model,
-              messages: input.messages,
-              tools: input.tools,
-              tool_choice: "auto",
-              temperature: input.temperature,
-              max_tokens: input.maxTokens,
-              stream: true,
-              ...openRouterExtras(input.openRouterProvider),
-            },
-            extraParams,
-          ),
+          Object.assign(baseParams, { reasoning: { effort: "medium" } }),
         ),
       ) as import("openai/streaming").Stream<import("openai/resources/chat/completions").ChatCompletionChunk>;
 
-      // Accumulate content, tool_call, and reasoning deltas.
+      // Accumulate content, tool_call, and reasoning/thinking deltas.
       let textContent = "";
       let totalCharsEmitted = 0;
-      let thinkingContent = "";    // cumulative reasoning/thinking text
+      let thinkingContent = "";
       let totalThinkingChars = 0;
-      // tool_calls deltas: indexed by delta.index
       const toolCallAccum: Record<
         number,
         { id: string; type: "function"; function: { name: string; arguments: string } }
@@ -222,17 +206,18 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
       let usage: OpenRouterCacheUsage | null = null;
 
       for await (const chunk of stream) {
-        const delta = chunk.choices[0]?.delta as Record<string, unknown> | undefined;
+        // Cast delta to a plain object so we can read non-standard fields
+        // (reasoning, reasoning_details) without TypeScript errors.
+        const delta = (chunk.choices[0]?.delta ?? {}) as Record<string, unknown>;
 
         // ── Reasoning / thinking tokens ─────────────────────────────────────
-        // OpenRouter surfaces reasoning in two ways depending on the model:
+        // OpenRouter surfaces reasoning in two ways:
         //   1. delta.reasoning (string) — legacy field (DeepSeek R1, some others)
-        //   2. delta.reasoning_details (array) — structured form with type:
-        //      "reasoning.text" | "reasoning.summary" | "reasoning.encrypted"
-        // We coalesce both into the cumulative thinkingContent string.
-        const reasoningStr = typeof delta?.reasoning === "string" ? delta.reasoning : "";
-        const reasoningDetails = Array.isArray(delta?.reasoning_details)
-          ? (delta!.reasoning_details as Array<{ type?: string; text?: string; summary?: string }>)
+        //   2. delta.reasoning_details (array of {type, text?, summary?}) —
+        //      structured form for Anthropic / OpenAI / Gemini reasoning models
+        const reasoningStr = typeof delta.reasoning === "string" ? delta.reasoning : "";
+        const reasoningDetails = Array.isArray(delta.reasoning_details)
+          ? (delta.reasoning_details as Array<{ type?: string; text?: string; summary?: string }>)
           : [];
 
         let thinkingChunk = reasoningStr;
@@ -242,7 +227,7 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
           } else if (detail.type === "reasoning.summary" && typeof detail.summary === "string") {
             thinkingChunk += detail.summary;
           }
-          // reasoning.encrypted: skip — content is [REDACTED] or opaque bytes
+          // reasoning.encrypted: skip — opaque bytes / [REDACTED]
         }
 
         if (thinkingChunk) {
@@ -258,7 +243,7 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
         }
 
         // ── Text content ─────────────────────────────────────────────────────
-        const contentStr = typeof delta?.content === "string" ? delta.content : null;
+        const contentStr = typeof delta.content === "string" ? delta.content : null;
         if (contentStr) {
           textContent += contentStr;
           const deltaChars = contentStr.length;
@@ -271,10 +256,10 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
             }
           }
         }
+
         // ── Tool call deltas ──────────────────────────────────────────────────
-        // Accumulate tool_call chunks (OpenAI streaming tool call pattern).
-        const toolCallsArr = Array.isArray(delta?.tool_calls)
-          ? (delta!.tool_calls as Array<{
+        const toolCallsArr = Array.isArray(delta.tool_calls)
+          ? (delta.tool_calls as Array<{
               index?: number;
               id?: string;
               function?: { name?: string; arguments?: string };
@@ -295,9 +280,8 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
             if (tc.function?.arguments) acc.function.arguments += tc.function.arguments;
           }
         }
+
         // ── Usage (last chunk) ────────────────────────────────────────────────
-        // Usage is typically in the last chunk. Cast to extended type to
-        // capture Anthropic cache token fields forwarded by OpenRouter.
         if (chunk.usage) {
           const u = chunk.usage as OpenRouterCacheUsage;
           usage = {

--- a/dashboard/lib/llm-provider/openrouter.ts
+++ b/dashboard/lib/llm-provider/openrouter.ts
@@ -188,8 +188,10 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
       // Enable reasoning/thinking for capable models.
       // OpenRouter normalizes this across Anthropic, OpenAI, Google, etc.
       // For models that don't support reasoning it is silently ignored.
+      // Cast via unknown to avoid TypeScript complaining about the non-standard
+      // `reasoning` field not being in the OpenAI SDK's type definitions.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const reasoningParam: Record<string, unknown> = { reasoning: { effort: "medium" } };
+      const reasoningParam = { reasoning: { effort: "medium" } } as any;
       const stream = await withOpenRouterRetry(() =>
         client.chat.completions.create({
           model: input.model,

--- a/dashboard/lib/llm-tools/runner-types.ts
+++ b/dashboard/lib/llm-tools/runner-types.ts
@@ -54,9 +54,16 @@ export interface AgenticRunStepInput {
   onTextDelta?: (chars: number, totalChars: number, accumulatedText: string) => void;
   /** Optional callback invoked while the model is in extended-thinking mode.
    *  Same contract as `onTextDelta` but for the chain-of-thought block. Fires
-   *  *before* the final answer text starts streaming (Claude only — OpenRouter
-   *  text streaming has no extended-thinking phase, so this is never invoked
-   *  for that adapter). */
+   *  *before* the final answer text starts streaming.
+   *
+   *  For the CLI (claude_code) adapter: fires when the Claude CLI emits
+   *  `thinking_delta` events in its native NDJSON stream.
+   *
+   *  For the OpenRouter adapter: fires when the model returns reasoning tokens
+   *  (via `delta.reasoning_details` or `delta.reasoning`). Requires a model
+   *  that supports reasoning (e.g. claude-3-7-sonnet, o3, deepseek-r1). The
+   *  OpenRouter adapter sends `reasoning: { effort: "medium" }` on every
+   *  request; models that don't support it silently ignore the parameter. */
   onThinkingDelta?: (chars: number, totalChars: number, accumulatedThinking: string) => void;
 }
 

--- a/dashboard/lib/llm-tools/runner-types.ts
+++ b/dashboard/lib/llm-tools/runner-types.ts
@@ -59,12 +59,19 @@ export interface AgenticRunStepInput {
    *  For the CLI (claude_code) adapter: fires when the Claude CLI emits
    *  `thinking_delta` events in its native NDJSON stream.
    *
-   *  For the OpenRouter adapter: fires when the model returns reasoning tokens
-   *  (via `delta.reasoning_details` or `delta.reasoning`). Requires a model
-   *  that supports reasoning (e.g. claude-3-7-sonnet, o3, deepseek-r1). The
-   *  OpenRouter adapter sends `reasoning: { effort: "medium" }` on every
-   *  request; models that don't support it silently ignore the parameter. */
+   *  For the OpenRouter adapter: fires when `enableReasoning=true` and the
+   *  model returns reasoning tokens (via `delta.reasoning_details` or
+   *  `delta.reasoning`). Supported by claude-3-7-sonnet, o3, deepseek-r1, etc. */
   onThinkingDelta?: (chars: number, totalChars: number, accumulatedThinking: string) => void;
+  /**
+   * OpenRouter adapter only: when true, adds `reasoning: { effort: "medium" }`
+   * to the API request, activating extended thinking for capable models
+   * (Claude 3.7+, o3, DeepSeek R1, Gemini 3, etc.).
+   *
+   * Defaults to false. Enable explicitly when using a known thinking-capable
+   * model to avoid unexpected cost/latency increases on standard models.
+   */
+  enableReasoning?: boolean;
 }
 
 export interface AgenticModelAdapter {

--- a/dashboard/lib/llm-tools/runner.ts
+++ b/dashboard/lib/llm-tools/runner.ts
@@ -117,6 +117,13 @@ export interface AgenticRunParams {
   maxTokens: number;
   /** Prior conversation turns injected between the system prompt and the new user message. */
   priorMessages?: ChatCompletionMessageParam[];
+  /**
+   * OpenRouter adapter only: when true, adds `reasoning: { effort: "medium" }`
+   * to each API request, enabling extended thinking for capable models
+   * (Claude 3.7+, o3, DeepSeek R1, Gemini 3, etc.).
+   * Defaults to false — opt in explicitly to avoid unexpected cost/latency.
+   */
+  enableReasoning?: boolean;
 }
 
 export interface AgenticRunResult {
@@ -215,6 +222,7 @@ export async function runAgenticChat(params: AgenticRunParams): Promise<AgenticR
     temperature,
     maxTokens,
     priorMessages,
+    enableReasoning,
   } = params;
 
   const cfg = getAgenticConfig();
@@ -289,6 +297,7 @@ export async function runAgenticChat(params: AgenticRunParams): Promise<AgenticR
         openRouterProvider,
         temperature,
         maxTokens,
+        enableReasoning,
         onTextDelta: (chars, totalChars, accumulatedText) => {
           emitAgenticProgress(ctx, {
             type: "model_text_delta",

--- a/dashboard/lib/llm-tools/runner.ts
+++ b/dashboard/lib/llm-tools/runner.ts
@@ -192,12 +192,12 @@ function emitAgenticProgress(ctx: LlmAgenticContext, event: AgenticProgressEvent
   } catch (hookErr) {
     console.warn("[agentic] onAgenticProgress hook failed:", hookErr);
   }
-  // Server logs: drop the cumulative `text` payload from model_thinking_delta
+  // Server logs: drop the cumulative `text` payload from streaming events
   // — it grows with every token chunk and would flood the log with redundant
-  // copies of Claude's running reasoning. The client still receives the full
-  // text via the NDJSON stream. (`model_text_delta` no longer carries `text`.)
+  // copies of the running text. The client still receives the full text via
+  // the NDJSON stream.
   const logEvent =
-    event.type === "model_thinking_delta" && "text" in event
+    (event.type === "model_thinking_delta" || event.type === "model_text_delta") && "text" in event
       ? { ...event, text: undefined }
       : event;
   console.info(`[agentic][${ctx.endpoint}][${ctx.requestId}]`, JSON.stringify(logEvent));
@@ -289,12 +289,13 @@ export async function runAgenticChat(params: AgenticRunParams): Promise<AgenticR
         openRouterProvider,
         temperature,
         maxTokens,
-        onTextDelta: (chars, totalChars) => {
+        onTextDelta: (chars, totalChars, accumulatedText) => {
           emitAgenticProgress(ctx, {
             type: "model_text_delta",
             round: round + 1,
             chars,
             totalChars,
+            text: accumulatedText,
           });
         },
         onThinkingDelta: (chars, totalChars, accumulatedThinking) => {

--- a/dashboard/lib/llm-tools/types.ts
+++ b/dashboard/lib/llm-tools/types.ts
@@ -15,11 +15,14 @@ export type AgenticProgressEvent =
       round: number;
       chars: number;
       totalChars: number;
-      // No `text` field: the streaming UI only renders the running counter for
-      // text deltas (the body is the JSON tool-protocol payload, not human
-      // prose), so emitting the cumulative text on every token would grow each
-      // NDJSON frame quadratically. Readable prose is carried by
-      // `model_thinking_delta` instead.
+      /**
+       * Cumulative text streamed so far this step.
+       * Populated so the UI can show the model's response as it streams.
+       * During tool-calling rounds this is typically JSON tool-call arguments
+       * (not human prose); during the final round it is the actual response.
+       * Consumers that only want the character counter may ignore this field.
+       */
+      text?: string;
     }
   | {
       type: "model_thinking_delta";

--- a/dashboard/lib/run-dashboard-generate-stream.ts
+++ b/dashboard/lib/run-dashboard-generate-stream.ts
@@ -1,6 +1,9 @@
 import type { DashboardSpec } from "@/lib/schema";
 import type { AgenticProgressEvent } from "@/lib/llm-tools/types";
-import { formatAgenticProgressLineEs } from "@/lib/format-agentic-progress";
+import {
+  formatAgenticProgressLineEs,
+  COALESCEABLE_LABELS,
+} from "@/lib/format-agentic-progress";
 import {
   isApiErrorResponse,
   type ApiErrorResponse,
@@ -9,7 +12,15 @@ import {
 
 export interface DashboardGenerateStreamHandlers {
   onMeta?: (requestId: string, lines: string[]) => void;
-  onLine?: (line: string) => void;
+  /**
+   * Called with a new progress line to append to the log.
+   * Consecutive "Modelo respondiendo" / "Claude está razonando" ticks are
+   * coalesced — `replace=true` signals that the previous log entry should be
+   * updated in place rather than a new line added. If the caller does not
+   * support in-place replacement, it may ignore the flag and append anyway
+   * (the log will then show the last value rather than a count counter).
+   */
+  onLine?: (line: string, replace?: boolean) => void;
 }
 
 /**
@@ -54,6 +65,17 @@ export async function runDashboardGenerateStream(
   let buffer = "";
   let finalSpec: DashboardSpec | null = null;
 
+  // Coalescing state: track the last label emitted to detect consecutive
+  // coalesceable ticks (model_text_delta / model_thinking_delta).
+  let lastCoalescedLabel: string | null = null;
+
+  const emitLine = (line: string, coalesceable: boolean) => {
+    const label = coalesceable ? line.split(" · ")[0] ?? line : null;
+    const replace = coalesceable && label !== null && label === lastCoalescedLabel;
+    lastCoalescedLabel = coalesceable ? label : null;
+    handlers.onLine?.(line, replace);
+  };
+
   const processLine = (rawLine: string) => {
     const line = rawLine.trim();
     if (!line) return;
@@ -75,11 +97,16 @@ export async function runDashboardGenerateStream(
     }
 
     if (msg.type === "progress" && msg.event) {
-      handlers.onLine?.(formatAgenticProgressLineEs(msg.event as AgenticProgressEvent));
+      const ev = msg.event as AgenticProgressEvent;
+      const formatted = formatAgenticProgressLineEs(ev);
+      // Coalesce consecutive streaming ticks of the same label so the
+      // progress dialog shows one growing line rather than one per token.
+      const coalesceable = COALESCEABLE_LABELS.has(formatted.split(" · ")[0] ?? "");
+      emitLine(formatted, coalesceable);
     }
 
     if (msg.type === "phase" && typeof msg.message === "string") {
-      handlers.onLine?.(String(msg.message));
+      emitLine(String(msg.message), false);
     }
 
     if (msg.type === "result" && msg.spec) {


### PR DESCRIPTION
## Summary

Fixes two OpenRouter-related dashboard UX issues, plus adds reasoning/thinking token support and fixes the AnalyzeLauncher flow.

### Problem 1 — Generate panel floods log with one line per token

With OpenRouter, the generate progress dialog was showing one \"Modelo respondiendo · N chars\" entry per streamed token instead of a single growing entry. The analyze/modify routes coalesced correctly via \`pushAgenticLogLine\`, but the generate route streamed raw events with no coalescing.

**Fix:** Client-side coalescing in \`run-dashboard-generate-stream.ts\` — consecutive coalesceable labels emit \`replace=true\` so \`new/page.tsx\` replaces the last line in place.

### Problem 2 — Model response text never shown, only character counter

With OpenRouter, the model's actual response text was silently dropped. Only a character counter grew. \`model_text_delta\` had no \`text\` field by design — but the comment was wrong: the final round (no tools called) streams human prose, not JSON protocol.

**Fix:** Add \`text?: string\` to \`model_text_delta\`, thread \`accumulatedText\` through the runner, render \`body: event.text\` in \`agenticEventToLogLine\`.

### Problem 3 — Thinking/reasoning not shown for OpenRouter thinking models

When using a thinking-capable model (claude-3-7-sonnet, o3, deepseek-r1, etc.) via OpenRouter, reasoning tokens were silently discarded.

**Fix:** Read \`delta.reasoning_details\` and \`delta.reasoning\` from each streaming chunk; call \`onThinkingDelta\` — same path as CLI extended thinking. Gated behind \`input.enableReasoning\` flag (default: false) to avoid unexpected cost/latency on non-thinking models.

### Problem 4 — AnalyzeLauncher created orphan conversations on every click

Every click on the \"Analizar con IA\" rail button created a new conversation and navigated to \`/k/<id>\`, which 404'd (static-generation bug), causing users to click again — creating more conversations.

**Fix:** AnalyzeLauncher now calls \`onOpen(seedPrompt)\` to open the chat sidebar in-place in analyze mode. No navigation, no conversation created until the user sends their first message.

## Changes

| File | Change |
|------|--------|
| \`lib/llm-tools/types.ts\` | Add \`text?: string\` to \`model_text_delta\` |
| \`lib/llm-tools/runner.ts\` | Thread \`accumulatedText\` + \`enableReasoning\` through \`stepInput\` |
| \`lib/llm-tools/runner-types.ts\` | Add \`enableReasoning?: boolean\` to \`AgenticRunStepInput\` + \`AgenticRunParams\`; update \`onThinkingDelta\` doc |
| \`lib/llm-provider/openrouter.ts\` | Add reasoning token streaming (\`delta.reasoning_details\` / \`delta.reasoning\`); gate \`reasoning: { effort: \"medium\" }\` behind \`enableReasoning\` |
| \`lib/format-agentic-progress.ts\` | Render \`body: event.text\` for \`model_text_delta\`; add \`model_thinking_delta\` case to \`formatAgenticProgressLineEs\` |
| \`lib/run-dashboard-generate-stream.ts\` | Add client-side coalescing with \`replace\` flag |
| \`app/dashboard/new/page.tsx\` | Handle \`replace=true\` in \`onLine\` callback |
| \`components/AnalyzeLauncher.tsx\` | Replace navigate+create with \`onOpen\` callback |
| \`components/surfaces/DashboardSurface.tsx\` | Wire \`handleAnalyzeLauncherOpen\` to pre-fill analyze sidebar |
| \`app/__tests__/view-page.test.tsx\` | Update test for new AnalyzeLauncher behaviour |
| \`app/k/[id]/page.tsx\`, \`app/c/[id]/page.tsx\` | Add \`export const dynamic = \"force-dynamic\"\` to prevent static 404 |