### PR TITLE
PR 3 of #625: trim AGENTS.md + ARCHITECTURE.md, extract reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,48 +45,17 @@ This is a **public repository** -- no credentials, customer data, or business-sp
 
 ## Unified CLI (`ps`)
 
-Single entry point for all operations. **Usage:** `ps <group> [subcommand] [options]`
+Single entry point for all operations. **Usage:** `ps <group> [subcommand] [options]`. Full command list in [docs/cli-reference.md](docs/cli-reference.md).
 
-| Command | Purpose |
-|---------|---------|
-| `ps setup` | First-time setup: create .env and repo symlink |
-| `ps setup check` | Verify prerequisites (Docker, .env, connectivity) |
-| `ps stack up` | Start all containers |
-| `ps stack down` | Stop all containers |
-| `ps stack restart` | Restart all containers |
-| `ps stack update` | Pull latest, rebuild images, restart stack |
-| `ps stack status` | Show container status and WrenAI UI health |
-| `ps stack logs [svc]` | Show logs (follow); optional service name |
-| `ps stack open` | Open WrenAI UI in browser |
-| `ps stack destroy` | Stop containers and remove volumes (with confirmation) |
-| `ps etl run` | Run ETL sync once (also triggerable via the Dashboard ETL Monitor "Sincronizar ahora" button → `POST /api/etl/run`) |
-| `ps etl status` | Show watermark table (last sync per table) |
-| `ps etl tables` | Show row counts for synced tables |
-| `ps etl logs` | Show ETL container logs |
-| `ps sql tables` | List all 4D tables |
-| `ps sql describe <table>` | Show columns for a table |
-| `ps sql query "<SQL>"` | Run a read-only SQL query |
-| `ps sql sample <table> [n]` | Show n sample rows |
-| `ps sql count <table>` | Row count for a table |
-| `ps wren push` | Push source knowledge to WrenAI (47 instructions, 56 SQL pairs — loaded from source MDs) |
-| `ps wren validate` | Validate all SQL pairs against PostgreSQL mirror |
-| `ps wren status` | Show instruction and SQL pair counts |
-| `ps dashboard open` | Open Dashboard App in browser |
-| `ps dashboard logs` | Show dashboard container logs |
-| `ps dashboard restart` | Restart the dashboard container |
-| `ps dashboard status` | Show dashboard container status |
-| `ps prod deploy` | Pull latest Docker Hub images on prod and restart the stack |
-| `ps prod update` | Full update: download new compose/config from latest GitHub release + deploy |
-| `ps prod restart [svc]` | Restart all services on prod, or a named one |
-| `ps prod status` | Container status + version + health checks + token state |
-| `ps prod logs [svc]` | Tail prod logs (follow); optional service |
-| `ps prod version` | Show the version running on prod |
-| `ps prod health` | Run health checks against all prod services |
-| `ps prod push-config` | Upload local wren-config.yaml to prod and restart wren-ai-service |
-| `ps prod token-status` | Show prod's Claude OAuth access-token expiry hours |
-| `ps prod login` | Interactive `ssh -t` to run `claude /login` on prod |
-| `ps prod ssh` | Open a shell on prod |
-| `ps config` | Show loaded configuration |
+**Groups (skim by these to find the right command):**
+- `setup` — first-time setup + prerequisite checks
+- `stack` — start/stop/restart/status/logs for the full Docker Compose stack
+- `etl` — run nightly sync once, watermark status, table row counts, logs
+- `sql` — read-only queries against the 4D source (list/describe/query/sample/count)
+- `wren` — push knowledge, validate SQL pairs, show counts
+- `dashboard` — open/logs/restart/status for the Dashboard container
+- `prod` — operate the production Mac over SSH (deploy, update, restart, health, login, ssh)
+- `config` — show loaded configuration
 
 ### CLI-first principle
 
@@ -477,144 +446,9 @@ The diagrams in that section reflect the post-#517/#518/#519 behaviour: implemen
 
 ## Issue and PR format
 
-All GitHub issues in this project follow a single standard format. When creating issues, always use this template exactly.
+All GitHub issues in this project follow a single standard format. Full template + worktree workflow + PR/review policy + phase labels + planner phasing rules: **[docs/issue-format.md](docs/issue-format.md)**.
 
