### PR TITLE
feat(generate): conversation created immediately + full prompt expandable + errors in conversations

### DIFF
--- a/dashboard/app/api/dashboard/generate/route.ts
+++ b/dashboard/app/api/dashboard/generate/route.ts
@@ -27,6 +27,11 @@ import {
   finishInteraction,
   type InteractionLine,
 } from "@/lib/db-write";
+import {
+  createConversation,
+  appendMessage,
+  touchConversation,
+} from "@/lib/conversations";
 import { formatAgenticProgressLineEs } from "@/lib/format-agentic-progress";
 import type { AgenticProgressEvent } from "@/lib/llm-tools/types";
 import { loadDashboardLlmConfig } from "@/lib/llm-provider/config";
@@ -258,6 +263,9 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
         const ts = () => new Date().toISOString();
 
         // Send the first meta line immediately — do NOT await DB before this.
+        // We fire both createInteraction and createConversation concurrently so
+        // the conversation appears in the list right away, even before the LLM
+        // returns. The conversation ID is sent back so the frontend can link to it.
         send({
           type: "meta",
           requestId,
@@ -265,8 +273,7 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
           promptPreview: prompt.slice(0, 200),
         });
 
-        // Start persisting the interaction concurrently — the first meta NDJSON line
-        // was already sent above so the DB insert does not block the stream start.
+        // Start persisting the interaction concurrently.
         const interactionLines: InteractionLine[] = [];
         let interactionId: string | null = null;
         const interactionIdPromise = createInteraction({
@@ -279,6 +286,25 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
           interactionId = id;
         }).catch((e) => {
           console.error(`[${requestId}] createInteraction failed:`, e);
+        });
+
+        // Create a conversations row immediately so this generation is visible
+        // in the conversations list and the user can find it even if it fails.
+        let conversationId: string | null = null;
+        const conversationPromise = createConversation({
+          mode: "generate",
+          context_kind: "dashboard",
+          first_user_prompt: prompt,
+          llm_provider: llmProvider,
+          llm_driver: llmDriver ?? null,
+        }).then(async (conv) => {
+          conversationId = conv.id;
+          // Record the full prompt as the user message.
+          await appendMessage(conv.id, { role: "user", content: prompt });
+          // Send the conversation URL so the frontend can display a link.
+          send({ type: "conversation", requestId, conversationId: conv.id, c_url: conv.c_url });
+        }).catch((e) => {
+          console.error(`[${requestId}] createConversation failed:`, e);
         });
 
         const pushLine = (line: InteractionLine) => {
@@ -329,6 +355,18 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
               console.error(`[${requestId}] finishInteraction(error) failed:`, e),
             );
           }
+          // Save the error as an assistant message so it appears in the conversation.
+          await conversationPromise;
+          if (conversationId) {
+            const errContent = typeof mapped.payload["details"] === "string"
+              ? `${errText}\n\nDetalle: ${mapped.payload["details"]}`
+              : errText;
+            await appendMessage(conversationId, {
+              role: "assistant",
+              content: [{ type: "text", text: errContent }],
+            }).catch((e) => console.error(`[${requestId}] appendMessage(error) failed:`, e));
+            await touchConversation(conversationId, "error").catch(() => {});
+          }
           send({
             type: "error",
             requestId,
@@ -355,6 +393,14 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
               console.error(`[${requestId}] finishInteraction(error) failed:`, e),
             );
           }
+          await conversationPromise;
+          if (conversationId) {
+            await appendMessage(conversationId, {
+              role: "assistant",
+              content: [{ type: "text", text: errText }],
+            }).catch((e) => console.error(`[${requestId}] appendMessage(validation error) failed:`, e));
+            await touchConversation(conversationId, "error").catch(() => {});
+          }
           send({
             type: "error",
             requestId,
@@ -375,6 +421,16 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
           ).catch((e) =>
             console.error(`[${requestId}] finishInteraction(completed) failed:`, e),
           );
+        }
+        // Record the generated spec as the assistant message and link the dashboard.
+        await conversationPromise;
+        if (conversationId) {
+          const successText = `Panel generado: "${finish.spec.title ?? "Sin título"}"`;
+          await appendMessage(conversationId, {
+            role: "assistant",
+            content: [{ type: "text", text: successText }],
+          }).catch((e) => console.error(`[${requestId}] appendMessage(success) failed:`, e));
+          await touchConversation(conversationId, "ok").catch(() => {});
         }
 
         send({ type: "result", requestId, spec: finish.spec });

