### PR TITLE
fix(dashboard): /c/ and /k/ 404 behind reverse proxy + conversations table layout

### DIFF
--- a/dashboard/components/ConversationsTable.tsx
+++ b/dashboard/components/ConversationsTable.tsx
@@ -180,7 +180,7 @@ export function ConversationsTable({
     setRenamingId(null);
   };
 
-  // Styles — headers always sticky at top: 0; bulk bar placed outside the
+   // Styles — headers always sticky at top: 0; bulk bar placed outside the
   // scrollable div with zIndex: 11 so it never covers column headers.
   const thStyle: React.CSSProperties = {
     padding: "8px 10px",
@@ -198,13 +198,19 @@ export function ConversationsTable({
     zIndex: 1,
   };
 
+  // Base cell style — NO overflow/truncation here so the checkbox and
+  // action columns don't get clipped. Apply truncation per-column below.
   const tdStyle: React.CSSProperties = {
     padding: "8px 10px",
     fontSize: 12,
     color: "var(--fg)",
     borderBottom: "1px solid var(--border)",
     verticalAlign: "middle",
-    maxWidth: 200,
+  };
+
+  // Truncating cell style for fixed-width columns (mode, duration, tokens, activity).
+  const tdTrunc: React.CSSProperties = {
+    ...tdStyle,
     overflow: "hidden",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
@@ -343,15 +349,15 @@ export function ConversationsTable({
           data-testid="conversations-table"
         >
           <colgroup>
-            <col style={{ width: 32 }} />
-            <col style={{ width: "auto", minWidth: 200 }} />
-            <col style={{ width: 100 }} />
-            <col style={{ width: 130 }} />
-            <col style={{ width: 130 }} />
-            <col style={{ width: 80 }} />
-            <col style={{ width: 150 }} />
-            <col style={{ width: 80 }} />
-            <col style={{ width: 90 }} />
+            <col style={{ width: 36 }} />           {/* checkbox */}
+            <col />                                  {/* title — takes all remaining space */}
+            <col style={{ width: 90 }} />            {/* tipo/mode */}
+            <col style={{ width: 150 }} />           {/* última actividad */}
+            <col style={{ width: 155 }} />           {/* creada — needs room for "14/05/2026, 06:40" */}
+            <col style={{ width: 75 }} />            {/* duración */}
+            <col style={{ width: 145 }} />           {/* actividad */}
+            <col style={{ width: 75 }} />            {/* tokens */}
+            <col style={{ width: 90 }} />            {/* acciones */}
           </colgroup>
           <thead>
             <tr>
@@ -398,7 +404,7 @@ export function ConversationsTable({
                   data-testid={`conversation-row-${row.id}`}
                 >
                   {/* Checkbox */}
-                  <td style={{ ...tdStyle, width: 32 }}>
+                  <td style={{ ...tdStyle, width: 36 }}>
                     <input
                       type="checkbox"
                       checked={selected.has(row.id)}
@@ -409,7 +415,7 @@ export function ConversationsTable({
                   </td>
 
                   {/* Título — click navigates to /c/:id; pencil icon triggers rename */}
-                  <td style={{ ...tdStyle, maxWidth: "none" }}>
+                  <td style={{ ...tdStyle, maxWidth: 0 }}>
                     {renamingId === row.id ? (
                       <input
                         type="text"
@@ -491,7 +497,7 @@ export function ConversationsTable({
                   </td>
 
                   {/* Tipo — mode pill */}
-                  <td style={{ ...tdStyle }}>
+                  <td style={{ ...tdTrunc }}>
                     <span
                       className={`${modeStyle.bg} ${modeStyle.fg}`}
                       style={{
@@ -510,14 +516,14 @@ export function ConversationsTable({
                   </td>
 
                   {/* Última actividad */}
-                  <td style={{ ...tdStyle, fontWeight: 500 }}>
+                  <td style={{ ...tdTrunc, fontWeight: 500 }}>
                     {relativeTime(row.last_interaction_at)}
                   </td>
 
                   {/* Creada */}
                   <td
                     style={{
-                      ...tdStyle,
+                      ...tdTrunc,
                       color: "var(--fg-muted)",
                       fontFamily: "var(--font-jetbrains, monospace)",
                       fontSize: 11,
@@ -527,12 +533,12 @@ export function ConversationsTable({
                   </td>
 
                   {/* Duración */}
-                  <td style={{ ...tdStyle, color: "var(--fg-muted)" }}>
+                  <td style={{ ...tdTrunc, color: "var(--fg-muted)" }}>
                     {formatDuration(row.duration_seconds)}
                   </td>
 
                   {/* Actividad */}
-                  <td style={{ ...tdStyle, color: "var(--fg-muted)" }}>
+                  <td style={{ ...tdTrunc, color: "var(--fg-muted)" }}>
                     {row.message_count} msg
                     {row.tool_calls_count > 0 &&
                       ` · ${row.tool_calls_count} herr`}
@@ -542,7 +548,7 @@ export function ConversationsTable({
                   {/* Tokens */}
                   <td
                     style={{
-                      ...tdStyle,
+                      ...tdTrunc,
                       color: "var(--fg-muted)",
                       fontFamily: "var(--font-jetbrains, monospace)",
                       fontSize: 11,

--- a/dashboard/components/ConversationsTable.tsx
+++ b/dashboard/components/ConversationsTable.tsx
@@ -180,7 +180,7 @@ export function ConversationsTable({
     setRenamingId(null);
   };
 
-   // Styles — headers always sticky at top: 0; bulk bar placed outside the
+  // Styles — headers always sticky at top: 0; bulk bar placed outside the
   // scrollable div with zIndex: 11 so it never covers column headers.
   const thStyle: React.CSSProperties = {
     padding: "8px 10px",
@@ -361,8 +361,8 @@ export function ConversationsTable({
           </colgroup>
           <thead>
             <tr>
-              {/* Checkbox header */}
-              <th style={{ ...thStyle, width: 32 }}>
+              {/* Checkbox header — width matches the colgroup col (36px) */}
+              <th style={{ ...thStyle, width: 36 }}>
                 <input
                   type="checkbox"
                   checked={allSelected}

--- a/dashboard/lib/conversation-api.ts
+++ b/dashboard/lib/conversation-api.ts
@@ -1,31 +1,31 @@
-import { headers } from "next/headers";
 import type { ConversationWithMessages } from "@/lib/conversation-types";
 import { getAppPublicUrl } from "@/lib/public-urls";
 
 /**
  * Fetches a conversation by ID from the internal API.
  *
- * IMPORTANT: This is a server-to-self call made during SSR. It must use the
- * internal (container-local) base URL — never the public URL — so it works
- * regardless of the external hostname or whether TLS is terminated externally.
+ * IMPORTANT: This is a server-to-self call made during SSR. It MUST use the
+ * loopback address (127.0.0.1) and the container's own PORT — never the
+ * incoming request's Host header.
  *
- * Internal URL is derived from the incoming request's Host header (which
- * inside Docker is always the container port, e.g. "localhost:4000"), NOT
- * from APP_PUBLIC_URL (which is the public reverse-proxy hostname and would
- * route traffic outside the container network).
+ * Why not use the Host header?
+ *   When the app is served through a reverse proxy (e.g. power.lobato.vip),
+ *   the Host header contains the external hostname. A self-fetch to
+ *   `http://power.lobato.vip/api/...` leaves the container network, goes
+ *   through the proxy, and fails (TLS mismatch, routing, or DNS inside Docker).
+ *   The result is a null response → notFound() → 404 for every /c/ and /k/ page.
+ *
+ * Fix: always fetch via http://127.0.0.1:{PORT}. The PORT env var is set by
+ * Next.js standalone to the port the server is actually listening on (4000).
  *
  * Returns null for 404 or any fetch error (caller should `notFound()`).
  */
 export async function fetchConversation(id: string): Promise<ConversationWithMessages | null> {
   try {
-    const headersList = await headers();
-    // Use the Host header to get the container-local address. Inside Docker
-    // this is always the container's own port (e.g. "localhost:4000"), so
-    // the fetch stays on the loopback and never leaves the container.
-    // APP_PUBLIC_URL is intentionally NOT used here — it's for external links.
-    const host = headersList.get("host") ?? "localhost:4000";
-    const proto = "http"; // always http inside the container (TLS is at the proxy)
-    const baseUrl = `${proto}://${host}`;
+    // Use the loopback address so the fetch always stays inside the container
+    // regardless of how the request arrived (direct LAN access or reverse proxy).
+    const port = process.env.PORT ?? "4000";
+    const baseUrl = `http://127.0.0.1:${port}`;
     const res = await fetch(`${baseUrl}/api/conversations/${id}`, {
       cache: "no-store",
     });

--- a/dashboard/lib/conversation-api.ts
+++ b/dashboard/lib/conversation-api.ts
@@ -15,8 +15,9 @@ import { getAppPublicUrl } from "@/lib/public-urls";
  *   through the proxy, and fails (TLS mismatch, routing, or DNS inside Docker).
  *   The result is a null response → notFound() → 404 for every /c/ and /k/ page.
  *
- * Fix: always fetch via http://127.0.0.1:{PORT}. The PORT env var is set by
- * Next.js standalone to the port the server is actually listening on (4000).
+ * Fix: always fetch via http://127.0.0.1:{DASHBOARD_PORT|PORT|4000}. The
+ * loopback address always resolves inside the container. Port resolution:
+ * DASHBOARD_PORT (docker-compose env) → PORT (Next.js standalone) → 4000.
  *
  * Returns null for 404 or any fetch error (caller should `notFound()`).
  */
@@ -24,7 +25,9 @@ export async function fetchConversation(id: string): Promise<ConversationWithMes
   try {
     // Use the loopback address so the fetch always stays inside the container
     // regardless of how the request arrived (direct LAN access or reverse proxy).
-    const port = process.env.PORT ?? "4000";
+    // Port resolution order: DASHBOARD_PORT (docker-compose), PORT (Next.js
+    // standalone default), fallback 4000.
+    const port = process.env.DASHBOARD_PORT ?? process.env.PORT ?? "4000";
     const baseUrl = `http://127.0.0.1:${port}`;
     const res = await fetch(`${baseUrl}/api/conversations/${id}`, {
       cache: "no-store",


### PR DESCRIPTION
## Bug 1 — /c/:id and /k/:id return 404 when accessed via reverse proxy

### Root cause

`fetchConversation` used `headersList.get("host")` to build the self-fetch URL. When the app is served through a reverse proxy (e.g. `power.lobato.vip`), the `Host` header contains the **external** hostname. The server then tries to fetch `http://power.lobato.vip/api/conversations/:id`, which leaves the container network, fails (TLS mismatch / DNS / routing), returns null → `notFound()` → 404 page.

The bug did not manifest on direct LAN access (`192.168.1.238:4000`) because there the `Host` header is the LAN address — which IS reachable from inside the container.

### Fix

Always use `http://127.0.0.1:${PORT}` for the self-fetch. The loopback address always resolves inside the container regardless of how the external request arrived. `PORT` is set by Next.js standalone (default `"4000"`).

## Bug 2 — Conversations table column layout issues

Three problems visible in the `/conversations` list:

| Problem | Cause | Fix |
|---------|-------|-----|
| Checkbox shows `...` | `tdStyle` applied `maxWidth:200 + overflow:hidden` to all cells including checkbox | Separate `tdStyle` (no truncation) from `tdTrunc` (for fixed-width text columns) |
| Date column truncated | 130px was too narrow for `"14/05/2026, 06:40"` (~17 chars × 7px monospace) | Widened to 155px |
| Title column too narrow / wasting space | `col width: auto` shared space with all other columns under `tableLayout:fixed` | Title col has no explicit width (takes all remaining space); td uses `maxWidth:0` (standard trick for flex-fill in fixed-layout tables) |

## Testing

- Navigate to `/c/:id` and `/k/:id` via the reverse-proxy hostname → should load the conversation, not 404
- Conversations list: title should fill the available width, date column should show without `...`, checkbox should render without truncation