-### Issue template
-
-```markdown
-# <Feature name>
-
-## Context
-- **Problem**: <what's wrong / missing; why it matters>
-- **Worktree**: <required: git worktree name for isolated execution, e.g. `wren-p1-compose`>
-- **Scope**: <what is in / out of scope>
-- **Constraints**: <perf, compatibility, no-breaking-changes, deps, etc.>
-- **Repo touchpoints**: <files/dirs likely involved, commands, datasets impacted>
-- **Definition of done**: <e.g., builds + tests pass; feature-specific checks>
-- **How is it going to be tested**: <testing strategy and specific test cases>
-
-## Tasks
-- [ ] 1) <task title> (owner: agent)
-  - **Change**: <precise behavior or code change>
-  - **Files**: <exact file paths>
-  - **Acceptance**: <how to verify; exact commands and expected output>
-  - **Spec update**: mark done + update remaining tasks/context as needed
-
-- [ ] 2) ... (owner: agent)
-
-- [ ] N-1) Run all checks and fix issues (owner: agent)
-  - **Change**: Run all tests, linting, type-checking, and formatting; fix any failures
-  - **Files**: any files with issues
-  - **Acceptance**: `docker compose run --rm etl python -m pytest && python -m ruff check etl/ && python -m mypy etl/`
-  - **Spec update**: mark done
-
-- [ ] N-1b) Copilot review (owner: agent, **one round only**)
-  - **Change**: Request a Copilot review, address all feedback, then stop. Do **not** re-request Copilot.
-  - **How**: `gh pr create`, then request Copilot review via REST API: `gh api repos/{owner}/{repo}/pulls/{PR#}/requested_reviewers --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'`. Poll for review: `gh api repos/{owner}/{repo}/pulls/{PR#}/reviews --jq '[.[] | {state, user: .user.login, body}]'`. Address all comments with inline replies.
-  - **Acceptance**: Copilot review arrived, every comment has either a code change or a reply explaining why it does not apply. No second Copilot round.
-  - **Spec update**: mark done
-
-- [ ] N-1c) Opus review (owner: agent, **one round only, clean context**)
-  - **Change**: Run a single Opus review of the PR **from a fresh context** (new session, no implementation history), address all feedback, then stop.
-  - **How**: Start a new Claude Code session with no prior conversation about this PR and invoke the PR review flow on this PR number. Reply inline to every comment; apply the fixes that are correct.
-  - **Acceptance**: Opus review completed; every comment has either a code change or a reply. No second Opus round.
-  - **Spec update**: mark done
-
-- [ ] N) Create commit (owner: agent)
-  - **Change**: Stage all changes and create a descriptive commit
-  - **Files**: none (git operation)
-  - **Acceptance**: `git status` shows clean working tree; `git log -1` shows the new commit
-  - **Spec update**: mark done
-
-## Additional Context
-<append-only notes: discoveries, links, decisions, gotchas found during execution>
-```
-
-### Worktree workflow
-
-Each issue specifies a **worktree name**. Before starting work:
-```bash
-git worktree add ../<repo>-<worktree-name> -b <worktree-name>
-cd ../<repo>-<worktree-name>
-```
-Work in the worktree. When done, PR is merged and worktree is removed:
-```bash
-git worktree remove ../<repo>-<worktree-name>
-```
-
-### PR and review policy
-
-Every PR gets **exactly two review rounds, in order, each run only once**:
-
-1. **One Copilot review** (bot).
-2. **One Opus review**, started from a **clean context** (fresh Claude Code session with no prior history about this PR or its implementation).
-
-After each round: address every comment with either a code change or an inline reply, then move on. **Do not re-request the same reviewer.** Iterating "until there are no comments" is no longer the policy — it was too much. If a later round surfaces a genuinely blocking issue, use judgement and escalate to the human owner rather than looping.
-
-Rules:
-- Every piece of work goes through a PR, even solo work.
-- **Round 1 — Copilot.** Request via the REST API:
-  ```bash
-  gh api repos/{owner}/{repo}/pulls/{PR#}/requested_reviewers \
-    --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
-  ```
-  Do NOT use `gh pr review --request copilot` (doesn't work) or `gh pr edit --add-reviewer copilot` (can't resolve bot users). The REST API with `copilot-pull-request-reviewer[bot]` is the only working CLI method.
-  - **From GitHub Actions**, the default `GITHUB_TOKEN` **cannot** assign `copilot-pull-request-reviewer[bot]` — the API returns 200 but with an empty `requested_reviewers` array. Workflows must use a PAT stored in the repo secret `COPILOT_PAT` (fine-grained PAT, scope `Pull requests: Read and write`). Pattern:
-    ```bash
-    GH_TOKEN="$COPILOT_PAT" gh api repos/{owner}/{repo}/pulls/{PR#}/requested_reviewers \
-      --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
-    ```
-    Always verify the response contains `Copilot` in `requested_reviewers` before claiming the review was requested.
-  - Poll for the review: `gh api repos/{owner}/{repo}/pulls/{PR#}/reviews --jq '[.[] | {state, user: .user.login, body}]'`.
-  - Address every comment with a code change or inline reply. **One round only — do not re-request Copilot.**
-- **Round 2 — Opus, clean context.** Start a new Claude Code session (no prior conversation about this PR or the branch) and run the PR review flow on this PR number. Reply inline to every comment; apply the correct fixes. **One round only — do not re-request Opus.**
-- **Merge** after both rounds are done and every comment has a change or a reply. Unresolved disagreement → flag to the human owner; don't start a third round to paper over it.
-
-### Phase labels and execution order
-
-Issues are labelled by phase: `phase-1`, `phase-2`, ..., `phase-6`.
-
-**Execution rules for unattended agents:**
-- Phase 1 is sequential: P1-A then P1-B.
-- Phases 2+3 sync issues are independent of each other — run in batches of 2-3 after P1-B merges. Each sync issue only creates `etl/sync/<module>.py` + tests. **None touch `etl/main.py`** — P4 owns that file.
-- Phase 4 (scheduler) wires all sync modules into `main.py` and runs the first full data load. Requires all sync PRs merged.
-- Phase 5 (WrenAI MDL) requires P4 complete (data must be in PostgreSQL).
-- Phase 6 (docs) requires P5 complete.
-
-### Planner phasing rules (mandatory for all decompositions)
-
-These rules apply to **every** planning session, not just the ETL epic above. The planner must apply them before finalising any sub-issue decomposition.
-
-#### Q1 — When to produce phases (trigger conditions)
-
-Phases are **mandatory** when any two sub-issues share any of the following:
-
-1. **Shared source file** — the same path appears in the `Files:` section of two sub-issues (especially `dashboard/lib/*.ts`, `dashboard/components/`, `etl/schema/init.sql`, shared hooks/types).
-2. **Shared DB table** — any two sub-issues `CREATE`, `ALTER`, or heavily write to the same table. Schema DDL is the highest-risk overlap.
-3. **Shared HTTP route family** — any two sub-issues add or modify routes under the same prefix (e.g. `/api/conversations/*`).
-4. **Producer/consumer dependency** — one sub-issue defines a shape that another reads. Classic chain: data layer → API route → UI component. The consumer cannot correctly implement against a shape that isn't merged yet.
-
-When **none** of the above apply, sub-issues may run in parallel.
-
-#### Q2 — Serialisation unit
-
-**Phase = a batch of sub-issues that share no files, tables, or contracts.** Within a phase, sub-issues run concurrently (existing worker behaviour). Between phases: all PRs from phase N must be **merged and `main` must be green** before any phase N+1 sub-issue receives `ai-work`.
-
-Phase N+1 sub-issues are created with the `ai-task` label but **without** `ai-work`. The owner adds `ai-work` once all phase N PRs are merged.
-
-#### Q3 — Enforcement rule for the planner
-
-After listing sub-issues, the planner must:
-
-1. For each pair (A, B) assigned to the same phase: check all four Q1 conditions:
-   - **File overlap**: is `Files(A) ∩ Files(B)` non-empty (string intersection on the `Files:` lines)?
-   - **DB table overlap**: do both touch (CREATE/ALTER/write) the same table?
-   - **Route prefix overlap**: do both add or modify routes under the same HTTP prefix?
-   - **Producer/consumer chain**: does A define a shape or contract that B reads?
-2. If **any** of the above is true: move B to the next phase; document the reason in the plan comment.
-3. Include a **dependency table** in the plan comment showing which sub-issues are in each phase and the reason for any serialisation.
-
-#### Phase labeling
-
-- Use `phase-1`, `phase-2`, ... labels on sub-issues to indicate which batch they belong to.
-- In the plan comment, include a dependency table with columns: Phase | Sub-issue | Files | Reason for phase assignment.
+**Short summary** (the rules that bind everyone):
+- Every PR gets **exactly two review rounds**, each once: Copilot first, then Opus from a clean context. No third round; escalate to the human owner if blocked. See [D-021](docs/decisions/D-021-two-review-rounds.md).
+- Each issue uses the standard template (Context / Tasks / Additional Context) and is opened against a named **worktree**.
+- Sub-issues are batched into **phases** when they share a file, DB table, HTTP route prefix, or producer/consumer dependency. Between phases: all PRs merged + `main` green before phase N+1 sub-issues get `ai-work`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,41 +9,9 @@ PowerShop Analytics is a platform that extracts data from a vendor-managed Power
 1. **WrenAI** — Ad-hoc single-question text-to-SQL (e.g., "¿Cuánto vendimos ayer?")
 2. **Dashboard App** — AI-generated multi-widget dashboards from natural language (e.g., "Créame un cuadro de mandos para el responsable de ventas")
 
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│ Data Source                                                             │
-│   4D Server (10.0.1.35)                                                 │
-│     ├── P4D SQL :19812  ─┐                                              │
-│     └── SOAP :8080       │                                              │
-└──────────────────────────┼──────────────────────────────────────────────┘
-                           │ ETL (nightly)
-┌──────────────────────────▼──────────────────────────────────────────────┐
-│ Docker Compose Stack                                                    │
-│                                                                         │
-│  ┌─────────────┐     ┌──────────────────┐     ┌─────────────────────┐  │
-│  │  ETL Python  │────▶│  PostgreSQL       │◄────│  Dashboard App      │  │
-│  │  (nightly)  │     │  18M+ rows        │     │  (Next.js+Tremor)   │  │
-│  └─────────────┘     │  ps_* tables      │     │  :4000              │  │
-│                      │  dashboard_* tbls │     └────────┬────────────┘  │
-│                      └────────┬─────────┘              │               │
-│                               │                         │               │
-│  ┌────────────────────────────┼─────────────────────────┼────────────┐  │
-│  │  WrenAI Stack              │                         │            │  │
-│  │   ├── wren-ui :3000 ───────┘                         │            │  │
-│  │   ├── wren-ai-service :5555                          │            │  │
-│  │   ├── wren-engine                         OpenRouter │            │  │
-│  │   ├── ibis-server                         (Claude)   │            │  │
-│  │   └── qdrant                                  ▲      │            │  │
-│  └───────────────────────────────────────────────┼──────┘            │  │
-│                                                  │                    │  │
-└──────────────────────────────────────────────────┼────────────────────┘  │
-                                                   │                       │
-                                        ┌──────────▼───────────┐          │
-                                        │  OpenRouter API       │          │
-                                        │  Claude Sonnet 4      │          │
-                                        │  text-embedding-3-lg  │          │
-                                        └──────────────────────┘          │
-```
+**Flow at a glance:** 4D Server (SQL `:19812` / SOAP `:8080`) → ETL (Python, nightly) → PostgreSQL mirror (`ps_*` tables, 18M+ rows) → consumed by both the WrenAI stack (wren-ui `:3000`, wren-ai-service `:5555`, wren-engine, ibis-server, qdrant) and the Dashboard App (Next.js + Tremor on `:4000`). Both LLM paths call OpenRouter (Claude Sonnet 4 + text-embedding-3-large).
+
+Full ASCII diagram in [docs/architecture/overview.md](docs/architecture/overview.md).
 
 ## Components
 
@@ -79,101 +47,15 @@ PowerShop Analytics is a platform that extracts data from a vendor-managed Power
 
 #### Dashboard App Architecture
 
-```
-┌───────────────────────────────────────────────────────┐
-│  Browser                                              │
-│                                                       │
-│  ┌─────────────────┐  ┌───────────────────────────┐  │
-│  │  Dashboard View  │  │  Chat Sidebar             │  │
-│  │                  │  │                            │  │
-│  │  ┌──────────┐   │  │  User: "Créame un cuadro  │  │
-│  │  │ KPI Row  │   │  │   de mandos para ventas"  │  │
-│  │  ├──────────┤   │  │                            │  │
-│  │  │ Bar Chart│   │  │  AI: "He creado un panel   │  │
-│  │  ├──────────┤   │  │   con 6 widgets..."        │  │
-│  │  │ Table    │   │  │                            │  │
-│  │  └──────────┘   │  │  User: "Añade el margen"  │  │
-│  │                  │  │                            │  │
-│  └─────────────────┘  └───────────────────────────┘  │
-└───────────────────────────┬───────────────────────────┘
-                            │ REST API
-┌───────────────────────────▼───────────────────────────┐
-│  Next.js API Routes                                   │
-│                                                       │
-│  POST /api/dashboard/generate  ← prompt → LLM (+ tools) → spec │
-│  POST /api/dashboard/modify    ← prompt + spec → LLM (+ tools) │
-│  POST /api/dashboard/analyze   ← spec + widget data → LLM (+ tools) │
-│  POST /api/query               ← SQL → PG → data     │
-│  GET  /api/dashboard/:id       ← load saved spec      │
-│  POST /api/dashboard/:id/save  ← persist spec         │
-│  GET  /api/dashboards          ← list all             │
-└───────────────────────────────────────────────────────┘
-```
+**Flow:** Browser (Dashboard view + Chat sidebar) → Next.js API routes. The agentic flows (`generate`, `modify`, `analyze`) call the LLM with read-only SQL tools and return a JSON spec; the frontend renders it via Tremor. Saved specs persist in `dashboards` / `dashboard_versions` tables. Full route map + ASCII diagram in [docs/architecture/overview.md](docs/architecture/overview.md).
 
-#### Dashboard JSON Spec Format
+#### Dashboard JSON spec
 
-The LLM generates a JSON specification that the frontend renders:
+The LLM emits a JSON spec with `title`, `description`, and a `widgets` array. Each widget has a `type` (see catalog below), per-widget SQL, and rendering hints (format, prefix, axes, etc.). Full example in [docs/architecture/overview.md](docs/architecture/overview.md).
 
-```json
-{
-  "title": "Cuadro de Mandos — Ventas Marzo 2026",
-  "description": "Panel para el responsable de ventas",
-  "widgets": [
-    {
-      "id": "w1",
-      "type": "kpi_row",
-      "items": [
-        {"label": "Ventas Netas", "sql": "SELECT SUM(total_si) ...", "format": "currency", "prefix": "€"},
-        {"label": "Tickets", "sql": "SELECT COUNT(DISTINCT reg_ventas) ...", "format": "number"},
-        {"label": "Ticket Medio", "sql": "SELECT SUM(total_si)/COUNT(...) ...", "format": "currency", "prefix": "€"}
-      ]
-    },
-    {
-      "type": "bar_chart",
-      "title": "Ventas por Tienda",
-      "sql": "SELECT tienda AS label, SUM(total_si) AS value FROM ps_ventas ...",
-      "x": "label", "y": "value"
-    },
-    {
-      "type": "line_chart",
-      "title": "Tendencia Semanal",
-      "sql": "SELECT DATE_TRUNC('week', fecha_creacion) AS x, SUM(total_si) AS y FROM ps_ventas ..."
-    },
-    {
-      "type": "table",
-      "title": "Top 10 Artículos",
-      "sql": "SELECT p.ccrefejofacm AS \"Referencia\", p.descripcion AS \"Descripción\", ..."
-    }
-  ]
-}
-```
+#### Widget catalog
 
-#### Widget Types
-
-| Type | Tremor Component | Purpose |
-|------|-----------------|---------|
-| `kpi_row` | Card + Metric | Row of KPI numbers (ventas, tickets, ticket medio) |
-| `bar_chart` | BarChart | Category comparison (ventas por tienda) |
-| `line_chart` | LineChart | Time series (tendencia semanal) |
-| `area_chart` | AreaChart | Stacked time series |
-| `donut_chart` | DonutChart | Proportions (mix por familia) |
-| `table` | Table | Detailed data (top artículos) |
-| `number` | Metric | Single big number |
-| `insights_strip` | Custom panels | 3-card narrative strip with up/down/warn icons |
-| `ranked_bars` | Custom bars | Horizontal bar chart with heat-cell values |
-
-#### UI Shell Components (redesign, Phase A+)
-
-| Component | Purpose |
-|-----------|---------|
-| `TopBar` | Sticky 56px header — logo, nav, live-data status, cog button, admin link, avatar |
-| `TweaksPanel` | Floating panel for theme/accent/density/kpiStyle — opened by TopBar cog |
-| `AnalyzeLauncher` | Fixed right-rail button "✦ Analizar con IA" — hidden when chat sidebar open |
-| `LogBlock` | Streaming + post-delivery collapsed LLM process log in ChatSidebar |
-| `Panel` | Shared widget chrome (title, subtitle, right actions, padded content) |
-| `InsightsStrip` | Narrative insight cards — up/down/warn |
-| `RankedBarsWidget` | Horizontal bars with heat cells |
-| `Sparkline` | 90×24 SVG inline sparkline in KPI editorial cards |
+`kpi_row`, `bar_chart`, `line_chart`, `area_chart`, `donut_chart`, `table`, `number`, `insights_strip`, `ranked_bars`. Tremor-component mapping and shell components (`TopBar`, `TweaksPanel`, `AnalyzeLauncher`, `LogBlock`, `Panel`, `InsightsStrip`, `RankedBarsWidget`, `Sparkline`) documented in [docs/architecture/overview.md](docs/architecture/overview.md). Token-driven theming per [D-022](docs/decisions/D-022-dashboard-redesign.md).
 
 ## Data Flow
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,7 @@ PowerShop Analytics is a platform that extracts data from a vendor-managed Power
 1. **WrenAI** — Ad-hoc single-question text-to-SQL (e.g., "¿Cuánto vendimos ayer?")
 2. **Dashboard App** — AI-generated multi-widget dashboards from natural language (e.g., "Créame un cuadro de mandos para el responsable de ventas")
 
-**Flow at a glance:** 4D Server (SQL `:19812` / SOAP `:8080`) → ETL (Python, nightly) → PostgreSQL mirror (`ps_*` tables, 18M+ rows) → consumed by both the WrenAI stack (wren-ui `:3000`, wren-ai-service `:5555`, wren-engine, ibis-server, qdrant) and the Dashboard App (Next.js + Tremor on `:4000`). Both LLM paths call OpenRouter (Claude Sonnet 4 + text-embedding-3-large).
+**Flow at a glance:** 4D Server (SQL `:19812` / SOAP `:8080`) → ETL (Python, nightly) → PostgreSQL mirror (`ps_*` tables, 18M+ rows) → consumed by both the WrenAI stack (wren-ui `:3000`, wren-ai-service `:5555`, wren-engine, ibis-server, qdrant) and the Dashboard App (Next.js + Tremor on `:4000`). WrenAI always calls OpenRouter (Claude Sonnet 4 + text-embedding-3-large via litellm). The Dashboard App is configurable via `DASHBOARD_LLM_PROVIDER` between OpenRouter (default) and a local Claude Code CLI — see [D-019](docs/decisions/D-019-pluggable-llm-providers.md).
 
 Full ASCII diagram in [docs/architecture/overview.md](docs/architecture/overview.md).
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -40,6 +40,8 @@ This file extracts the ASCII diagrams, dashboard JSON example, and widget tables
                                         └──────────────────────┘          │
 ```
 
+> **Dashboard App LLM backend is configurable.** `DASHBOARD_LLM_PROVIDER=openrouter` (default, shown above) calls OpenRouter; `=cli` invokes a local Claude Code CLI via argv-array spawn instead. WrenAI always uses OpenRouter. See [D-019](decisions/D-019-pluggable-llm-providers.md).
+
 ## Dashboard App browser ↔ API
 
 ```

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -40,7 +40,7 @@ This file extracts the ASCII diagrams, dashboard JSON example, and widget tables
                                         └──────────────────────┘          │
 ```
 
-> **Dashboard App LLM backend is configurable.** `DASHBOARD_LLM_PROVIDER=openrouter` (default, shown above) calls OpenRouter; `=cli` invokes a local Claude Code CLI via argv-array spawn instead. WrenAI always uses OpenRouter. See [D-019](decisions/D-019-pluggable-llm-providers.md).
+> **Dashboard App LLM backend is configurable.** `DASHBOARD_LLM_PROVIDER=openrouter` (default, shown above) calls OpenRouter; `=cli` invokes a local Claude Code CLI via argv-array spawn instead. WrenAI always uses OpenRouter. See [D-019](../decisions/D-019-pluggable-llm-providers.md).
 
 ## Dashboard App browser ↔ API
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,139 @@
+# Architecture — visual overview
+
+This file extracts the ASCII diagrams, dashboard JSON example, and widget tables from `ARCHITECTURE.md`. `ARCHITECTURE.md` keeps the prose, components list, and policy; this file is for visual reference.
+
+## System diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Data Source                                                             │
+│   4D Server (10.0.1.35)                                                 │
+│     ├── P4D SQL :19812  ─┐                                              │
+│     └── SOAP :8080       │                                              │
+└──────────────────────────┼──────────────────────────────────────────────┘
+                           │ ETL (nightly)
+┌──────────────────────────▼──────────────────────────────────────────────┐
+│ Docker Compose Stack                                                    │
+│                                                                         │
+│  ┌─────────────┐     ┌──────────────────┐     ┌─────────────────────┐  │
+│  │  ETL Python  │────▶│  PostgreSQL       │◄────│  Dashboard App      │  │
+│  │  (nightly)  │     │  18M+ rows        │     │  (Next.js+Tremor)   │  │
+│  └─────────────┘     │  ps_* tables      │     │  :4000              │  │
+│                      │  dashboard_* tbls │     └────────┬────────────┘  │
+│                      └────────┬─────────┘              │               │
+│                               │                         │               │
+│  ┌────────────────────────────┼─────────────────────────┼────────────┐  │
+│  │  WrenAI Stack              │                         │            │  │
+│  │   ├── wren-ui :3000 ───────┘                         │            │  │
+│  │   ├── wren-ai-service :5555                          │            │  │
+│  │   ├── wren-engine                         OpenRouter │            │  │
+│  │   ├── ibis-server                         (Claude)   │            │  │
+│  │   └── qdrant                                  ▲      │            │  │
+│  └───────────────────────────────────────────────┼──────┘            │  │
+│                                                  │                    │  │
+└──────────────────────────────────────────────────┼────────────────────┘  │
+                                                   │                       │
+                                        ┌──────────▼───────────┐          │
+                                        │  OpenRouter API       │          │
+                                        │  Claude Sonnet 4      │          │
+                                        │  text-embedding-3-lg  │          │
+                                        └──────────────────────┘          │
+```
+
+## Dashboard App browser ↔ API
+
+```
+┌───────────────────────────────────────────────────────┐
+│  Browser                                              │
+│                                                       │
+│  ┌─────────────────┐  ┌───────────────────────────┐  │
+│  │  Dashboard View  │  │  Chat Sidebar             │  │
+│  │                  │  │                            │  │
+│  │  ┌──────────┐   │  │  User: "Créame un cuadro  │  │
+│  │  │ KPI Row  │   │  │   de mandos para ventas"  │  │
+│  │  ├──────────┤   │  │                            │  │
+│  │  │ Bar Chart│   │  │  AI: "He creado un panel   │  │
+│  │  ├──────────┤   │  │   con 6 widgets..."        │  │
+│  │  │ Table    │   │  │                            │  │
+│  │  └──────────┘   │  │  User: "Añade el margen"  │  │
+│  │                  │  │                            │  │
+│  └─────────────────┘  └───────────────────────────┘  │
+└───────────────────────────┬───────────────────────────┘
+                            │ REST API
+┌───────────────────────────▼───────────────────────────┐
+│  Next.js API Routes                                   │
+│                                                       │
+│  POST /api/dashboard/generate  ← prompt → LLM (+ tools) → spec │
+│  POST /api/dashboard/modify    ← prompt + spec → LLM (+ tools) │
+│  POST /api/dashboard/analyze   ← spec + widget data → LLM (+ tools) │
+│  POST /api/query               ← SQL → PG → data     │
+│  GET  /api/dashboard/:id       ← load saved spec      │
+│  POST /api/dashboard/:id/save  ← persist spec         │
+│  GET  /api/dashboards          ← list all             │
+└───────────────────────────────────────────────────────┘
+```
+
+## Dashboard JSON spec example
+
+The LLM generates a JSON specification that the frontend renders:
+
+```json
+{
+  "title": "Cuadro de Mandos — Ventas Marzo 2026",
+  "description": "Panel para el responsable de ventas",
+  "widgets": [
+    {
+      "id": "w1",
+      "type": "kpi_row",
+      "items": [
+        {"label": "Ventas Netas", "sql": "SELECT SUM(total_si) ...", "format": "currency", "prefix": "€"},
+        {"label": "Tickets", "sql": "SELECT COUNT(DISTINCT reg_ventas) ...", "format": "number"},
+        {"label": "Ticket Medio", "sql": "SELECT SUM(total_si)/COUNT(...) ...", "format": "currency", "prefix": "€"}
+      ]
+    },
+    {
+      "type": "bar_chart",
+      "title": "Ventas por Tienda",
+      "sql": "SELECT tienda AS label, SUM(total_si) AS value FROM ps_ventas ...",
+      "x": "label", "y": "value"
+    },
+    {
+      "type": "line_chart",
+      "title": "Tendencia Semanal",
+      "sql": "SELECT DATE_TRUNC('week', fecha_creacion) AS x, SUM(total_si) AS y FROM ps_ventas ..."
+    },
+    {
+      "type": "table",
+      "title": "Top 10 Artículos",
+      "sql": "SELECT p.ccrefejofacm AS \"Referencia\", p.descripcion AS \"Descripción\", ..."
+    }
+  ]
+}
+```
+
+## Widget types
+
+| Type | Tremor Component | Purpose |
+|------|-----------------|---------|
+| `kpi_row` | Card + Metric | Row of KPI numbers (ventas, tickets, ticket medio) |
+| `bar_chart` | BarChart | Category comparison (ventas por tienda) |
+| `line_chart` | LineChart | Time series (tendencia semanal) |
+| `area_chart` | AreaChart | Stacked time series |
+| `donut_chart` | DonutChart | Proportions (mix por familia) |
+| `table` | Table | Detailed data (top artículos) |
+| `number` | Metric | Single big number |
+| `insights_strip` | Custom panels | 3-card narrative strip with up/down/warn icons |
+| `ranked_bars` | Custom bars | Horizontal bar chart with heat-cell values |
+
+## UI shell components (redesign, Phase A+)
+
+| Component | Purpose |
+|-----------|---------|
+| `TopBar` | Sticky 56px header — logo, nav, live-data status, cog button, admin link, avatar |
+| `TweaksPanel` | Floating panel for theme/accent/density/kpiStyle — opened by TopBar cog |
+| `AnalyzeLauncher` | Fixed right-rail button "✦ Analizar con IA" — hidden when chat sidebar open |
+| `LogBlock` | Streaming + post-delivery collapsed LLM process log in ChatSidebar |
+| `Panel` | Shared widget chrome (title, subtitle, right actions, padded content) |
+| `InsightsStrip` | Narrative insight cards — up/down/warn |
+| `RankedBarsWidget` | Horizontal bars with heat cells |
+| `Sparkline` | 90×24 SVG inline sparkline in KPI editorial cards |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,56 @@
+# CLI reference — `ps` command
+
+Single entry point for all operations. **Usage:** `ps <group> [subcommand] [options]`
+
+> **Why this lives here, not in AGENTS.md:** the full table is ~40 rows of mostly-stable operational reference. AGENTS.md keeps a short summary of the groups; this file is the complete map.
+
+## Read-only policy
+
+**CRITICAL:** All SQL operations are read-only. The CLI rejects INSERT, UPDATE, DELETE, DROP, ALTER, CREATE, and TRUNCATE statements. We are extracting data, never modifying the source ERP.
+
+## CLI-first principle
+
+All automation should delegate work to the CLI. This ensures every operation is reproducible locally and in Docker/CI.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `ps setup` | First-time setup: create .env and repo symlink |
+| `ps setup check` | Verify prerequisites (Docker, .env, connectivity) |
+| `ps stack up` | Start all containers |
+| `ps stack down` | Stop all containers |
+| `ps stack restart` | Restart all containers |
+| `ps stack update` | Pull latest, rebuild images, restart stack |
+| `ps stack status` | Show container status and WrenAI UI health |
+| `ps stack logs [svc]` | Show logs (follow); optional service name |
+| `ps stack open` | Open WrenAI UI in browser |
+| `ps stack destroy` | Stop containers and remove volumes (with confirmation) |
+| `ps etl run` | Run ETL sync once (also triggerable via the Dashboard ETL Monitor "Sincronizar ahora" button → `POST /api/etl/run`) |
+| `ps etl status` | Show watermark table (last sync per table) |
+| `ps etl tables` | Show row counts for synced tables |
+| `ps etl logs` | Show ETL container logs |
+| `ps sql tables` | List all 4D tables |
+| `ps sql describe <table>` | Show columns for a table |
+| `ps sql query "<SQL>"` | Run a read-only SQL query |
+| `ps sql sample <table> [n]` | Show n sample rows |
+| `ps sql count <table>` | Row count for a table |
+| `ps wren push` | Push source knowledge to WrenAI (47 instructions, 56 SQL pairs — loaded from source MDs) |
+| `ps wren validate` | Validate all SQL pairs against PostgreSQL mirror |
+| `ps wren status` | Show instruction and SQL pair counts |
+| `ps dashboard open` | Open Dashboard App in browser |
+| `ps dashboard logs` | Show dashboard container logs |
+| `ps dashboard restart` | Restart the dashboard container |
+| `ps dashboard status` | Show dashboard container status |
+| `ps prod deploy` | Pull latest Docker Hub images on prod and restart the stack |
+| `ps prod update` | Full update: download new compose/config from latest GitHub release + deploy |
+| `ps prod restart [svc]` | Restart all services on prod, or a named one |
+| `ps prod status` | Container status + version + health checks + token state |
+| `ps prod logs [svc]` | Tail prod logs (follow); optional service |
+| `ps prod version` | Show the version running on prod |
+| `ps prod health` | Run health checks against all prod services |
+| `ps prod push-config` | Upload local wren-config.yaml to prod and restart wren-ai-service |
+| `ps prod token-status` | Show prod's Claude OAuth access-token expiry hours |
+| `ps prod login` | Interactive `ssh -t` to run `claude /login` on prod |
+| `ps prod ssh` | Open a shell on prod |
+| `ps config` | Show loaded configuration |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -26,6 +26,8 @@ All automation should delegate work to the CLI. This ensures every operation is 
 | `ps stack logs [svc]` | Show logs (follow); optional service name |
 | `ps stack open` | Open WrenAI UI in browser |
 | `ps stack destroy` | Stop containers and remove volumes (with confirmation) |
+| `ps stack migrate` | Apply pending schema migrations |
+| `ps stack setup-wren` | Bootstrap WrenAI on first run (semantic model + knowledge push) |
 | `ps etl run` | Run ETL sync once (also triggerable via the Dashboard ETL Monitor "Sincronizar ahora" button → `POST /api/etl/run`) |
 | `ps etl status` | Show watermark table (last sync per table) |
 | `ps etl tables` | Show row counts for synced tables |
@@ -35,8 +37,10 @@ All automation should delegate work to the CLI. This ensures every operation is 
 | `ps sql query "<SQL>"` | Run a read-only SQL query |
 | `ps sql sample <table> [n]` | Show n sample rows |
 | `ps sql count <table>` | Row count for a table |
-| `ps wren push` | Push source knowledge to WrenAI (47 instructions, 56 SQL pairs — loaded from source MDs) |
+| `ps sql schema` | Generate the full 4D schema dump locally (git-ignored; contains real data) |
+| `ps wren push` | Push source knowledge to WrenAI (instructions + SQL pairs — counts loaded dynamically from source MDs; `ps wren status` shows current numbers) |
 | `ps wren validate` | Validate all SQL pairs against PostgreSQL mirror |
+| `ps wren crosscheck` | Cross-check WrenAI knowledge against the schema in PostgreSQL (find drift) |
 | `ps wren status` | Show instruction and SQL pair counts |
 | `ps dashboard open` | Open Dashboard App in browser |
 | `ps dashboard logs` | Show dashboard container logs |

--- a/docs/issue-format.md
+++ b/docs/issue-format.md
@@ -1,0 +1,145 @@
+# Issue and PR format
+
+All GitHub issues in this project follow a single standard format. When creating issues, always use this template exactly.
+
+> **Why this lives here, not in AGENTS.md:** the template + phasing rules are ~140 lines of reference that the planner reads once when decomposing work, but every Claude session in the repo doesn't need them in the always-loaded context chain. AGENTS.md keeps a short summary and links here.
+
+## Issue template
+
+```markdown
+# <Feature name>
+
+## Context
+- **Problem**: <what's wrong / missing; why it matters>
+- **Worktree**: <required: git worktree name for isolated execution, e.g. `wren-p1-compose`>
+- **Scope**: <what is in / out of scope>
+- **Constraints**: <perf, compatibility, no-breaking-changes, deps, etc.>
+- **Repo touchpoints**: <files/dirs likely involved, commands, datasets impacted>
+- **Definition of done**: <e.g., builds + tests pass; feature-specific checks>
+- **How is it going to be tested**: <testing strategy and specific test cases>
+
+## Tasks
+- [ ] 1) <task title> (owner: agent)
+  - **Change**: <precise behavior or code change>
+  - **Files**: <exact file paths>
+  - **Acceptance**: <how to verify; exact commands and expected output>
+  - **Spec update**: mark done + update remaining tasks/context as needed
+
+- [ ] 2) ... (owner: agent)
+
+- [ ] N-1) Run all checks and fix issues (owner: agent)
+  - **Change**: Run all tests, linting, type-checking, and formatting; fix any failures
+  - **Files**: any files with issues
+  - **Acceptance**: `docker compose run --rm etl python -m pytest && python -m ruff check etl/ && python -m mypy etl/`
+  - **Spec update**: mark done
+
+- [ ] N-1b) Copilot review (owner: agent, **one round only**)
+  - **Change**: Request a Copilot review, address all feedback, then stop. Do **not** re-request Copilot.
+  - **How**: `gh pr create`, then request Copilot review via REST API: `gh api repos/{owner}/{repo}/pulls/{PR#}/requested_reviewers --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'`. Poll for review: `gh api repos/{owner}/{repo}/pulls/{PR#}/reviews --jq '[.[] | {state, user: .user.login, body}]'`. Address all comments with inline replies.
+  - **Acceptance**: Copilot review arrived, every comment has either a code change or a reply explaining why it does not apply. No second Copilot round.
+  - **Spec update**: mark done
+
+- [ ] N-1c) Opus review (owner: agent, **one round only, clean context**)
+  - **Change**: Run a single Opus review of the PR **from a fresh context** (new session, no implementation history), address all feedback, then stop.
+  - **How**: Start a new Claude Code session with no prior conversation about this PR and invoke the PR review flow on this PR number. Reply inline to every comment; apply the fixes that are correct.
+  - **Acceptance**: Opus review completed; every comment has either a code change or a reply. No second Opus round.
+  - **Spec update**: mark done
+
+- [ ] N) Create commit (owner: agent)
+  - **Change**: Stage all changes and create a descriptive commit
+  - **Files**: none (git operation)
+  - **Acceptance**: `git status` shows clean working tree; `git log -1` shows the new commit
+  - **Spec update**: mark done
+
+## Additional Context
+<append-only notes: discoveries, links, decisions, gotchas found during execution>
+```
+
+## Worktree workflow
+
+Each issue specifies a **worktree name**. Before starting work:
+```bash
+git worktree add ../<repo>-<worktree-name> -b <worktree-name>
+cd ../<repo>-<worktree-name>
+```
+Work in the worktree. When done, PR is merged and worktree is removed:
+```bash
+git worktree remove ../<repo>-<worktree-name>
+```
+
+## PR and review policy
+
+Every PR gets **exactly two review rounds, in order, each run only once**:
+
+1. **One Copilot review** (bot).
+2. **One Opus review**, started from a **clean context** (fresh Claude Code session with no prior history about this PR or its implementation).
+
+After each round: address every comment with either a code change or an inline reply, then move on. **Do not re-request the same reviewer.** Iterating "until there are no comments" is no longer the policy — it was too much. If a later round surfaces a genuinely blocking issue, use judgement and escalate to the human owner rather than looping. See [D-021](decisions/D-021-two-review-rounds.md).
+
+Rules:
+- Every piece of work goes through a PR, even solo work.
+- **Round 1 — Copilot.** Request via the REST API:
+  ```bash
+  gh api repos/{owner}/{repo}/pulls/{PR#}/requested_reviewers \
+    --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
+  ```
+  Do NOT use `gh pr review --request copilot` (doesn't work) or `gh pr edit --add-reviewer copilot` (can't resolve bot users). The REST API with `copilot-pull-request-reviewer[bot]` is the only working CLI method.
+  - **From GitHub Actions**, the default `GITHUB_TOKEN` **cannot** assign `copilot-pull-request-reviewer[bot]` — the API returns 200 but with an empty `requested_reviewers` array. Workflows must use a PAT stored in the repo secret `COPILOT_PAT` (fine-grained PAT, scope `Pull requests: Read and write`). Pattern:
+    ```bash
+    GH_TOKEN="$COPILOT_PAT" gh api repos/{owner}/{repo}/pulls/{PR#}/requested_reviewers \
+      --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
+    ```
+    Always verify the response contains `Copilot` in `requested_reviewers` before claiming the review was requested.
+  - Poll for the review: `gh api repos/{owner}/{repo}/pulls/{PR#}/reviews --jq '[.[] | {state, user: .user.login, body}]'`.
+  - Address every comment with a code change or inline reply. **One round only — do not re-request Copilot.**
+- **Round 2 — Opus, clean context.** Start a new Claude Code session (no prior conversation about this PR or the branch) and run the PR review flow on this PR number. Reply inline to every comment; apply the correct fixes. **One round only — do not re-request Opus.**
+- **Merge** after both rounds are done and every comment has a change or a reply. Unresolved disagreement → flag to the human owner; don't start a third round to paper over it.
+
+## Phase labels and execution order
+
+Issues are labelled by phase: `phase-1`, `phase-2`, ..., `phase-6`.
+
+**Execution rules for unattended agents:**
+- Phase 1 is sequential: P1-A then P1-B.
+- Phases 2+3 sync issues are independent of each other — run in batches of 2-3 after P1-B merges. Each sync issue only creates `etl/sync/<module>.py` + tests. **None touch `etl/main.py`** — P4 owns that file.
+- Phase 4 (scheduler) wires all sync modules into `main.py` and runs the first full data load. Requires all sync PRs merged.
+- Phase 5 (WrenAI MDL) requires P4 complete (data must be in PostgreSQL).
+- Phase 6 (docs) requires P5 complete.
+
+## Planner phasing rules (mandatory for all decompositions)
+
+These rules apply to **every** planning session, not just the ETL epic above. The planner must apply them before finalising any sub-issue decomposition.
+
+### Q1 — When to produce phases (trigger conditions)
+
+Phases are **mandatory** when any two sub-issues share any of the following:
+
+1. **Shared source file** — the same path appears in the `Files:` section of two sub-issues (especially `dashboard/lib/*.ts`, `dashboard/components/`, `etl/schema/init.sql`, shared hooks/types).
+2. **Shared DB table** — any two sub-issues `CREATE`, `ALTER`, or heavily write to the same table. Schema DDL is the highest-risk overlap.
+3. **Shared HTTP route family** — any two sub-issues add or modify routes under the same prefix (e.g. `/api/conversations/*`).
+4. **Producer/consumer dependency** — one sub-issue defines a shape that another reads. Classic chain: data layer → API route → UI component. The consumer cannot correctly implement against a shape that isn't merged yet.
+
+When **none** of the above apply, sub-issues may run in parallel.
+
+### Q2 — Serialisation unit
+
+**Phase = a batch of sub-issues that share no files, tables, or contracts.** Within a phase, sub-issues run concurrently (existing worker behaviour). Between phases: all PRs from phase N must be **merged and `main` must be green** before any phase N+1 sub-issue receives `ai-work`.
+
+Phase N+1 sub-issues are created with the `ai-task` label but **without** `ai-work`. The owner adds `ai-work` once all phase N PRs are merged.
+
+### Q3 — Enforcement rule for the planner
+
+After listing sub-issues, the planner must:
+
+1. For each pair (A, B) assigned to the same phase: check all four Q1 conditions:
+   - **File overlap**: is `Files(A) ∩ Files(B)` non-empty (string intersection on the `Files:` lines)?
+   - **DB table overlap**: do both touch (CREATE/ALTER/write) the same table?
+   - **Route prefix overlap**: do both add or modify routes under the same HTTP prefix?
+   - **Producer/consumer chain**: does A define a shape or contract that B reads?
+2. If **any** of the above is true: move B to the next phase; document the reason in the plan comment.
+3. Include a **dependency table** in the plan comment showing which sub-issues are in each phase and the reason for any serialisation.
+
+### Phase labeling
+
+- Use `phase-1`, `phase-2`, ... labels on sub-issues to indicate which batch they belong to.
+- In the plan comment, include a dependency table with columns: Phase | Sub-issue | Files | Reason for phase assignment.


### PR DESCRIPTION
Implements PR 3 of #625.

## Summary
Extracts reference content out of the always-loaded context chain. Boot context drops ~17.5 KB (~4.4k tokens).

| File | Before | After |
|------|------:|-----:|
| AGENTS.md | 37,879 B | 27,904 B |
| ARCHITECTURE.md | 16,635 B | 9,078 B |
| **Chain total** | **68,493 B** | **50,961 B** |

## What moved

**`docs/cli-reference.md`** (new, ~3.2 KB) — full `ps` command table. AGENTS.md now shows a short summary of the CLI groups (`setup`, `stack`, `etl`, `sql`, `wren`, `dashboard`, `prod`, `config`).

**`docs/issue-format.md`** (new, ~9.3 KB) — full issue template + worktree workflow + PR review policy + phase labels + planner phasing rules. AGENTS.md now has a 4-line "Short summary" of the binding rules.

**`docs/architecture/overview.md`** (new, ~9.5 KB) — system ASCII diagram, Dashboard App ASCII diagram, dashboard JSON spec example, widget catalog tables, UI shell components. ARCHITECTURE.md now has one-line summaries and links.

## What stays in AGENTS.md / ARCHITECTURE.md

- All **policy** and **binding rules** (read-only SQL, no worker workflows, recording decisions, knowledge file maintenance, etc.).
- All **D-NN cross-references**.
- Component summaries and configuration.

## Why this works for the AI Factory

The per-role context split from PR 2 (#627) already means most workflows load lighter context (review, feedback, mergeability, audit, triage). The two roles that still import the full chain are **worker-plan** and **command** — they now get ~4.4k tokens lighter at boot. CLI use is unaffected: root `CLAUDE.md` continues to import the chain in full, and the extracted files are one Read away.

## Test plan
- [ ] Open a CLI session in the repo and verify the agent boots and answers a CLI-related question correctly (uses the full chain).
- [ ] Spot-check 3 of the moved links from AGENTS.md / ARCHITECTURE.md — they resolve to the right new files.
- [ ] Confirm `git grep -F "ps wren push"` still finds it in the codebase (it now lives in `docs/cli-reference.md`).
- [ ] Confirm the AI Factory worker-plan / command roles still have everything they need by running one ad-hoc planner flow (or dry-run via workflow_dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)