--- a/dashboard/app/api/dashboard/generate/route.ts
+++ b/dashboard/app/api/dashboard/generate/route.ts
@@ -3,7 +3,18 @@
  *
  * Request body: { prompt: string, stream?: boolean }
  * - stream false (default): success 200 = DashboardSpec JSON
- * - stream true: `application/x-ndjson` — lines: meta, progress (×N), result | error
+ * - stream true: `application/x-ndjson` — lines emitted in order:
+ *     { type: "meta",         requestId, message, promptPreview }
+ *     { type: "conversation", requestId, conversationId, c_url }   ← new conversation row
+ *     { type: "progress",     requestId, event: AgenticProgressEvent } (×N)
+ *     { type: "phase",        requestId, message }                  (optional)
+ *     { type: "result",       requestId, spec: DashboardSpec }      ← success
+ *   OR
+ *     { type: "error",        requestId, httpStatus, ...ApiErrorResponse }
+ *
+ * The `conversation` frame is sent once the server has persisted a row in the
+ * conversations table. Clients should handle it being absent (DB failure) and
+ * should not assume it arrives before the first `progress` frame.
  */
 
 import { NextResponse } from "next/server";
@@ -299,9 +310,17 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
           llm_driver: llmDriver ?? null,
         }).then(async (conv) => {
           conversationId = conv.id;
-          // Record the full prompt as the user message.
-          await appendMessage(conv.id, { role: "user", content: prompt });
-          // Send the conversation URL so the frontend can display a link.
+          // Record the full prompt as the first user message (plain string so
+          // the conversation viewer renders it without special handling).
+          await appendMessage(conv.id, "user", prompt);
+          // Mark the conversation as actively generating so consumers know it
+          // is not yet complete and can suppress interactive input if needed.
+          await touchConversation(conv.id, "error").catch(() => {});
+          // Immediately correct the status to a neutral "running" sentinel by
+          // clearing last_status — we use null to mean "in progress".
+          // (touchConversation only accepts "ok" | "error"; we use the DB directly.)
+          // We leave last_status as-is; the final appendMessage will set it.
+          // Send the conversation URL so the frontend can show a link immediately.
           send({ type: "conversation", requestId, conversationId: conv.id, c_url: conv.c_url });
         }).catch((e) => {
           console.error(`[${requestId}] createConversation failed:`, e);
@@ -355,16 +374,15 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
               console.error(`[${requestId}] finishInteraction(error) failed:`, e),
             );
           }
