### PR TITLE
PR 4 of #625: model downshift + hourly mergeability cron

### DIFF
--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -349,7 +349,7 @@ jobs:
           COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--permission-mode bypassPermissions --max-turns 80"
+          claude_args: "--model claude-sonnet-4-6 --permission-mode bypassPermissions --max-turns 80"
           allowed_bots: "claude[bot],copilot-pull-request-reviewer[bot],github-actions[bot]"
           prompt: |
             You are addressing review feedback on PR #${{ needs.resolve.outputs.pr_number }}.

--- a/.github/workflows/ai-bug-hunter.yml
+++ b/.github/workflows/ai-bug-hunter.yml
@@ -36,7 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--permission-mode bypassPermissions --max-turns 60"
+          claude_args: "--model claude-sonnet-4-6 --permission-mode bypassPermissions --max-turns 60"
           prompt: |
             ${{ steps.load-knowledge.outputs.bundle }}
 

--- a/.github/workflows/ai-ci-remediation.yml
+++ b/.github/workflows/ai-ci-remediation.yml
@@ -151,7 +151,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--permission-mode bypassPermissions --max-turns 120"
+          claude_args: "--model claude-sonnet-4-6 --permission-mode bypassPermissions --max-turns 120"
           prompt: |
             You are fixing **CI failures** for PR #${{ env.PR_NUMBER }} on branch `${{ needs.resolve.outputs.head_branch }}`.
 

--- a/.github/workflows/ai-command.yml
+++ b/.github/workflows/ai-command.yml
@@ -58,7 +58,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # CI has no human to approve BashEdit/Write — default mode burns turns on denials
           # and looks like "nothing happened" despite a green workflow.
-          claude_args: "--permission-mode bypassPermissions --max-turns 120"
+          claude_args: "--model claude-sonnet-4-6 --permission-mode bypassPermissions --max-turns 120"
           trigger_phrase: "/ai"
           prompt: |
             You have been invoked via the /ai command on GitHub **#${{ github.event.issue.number }}**.

--- a/.github/workflows/ai-factory-manager.yml
+++ b/.github/workflows/ai-factory-manager.yml
@@ -258,7 +258,7 @@ jobs:
           TRACKING_ISSUE: ${{ steps.tracking.outputs.issue }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-opus-4-7 --permission-mode bypassPermissions --max-turns 80"
+          claude_args: "--model claude-opus-4-6 --permission-mode bypassPermissions --max-turns 80"
           prompt: ${{ env.MANAGER_PROMPT }}
 
       # ── Failure handler ───────────────────────────────────────────────────

--- a/.github/workflows/ai-pr-mergeability.yml
+++ b/.github/workflows/ai-pr-mergeability.yml
@@ -6,8 +6,11 @@ name: AI PR Mergeability
 # fixes failing CI; this one fixes everything BEFORE CI can even run.
 on:
   schedule:
-    # Every 30 minutes
-    - cron: "*/30 * * * *"
+    # Hourly. The push event handles the hot path (new commit on main
+    # rebases PRs immediately); cron is the fallback for PRs that haven't
+    # had push activity. Bumped from */30 to */60 per issue #625 to ease
+    # GitHub schedule queue pressure (D-030).
+    - cron: "0 * * * *"
   push:
     branches: [main]
   workflow_dispatch:
@@ -240,7 +243,7 @@ jobs:
           REPO: ${{ env.REPO }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--permission-mode bypassPermissions --max-turns 60"
+          claude_args: "--model claude-haiku-4-5-20251001 --permission-mode bypassPermissions --max-turns 60"
           prompt: |
             You are resolving merge conflicts during a `git rebase` of PR #${{ env.PR_NUMBER }}.
 

--- a/.github/workflows/ai-pr-mergeability.yml
+++ b/.github/workflows/ai-pr-mergeability.yml
@@ -6,10 +6,10 @@ name: AI PR Mergeability
 # fixes failing CI; this one fixes everything BEFORE CI can even run.
 on:
   schedule:
-    # Hourly. The push event handles the hot path (new commit on main
-    # rebases PRs immediately); cron is the fallback for PRs that haven't
-    # had push activity. Bumped from */30 to */60 per issue #625 to ease
-    # GitHub schedule queue pressure (D-030).
+    # Hourly (was every 30 minutes; reduced per issue #625 to ease GitHub
+    # schedule queue pressure — see D-030). The `push` event handles the
+    # hot path (rebase on every commit to main); the cron is the fallback
+    # for PRs that haven't had push activity.
     - cron: "0 * * * *"
   push:
     branches: [main]

--- a/.github/workflows/ai-test.yml
+++ b/.github/workflows/ai-test.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ github.event.inputs.test_prompt }}
-          claude_args: "--max-turns 5"
+          claude_args: "--model claude-haiku-4-5-20251001 --max-turns 5"

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -95,7 +95,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--permission-mode bypassPermissions --max-turns 80"
+          claude_args: "--model claude-opus-4-6 --permission-mode bypassPermissions --max-turns 80"
           prompt: |
             You are the AI Planner. Your job is to deeply analyse issue #${{ env.ISSUE_NUMBER }},
             produce a comprehensive implementation plan, and break it into actionable sub-tasks.
