### PR TITLE
fix: doubled thinking text, conversations title truncation, generate thinking body

### DIFF
--- a/dashboard/app/dashboard/new/page.tsx
+++ b/dashboard/app/dashboard/new/page.tsx
@@ -7,11 +7,11 @@ import { TEMPLATES, type DashboardTemplate } from "@/lib/templates";
 import { TASK_PROMPTS } from "@/lib/task-prompts";
 import { DASHBOARD_ROLES } from "@/lib/dashboard-roles";
 import { DataFreshnessBanner } from "@/components/DataFreshnessBanner";
-import { DashboardGenerateProgressDialog } from "@/components/DashboardGenerateProgressDialog";
+import { DashboardGenerateProgressDialog, type ProgressLine } from "@/components/DashboardGenerateProgressDialog";
 import { ErrorDisplay } from "@/components/ErrorDisplay";
 import { isApiErrorResponse } from "@/lib/errors";
 import type { ApiErrorResponse } from "@/lib/errors";
-import { runDashboardGenerateStream } from "@/lib/run-dashboard-generate-stream";
+import { runDashboardGenerateStream, type GenerateProgressLine } from "@/lib/run-dashboard-generate-stream";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -97,7 +97,7 @@ export default function NewDashboard() {
   const [gapsError, setGapsError] = useState<string | null>(null);
 
   const [agenticOpen, setAgenticOpen] = useState(false);
-  const [agenticLines, setAgenticLines] = useState<string[]>([]);
+  const [agenticLines, setAgenticLines] = useState<ProgressLine[]>([]);
   const [agenticRequestId, setAgenticRequestId] = useState<string | null>(null);
   const [agenticPhase, setAgenticPhase] = useState<"running" | "error" | "success">("running");
   const [agenticErrorSummary, setAgenticErrorSummary] = useState<ReactNode>(null);
@@ -177,17 +177,15 @@ export default function NewDashboard() {
         onMeta: (rid, lines) => {
           capturedRequestId = rid;
           setAgenticRequestId(rid);
-          setAgenticLines((prev) => [...prev, ...lines]);
+          setAgenticLines((prev) => [...prev, ...lines.map((text) => ({ text }))]);
         },
-        onLine: (line, replace) => {
+        onLine: (line: GenerateProgressLine, replace) => {
+          const progressLine: ProgressLine = { text: line.text, body: line.body };
           setAgenticLines((prev) => {
             if (replace && prev.length > 0) {
-              // Coalesce: replace the last line in place so streaming ticks
-              // (e.g. "Modelo respondiendo · N caracteres") show as one
-              // growing entry instead of one per token.
-              return [...prev.slice(0, -1), line];
+              return [...prev.slice(0, -1), progressLine];
             }
-            return [...prev, line];
+            return [...prev, progressLine];
           });
         },
       });

--- a/dashboard/app/dashboard/new/page.tsx
+++ b/dashboard/app/dashboard/new/page.tsx
@@ -7,7 +7,7 @@ import { TEMPLATES, type DashboardTemplate } from "@/lib/templates";
 import { TASK_PROMPTS } from "@/lib/task-prompts";
 import { DASHBOARD_ROLES } from "@/lib/dashboard-roles";
 import { DataFreshnessBanner } from "@/components/DataFreshnessBanner";
-import { DashboardGenerateProgressDialog, type ProgressLine } from "@/components/DashboardGenerateProgressDialog";
+import { DashboardGenerateProgressDialog, type ProgressLine, inferKind } from "@/components/DashboardGenerateProgressDialog";
 import { ErrorDisplay } from "@/components/ErrorDisplay";
 import { isApiErrorResponse } from "@/lib/errors";
 import type { ApiErrorResponse } from "@/lib/errors";
@@ -177,10 +177,10 @@ export default function NewDashboard() {
         onMeta: (rid, lines) => {
           capturedRequestId = rid;
           setAgenticRequestId(rid);
-          setAgenticLines((prev) => [...prev, ...lines.map((text) => ({ text }))]);
+          setAgenticLines((prev) => [...prev, ...lines.map((text) => ({ text, kind: inferKind(text) as ProgressLine["kind"] }))]);
         },
         onLine: (line: GenerateProgressLine, replace) => {
-          const progressLine: ProgressLine = { text: line.text, body: line.body };
+          const progressLine: ProgressLine = { text: line.text, body: line.body, kind: inferKind(line.text) as ProgressLine["kind"] };
           setAgenticLines((prev) => {
             if (replace && prev.length > 0) {
               return [...prev.slice(0, -1), progressLine];

--- a/dashboard/components/ConversationsTable.tsx
+++ b/dashboard/components/ConversationsTable.tsx
@@ -387,10 +387,8 @@ export function ConversationsTable({
               const modeStyle = getModePillStyle(row.mode);
               const displayTitle =
                 row.title ??
-                (row.first_user_prompt
-                  ? row.first_user_prompt.slice(0, 60) +
-                    (row.first_user_prompt.length > 60 ? "…" : "")
-                  : "(sin título)");
+                row.first_user_prompt ??
+                "(sin título)";
 
               return (
                 <tr

--- a/dashboard/components/DashboardGenerateProgressDialog.tsx
+++ b/dashboard/components/DashboardGenerateProgressDialog.tsx
@@ -9,8 +9,10 @@ import { interactionLineClass } from "@/lib/interaction-line-class";
 
 /**
  * Infer a line `kind` from its raw text when no explicit kind is provided.
+ * Exported so callers can set kind when constructing ProgressLine objects,
+ * preserving tool-call / tool-result / error styling.
  */
-function inferKind(text: string): InteractionLine["kind"] {
+export function inferKind(text: string): InteractionLine["kind"] {
   const t = text.trim();
   if (t.startsWith("  →") || t.startsWith("→") || t.includes("Herramientas solicitadas")) {
     return "tool_call";
@@ -60,13 +62,23 @@ export function DashboardGenerateProgressDialog({
   const logRef = useRef<HTMLDivElement>(null);
   const userScrolledRef = useRef(false);
 
-  // Auto-scroll to bottom on each new line, unless user has scrolled up manually.
+  // Normalise lines so we always have ProgressLine[] — done before effects
+  // so lastLine is available for the auto-scroll dependency.
+  const normalised: ProgressLine[] = (lines as (string | ProgressLine)[]).map((l) =>
+    typeof l === "string" ? { kind: inferKind(l), text: l } : l,
+  );
+
+  // Auto-scroll to bottom on each new line or coalesced update, unless the
+  // user has scrolled up manually. The dependency on the last line's text and
+  // body ensures coalescing (same array length, content replaced) also
+  // triggers the scroll.
+  const lastLine = normalised[normalised.length - 1];
   useEffect(() => {
     const el = logRef.current;
     if (!el) return;
     if (userScrolledRef.current) return;
     el.scrollTop = el.scrollHeight;
-  }, [lines.length]);
+  }, [lines.length, lastLine?.text, lastLine?.body]);
 
   // Reset userScrolled when dialog opens.
   useEffect(() => {
@@ -81,11 +93,6 @@ export function DashboardGenerateProgressDialog({
     const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 8;
     userScrolledRef.current = !atBottom;
   };
-
-  // Normalise lines so we always have ProgressLine[]
-  const normalised: ProgressLine[] = (lines as (string | ProgressLine)[]).map((l) =>
-    typeof l === "string" ? { kind: inferKind(l), text: l } : l,
-  );
 
   return (
     <Dialog

--- a/dashboard/components/DashboardGenerateProgressDialog.tsx
+++ b/dashboard/components/DashboardGenerateProgressDialog.tsx
@@ -27,10 +27,12 @@ function inferKind(text: string): InteractionLine["kind"] {
 
 // ─── Component types ─────────────────────────────────────────────────────────
 
-/** A typed line with optional kind + text. Accepts plain string or typed object. */
+/** A typed line with optional kind + text + body. Accepts plain string or typed object. */
 export interface ProgressLine {
   kind?: InteractionLine["kind"];
   text: string;
+  /** Optional expanded body text (e.g. model reasoning/thinking content). */
+  body?: string;
 }
 
 export interface DashboardGenerateProgressDialogProps {
@@ -135,6 +137,26 @@ export function DashboardGenerateProgressDialog({
                   className={`whitespace-pre-wrap break-words ${interactionLineClass(line.kind)}`}
                 >
                   {line.text}
+                  {line.body && (
+                    <pre
+                      style={{
+                        marginTop: 4,
+                        marginLeft: 12,
+                        padding: "6px 8px",
+                        fontSize: 11,
+                        lineHeight: 1.5,
+                        fontFamily: "var(--font-jetbrains, monospace)",
+                        background: "var(--bg-2, rgba(0,0,0,0.15))",
+                        borderRadius: 4,
+                        whiteSpace: "pre-wrap",
+                        wordBreak: "break-word",
+                        color: "var(--fg-muted)",
+                        borderLeft: "2px solid var(--border)",
+                      }}
+                    >
+                      {line.body}
+                    </pre>
+                  )}
                 </div>
               ))
             )}

--- a/dashboard/lib/llm-provider/openrouter.ts
+++ b/dashboard/lib/llm-provider/openrouter.ts
@@ -214,23 +214,29 @@ export function createOpenRouterAgenticAdapter(client: OpenAI): AgenticModelAdap
         const delta = (chunk.choices[0]?.delta ?? {}) as Record<string, unknown>;
 
         // ── Reasoning / thinking tokens ─────────────────────────────────────
-        // OpenRouter surfaces reasoning in two ways:
-        //   1. delta.reasoning (string) — legacy field (DeepSeek R1, some others)
-        //   2. delta.reasoning_details (array of {type, text?, summary?}) —
-        //      structured form for Anthropic / OpenAI / Gemini reasoning models
-        const reasoningStr = typeof delta.reasoning === "string" ? delta.reasoning : "";
+        // OpenRouter surfaces reasoning in two formats. IMPORTANT: some models
+        // (e.g. claude-3-7-sonnet via OpenRouter) include BOTH fields on the
+        // same chunk, which would double the text. Always prefer one source:
+        //   • reasoning_details (structured array) when present — use it exclusively
+        //   • reasoning (legacy string) only as fallback when reasoning_details absent
         const reasoningDetails = Array.isArray(delta.reasoning_details)
           ? (delta.reasoning_details as Array<{ type?: string; text?: string; summary?: string }>)
           : [];
 
-        let thinkingChunk = reasoningStr;
-        for (const detail of reasoningDetails) {
-          if (detail.type === "reasoning.text" && typeof detail.text === "string") {
-            thinkingChunk += detail.text;
-          } else if (detail.type === "reasoning.summary" && typeof detail.summary === "string") {
-            thinkingChunk += detail.summary;
+        let thinkingChunk = "";
+        if (reasoningDetails.length > 0) {
+          // Structured form — extract text from each detail object
+          for (const detail of reasoningDetails) {
+            if (detail.type === "reasoning.text" && typeof detail.text === "string") {
+              thinkingChunk += detail.text;
+            } else if (detail.type === "reasoning.summary" && typeof detail.summary === "string") {
+              thinkingChunk += detail.summary;
+            }
+            // reasoning.encrypted: skip — opaque bytes / [REDACTED]
           }
-          // reasoning.encrypted: skip — opaque bytes / [REDACTED]
+        } else if (typeof delta.reasoning === "string" && delta.reasoning) {
+          // Legacy string field — only used when reasoning_details is absent
+          thinkingChunk = delta.reasoning;
         }
 
         if (thinkingChunk) {

--- a/dashboard/lib/run-dashboard-generate-stream.ts
+++ b/dashboard/lib/run-dashboard-generate-stream.ts
@@ -10,17 +10,21 @@ import {
   type ErrorCode,
 } from "@/lib/errors";
 
+/** A progress line emitted to the generate dialog. */
+export interface GenerateProgressLine {
+  text: string;
+  /** Thinking/reasoning body text to show expanded below the label line. */
+  body?: string;
+}
+
 export interface DashboardGenerateStreamHandlers {
   onMeta?: (requestId: string, lines: string[]) => void;
   /**
-   * Called with a new progress line to append to the log.
-   * Consecutive "Modelo respondiendo" / "Claude está razonando" ticks are
-   * coalesced — `replace=true` signals that the previous log entry should be
-   * updated in place rather than a new line added. If the caller does not
-   * support in-place replacement, it may ignore the flag and append anyway
-   * (the log will then show the last value rather than a count counter).
+   * Called with a progress line to append or update in the log.
+   * `replace=true` means update the last line in-place (coalescing).
+   * `body` carries thinking/reasoning text to render expanded below the label.
    */
-  onLine?: (line: string, replace?: boolean) => void;
+  onLine?: (line: GenerateProgressLine, replace?: boolean) => void;
 }
 
 /**
@@ -69,11 +73,11 @@ export async function runDashboardGenerateStream(
   // coalesceable ticks (model_text_delta / model_thinking_delta).
   let lastCoalescedLabel: string | null = null;
 
-  const emitLine = (line: string, coalesceable: boolean) => {
-    const label = coalesceable ? line.split(" · ")[0] ?? line : null;
+  const emitLine = (progressLine: GenerateProgressLine, coalesceable: boolean) => {
+    const label = coalesceable ? progressLine.text.split(" · ")[0] ?? progressLine.text : null;
     const replace = coalesceable && label !== null && label === lastCoalescedLabel;
     lastCoalescedLabel = coalesceable ? label : null;
-    handlers.onLine?.(line, replace);
+    handlers.onLine?.(progressLine, replace);
   };
 
   const processLine = (rawLine: string) => {
@@ -99,14 +103,21 @@ export async function runDashboardGenerateStream(
     if (msg.type === "progress" && msg.event) {
       const ev = msg.event as AgenticProgressEvent;
       const formatted = formatAgenticProgressLineEs(ev);
-      // Coalesce consecutive streaming ticks of the same label so the
-      // progress dialog shows one growing line rather than one per token.
+      // Coalesce consecutive streaming ticks of the same label.
       const coalesceable = COALESCEABLE_LABELS.has(formatted.split(" · ")[0] ?? "");
-      emitLine(formatted, coalesceable);
+      // For thinking events, pass the accumulated text as body so the dialog
+      // can render it expanded below the label line.
+      const body =
+        ev.type === "model_thinking_delta" && typeof ev.text === "string" && ev.text
+          ? ev.text
+          : ev.type === "model_text_delta" && typeof ev.text === "string" && ev.text
+            ? ev.text
+            : undefined;
+      emitLine({ text: formatted, body }, coalesceable);
     }
 
     if (msg.type === "phase" && typeof msg.message === "string") {
-      emitLine(String(msg.message), false);
+      emitLine({ text: String(msg.message) }, false);
     }
 
     if (msg.type === "result" && msg.spec) {


### PR DESCRIPTION
## Three bugs fixed

### Bug 1 — Thinking text doubled ("ElEl usuario usuario...")

OpenRouter sends BOTH `delta.reasoning` (legacy string) AND `delta.reasoning_details` (structured array) on the same chunk for some models (claude-3-7-sonnet, etc.). The previous code added both sources, doubling every word.

**Fix:** When `reasoning_details` is present use it exclusively; fall back to `delta.reasoning` only when `reasoning_details` is absent.

### Bug 2 — Conversations title column still shows "..." at 60 chars

`displayTitle` was JS-truncated to 60 chars with a hard-coded "…" before being passed to the CSS `text-overflow:ellipsis` anchor. The ellipsis fired at exactly 60 chars regardless of the available column width.

**Fix:** Pass the full text and let CSS handle truncation responsively.

### Bug 3 — Generate panel shows "Claude está razonando · N chars" instead of thinking text

The generate route streams raw `AgenticProgressEvent` objects, not `LogLine` objects with `body`. `formatAgenticProgressLineEs()` only returns a label+count string. The thinking text was discarded.

**Fix:**
- Add `body?: string` to `ProgressLine` in `DashboardGenerateProgressDialog` and render it as an expanded `<pre>` block below the label line
- Add `GenerateProgressLine` type to `run-dashboard-generate-stream.ts` with `text` + `body` fields
- Pass `ev.text` (thinking/response text) as `body` for `model_thinking_delta` and `model_text_delta` events
- Update `new/page.tsx` state from `string[]` to `ProgressLine[]` and thread `body` through

## Files changed

| File | Change |
|------|--------|
| `lib/llm-provider/openrouter.ts` | Prefer `reasoning_details` over `delta.reasoning` to avoid doubling |
| `components/ConversationsTable.tsx` | Remove 60-char JS truncation, let CSS handle it |
| `components/DashboardGenerateProgressDialog.tsx` | Add `body?: string` to `ProgressLine`, render expanded text |
| `lib/run-dashboard-generate-stream.ts` | New `GenerateProgressLine` type, pass thinking `body` |
| `app/dashboard/new/page.tsx` | State from `string[]` to `ProgressLine[]`, thread `body` |