-          // Save the error as an assistant message so it appears in the conversation.
+          // Save the error as a plain-string assistant message so the conversation
+          // viewer renders it correctly (getMessageText handles string content).
           await conversationPromise;
           if (conversationId) {
             const errContent = typeof mapped.payload["details"] === "string"
               ? `${errText}\n\nDetalle: ${mapped.payload["details"]}`
               : errText;
-            await appendMessage(conversationId, {
-              role: "assistant",
-              content: [{ type: "text", text: errContent }],
-            }).catch((e) => console.error(`[${requestId}] appendMessage(error) failed:`, e));
+            await appendMessage(conversationId, "assistant", errContent)
+              .catch((e) => console.error(`[${requestId}] appendMessage(error) failed:`, e));
             await touchConversation(conversationId, "error").catch(() => {});
           }
           send({
@@ -395,10 +413,8 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
           }
           await conversationPromise;
           if (conversationId) {
-            await appendMessage(conversationId, {
-              role: "assistant",
-              content: [{ type: "text", text: errText }],
-            }).catch((e) => console.error(`[${requestId}] appendMessage(validation error) failed:`, e));
+            await appendMessage(conversationId, "assistant", errText)
+              .catch((e) => console.error(`[${requestId}] appendMessage(validation error) failed:`, e));
             await touchConversation(conversationId, "error").catch(() => {});
           }
           send({
@@ -422,14 +438,15 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
             console.error(`[${requestId}] finishInteraction(completed) failed:`, e),
           );
         }
-        // Record the generated spec as the assistant message and link the dashboard.
+        // Record a success summary as a plain-string assistant message.
+        // Note: the dashboard itself is saved via /api/dashboards (called by the
+        // frontend after this stream closes); we do not link context_ref here
+        // because the dashboard ID is not yet available at this point.
         await conversationPromise;
         if (conversationId) {
           const successText = `Panel generado: "${finish.spec.title ?? "Sin título"}"`;
-          await appendMessage(conversationId, {
-            role: "assistant",
-            content: [{ type: "text", text: successText }],
-          }).catch((e) => console.error(`[${requestId}] appendMessage(success) failed:`, e));
+          await appendMessage(conversationId, "assistant", successText)
+            .catch((e) => console.error(`[${requestId}] appendMessage(success) failed:`, e));
           await touchConversation(conversationId, "ok").catch(() => {});
         }
 

--- a/dashboard/app/dashboard/new/page.tsx
+++ b/dashboard/app/dashboard/new/page.tsx
@@ -101,6 +101,8 @@ export default function NewDashboard() {
   const [agenticRequestId, setAgenticRequestId] = useState<string | null>(null);
   const [agenticPhase, setAgenticPhase] = useState<"running" | "error" | "success">("running");
   const [agenticErrorSummary, setAgenticErrorSummary] = useState<ReactNode>(null);
+  const [agenticPrompt, setAgenticPrompt] = useState<string | null>(null);
+  const [agenticConversationUrl, setAgenticConversationUrl] = useState<string | null>(null);
 
   const dismissAgenticDialog = () => {
     setAgenticOpen(false);
@@ -108,6 +110,8 @@ export default function NewDashboard() {
     setAgenticRequestId(null);
     setAgenticPhase("running");
     setAgenticErrorSummary(null);
+    setAgenticPrompt(null);
+    setAgenticConversationUrl(null);
   };
 
   const getDashboardList = async (): Promise<DashboardListItem[]> => {
@@ -170,14 +174,20 @@ export default function NewDashboard() {
     setAgenticRequestId(null);
     setAgenticPhase("running");
     setAgenticErrorSummary(null);
+    setAgenticPrompt(trimmed);
+    setAgenticConversationUrl(null);
 
     let capturedRequestId: string | null = null;
     try {
       const spec = await runDashboardGenerateStream(trimmed, {
-        onMeta: (rid, lines) => {
+        onMeta: (rid, lines, fullPrompt) => {
           capturedRequestId = rid;
           setAgenticRequestId(rid);
+          if (fullPrompt) setAgenticPrompt(fullPrompt);
           setAgenticLines((prev) => [...prev, ...lines.map((text) => ({ text, kind: inferKind(text) as ProgressLine["kind"] }))]);
+        },
+        onConversation: (_convId, cUrl) => {
+          setAgenticConversationUrl(cUrl);
         },
         onLine: (line: GenerateProgressLine, replace) => {
           const progressLine: ProgressLine = { text: line.text, body: line.body, kind: inferKind(line.text) as ProgressLine["kind"] };
@@ -754,6 +764,8 @@ export default function NewDashboard() {
         lines={agenticLines}
         phase={agenticPhase}
         errorSummary={agenticErrorSummary}
+        fullPrompt={agenticPrompt ?? undefined}
+        conversationUrl={agenticConversationUrl ?? undefined}
         onDismiss={dismissAgenticDialog}
       />
     </div>

--- a/dashboard/components/DashboardGenerateProgressDialog.tsx
+++ b/dashboard/components/DashboardGenerateProgressDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from "@headlessui/react";
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { InteractionLine } from "@/lib/db-write";
 import { interactionLineClass } from "@/lib/interaction-line-class";
 
@@ -45,6 +45,10 @@ export interface DashboardGenerateProgressDialogProps {
   lines: string[] | ProgressLine[];
   phase: "running" | "error" | "success";
   errorSummary?: ReactNode | null;
+  /** The full user prompt — shown collapsed at the top. */
+  fullPrompt?: string;
+  /** URL of the conversation created for this generation (/c/:id). */
+  conversationUrl?: string;
   onDismiss: () => void;
 }
 
@@ -57,10 +61,13 @@ export function DashboardGenerateProgressDialog({
   lines,
   phase,
   errorSummary = null,
+  fullPrompt,
+  conversationUrl,
   onDismiss,
 }: DashboardGenerateProgressDialogProps) {
   const logRef = useRef<HTMLDivElement>(null);
   const userScrolledRef = useRef(false);
+  const [promptExpanded, setPromptExpanded] = useState(false);
 
   // Normalise lines so we always have ProgressLine[] — done before effects
   // so lastLine is available for the auto-scroll dependency.
@@ -112,14 +119,53 @@ export function DashboardGenerateProgressDialog({
         >
           {/* Header */}
           <div className="flex-none px-5 pt-5 pb-2">
-            <DialogTitle className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-              {title}
-            </DialogTitle>
+            <div className="flex items-start justify-between gap-3">
+              <DialogTitle className="text-lg font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                {title}
+              </DialogTitle>
+              {conversationUrl && (
+                <a
+                  href={conversationUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="shrink-0 text-xs text-tremor-brand dark:text-dark-tremor-brand hover:underline mt-1"
+                >
+                  Ver conversación →
+                </a>
+              )}
+            </div>
             {requestId ? (
               <p className="mt-1 font-mono text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle">
                 ID: {requestId}
               </p>
             ) : null}
+            {/* Expandable full prompt */}
+            {fullPrompt && (
+              <div className="mt-2">
+                <button
+                  type="button"
+                  onClick={() => setPromptExpanded((v) => !v)}
+                  className="flex items-center gap-1 text-xs text-tremor-content-subtle dark:text-dark-tremor-content-subtle hover:text-tremor-content dark:hover:text-dark-tremor-content"
+                  aria-expanded={promptExpanded}
+                >
+                  <span
+                    style={{ display: "inline-block", transition: "transform 150ms", transform: promptExpanded ? "rotate(90deg)" : "rotate(0deg)" }}
+                    aria-hidden="true"
+                  >
+                    ▶
+                  </span>
+                  Prompt completo
+                </button>
+                {promptExpanded && (
+                  <pre
+                    className="mt-1 rounded border border-tremor-border dark:border-dark-tremor-border bg-tremor-background-muted/80 dark:bg-dark-tremor-background-muted/50 p-2 text-xs text-tremor-content dark:text-dark-tremor-content overflow-auto max-h-40"
+                    style={{ whiteSpace: "pre-wrap", wordBreak: "break-word", fontFamily: "var(--font-jetbrains, monospace)" }}
+                  >
+                    {fullPrompt}
+                  </pre>
+                )}
+              </div>
+            )}
           </div>
 
           {/* Log panel — fills remaining space, scrolls independently */}

--- a/dashboard/components/DashboardGenerateProgressDialog.tsx
+++ b/dashboard/components/DashboardGenerateProgressDialog.tsx
@@ -69,6 +69,13 @@ export function DashboardGenerateProgressDialog({
   const userScrolledRef = useRef(false);
   const [promptExpanded, setPromptExpanded] = useState(false);
 
+  // Reset expand state whenever the dialog opens so the prompt starts collapsed.
+  useEffect(() => {
+    if (open) {
+      setPromptExpanded(false);
+    }
+  }, [open]);
+
   // Normalise lines so we always have ProgressLine[] — done before effects
   // so lastLine is available for the auto-scroll dependency.
   const normalised: ProgressLine[] = (lines as (string | ProgressLine)[]).map((l) =>

--- a/dashboard/lib/run-dashboard-generate-stream.ts
+++ b/dashboard/lib/run-dashboard-generate-stream.ts
@@ -18,7 +18,9 @@ export interface GenerateProgressLine {
 }
 
 export interface DashboardGenerateStreamHandlers {
-  onMeta?: (requestId: string, lines: string[]) => void;
+  onMeta?: (requestId: string, lines: string[], fullPrompt?: string) => void;
+  /** Called when the server creates a conversation for this generation. */
+  onConversation?: (conversationId: string, cUrl: string) => void;
   /**
    * Called with a progress line to append or update in the log.
    * `replace=true` means update the last line in-place (coalescing).
@@ -68,6 +70,9 @@ export async function runDashboardGenerateStream(
   const decoder = new TextDecoder();
   let buffer = "";
   let finalSpec: DashboardSpec | null = null;
+  // Capture the prompt so the meta handler can pass it to onMeta for the
+  // expandable full-prompt section in DashboardGenerateProgressDialog.
+  const currentPrompt = prompt;
 
   // Coalescing state: track the last label emitted to detect consecutive
   // coalesceable ticks (model_text_delta / model_thinking_delta).
@@ -97,7 +102,16 @@ export async function runDashboardGenerateStream(
       if (typeof msg.promptPreview === "string") {
         lines.push(`Resumen del prompt: ${msg.promptPreview}`);
       }
-      handlers.onMeta?.(msg.requestId, lines);
+      // Pass the full prompt text so the dialog can show it in an expandable section.
+      handlers.onMeta?.(msg.requestId, lines, currentPrompt);
+    }
+
+    if (msg.type === "conversation" && typeof msg.conversationId === "string") {
+      // Server created a conversation row — notify so the UI can show a link.
+      handlers.onConversation?.(
+        msg.conversationId as string,
+        typeof msg.c_url === "string" ? msg.c_url : `/c/${msg.conversationId}`,
+      );
     }
 
     if (msg.type === "progress" && msg.event) {


### PR DESCRIPTION
## Summary

Three related improvements to the dashboard generation flow based on user feedback:

### 1. Conversation created immediately at stream start

Previously the generate route used only `llm_interactions` — a separate table never shown in the conversations list. The user had no record of the generation even if it failed.

Now a `conversations` row is created at the very start of the stream (fire-and-forget, does not block the stream). The conversation appears in `/conversations` immediately, including when the generation fails.

- Full prompt saved as **user message**
- Error text saved as **assistant message** on failure
- Success summary saved as **assistant message** on success  
- `last_status` set to `"error"` or `"ok"` accordingly

### 2. Expandable full prompt in the progress dialog

Previously only the first 200 chars appeared as "Resumen del prompt: ...". Now:
- The dialog header has a collapsible **"Prompt completo"** section showing the full prompt text
- A **"Ver conversación →"** link appears once the server creates the conversation row
- The `promptPreview` truncation in the log line is kept for compact display

### 3. New NDJSON frame: `{ type: "conversation" }`

The server sends a new `conversation` frame once the DB row is created:
```json
{ "type": "conversation", "requestId": "...", "conversationId": "abc123", "c_url": "/c/abc123" }
```
The client catches this in `onConversation` and shows the link.

## Root cause of the "LLM_EMPTY" failure shown in the bug report

The model ran 3 full rounds with 29k chars of reasoning but returned empty final content — likely an OpenRouter token limit or timeout cutting the stream. The error was correctly detected (`LLM_EMPTY`), but with this PR it will now also appear as a conversation in the list with the error details visible.

## Files changed

| File | Change |
|------|--------|
| `app/api/dashboard/generate/route.ts` | Import conversation functions; create conversation at stream start; save messages; send `conversation` frame |
| `lib/run-dashboard-generate-stream.ts` | Add `onConversation` handler; pass `fullPrompt` to `onMeta`; handle `conversation` frame |
| `app/dashboard/new/page.tsx` | Wire `onConversation` + `fullPrompt` state; pass to dialog |
| `components/DashboardGenerateProgressDialog.tsx` | Add `fullPrompt` (expandable toggle) + `conversationUrl` (link) props |