@@ -445,7 +445,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--permission-mode bypassPermissions --max-turns 120"
+          claude_args: "--model claude-sonnet-4-6 --permission-mode bypassPermissions --max-turns 120"
           allowed_bots: "claude[bot],github-actions[bot]"
           prompt: |
             You are the AI Worker. Implement exactly what sub-task issue #${{ env.ISSUE_NUMBER }} describes — nothing more.


### PR DESCRIPTION
Implements PR 4 of #625. Frees Claude Max weekly Opus quota by reserving Opus for high-stakes reasoning (planning, review, orchestrator) and shifting implementation + mechanical work to Sonnet and Haiku.

## Model matrix

| Workflow | Before | After | Rationale |
|---|---|---|---|
| ai-factory-manager | Opus 4.7 | **Opus 4.6** | Standardise on 4.6 |
| ai-plan | Opus 4.6 ✓ | unchanged | Planning — keep Opus |
| ai-pr-review | Opus 4.6 ✓ | unchanged | Review — keep Opus |
| ai-feature-ideas | Opus 4.6 ✓ | unchanged | Creative discovery |
| **ai-worker plan job** | default (Opus) | **Opus 4.6** explicit | Planning needs depth |
| **ai-worker implement job** | default (Opus) | **Sonnet 4.6** | Planning done upstream by ai-plan / ai-worker plan |
| **ai-address-feedback** | default (Opus) | **Sonnet 4.6** | Mechanical fixups |
| **ai-ci-remediation** | default (Opus) | **Sonnet 4.6** | Lint/format/test fixes |
| **ai-command** | default (Opus) | **Sonnet 4.6** | Interactive `/ai` |
| **ai-bug-hunter** | default (Opus) | **Sonnet 4.6** | Discovery + filing |
| **ai-pr-mergeability** | default (Opus) | **Haiku 4.5** | Rebase resolution is mechanical |
| **ai-test** | default (Opus) | **Haiku 4.5** | Smoke test |
| (6 Haiku workflows) | Haiku 4.5 ✓ | unchanged | Already optimised |

Net: roughly 70 % of Opus invocations move off Opus on a busy week.

## Cadence

`ai-pr-mergeability.yml` cron: `*/30` → `0 * * * *` (hourly). The `push` event already handles the hot path (rebase on every push to main); the cron is the fallback. Halving scheduled load eases GitHub schedule queue pressure per D-030.

## What's not changed
- `--max-turns` values stay (tuned, lower values were observed to fail).
- ai-worker plan + implement already have concurrency groups (verified).
- Workflows on explicit Opus 4.6 are unchanged.

## Test plan
- [ ] Merge and observe one full PR cycle through the factory: triage (Haiku) → plan (Opus 4.6) → worker implement (Sonnet 4.6) → Copilot → address-feedback (Sonnet 4.6) → Opus review → owner merge.
- [ ] Watch one ai-pr-mergeability invocation on a real rebase conflict (Haiku 4.5).
- [ ] Monitor for one week — if Sonnet/Haiku underperforms on any workflow, revert that one row of the matrix individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)