### PR TITLE
PR 5 of #625: business review — per-role model split

### DIFF
--- a/.github/workflows/business-review-weekly.yml
+++ b/.github/workflows/business-review-weekly.yml
@@ -79,14 +79,22 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
+        # Per-role model split (PR 5 of issue #625). Opus stays on the
+        # roles whose value is hardest to recover if downgraded:
+        #   - CFO: numerical / margin / financial accuracy critical
+        #   - BI Skeptic: "what could mislead" — catches data-quality
+        #     failure modes the other roles miss; downgrade risks
+        #     missing subtle issues.
+        # The other five roles produce creative business-strategy
+        # proposals that Sonnet handles well.
         role:
-          - { slug: ceo,        file: 01-ceo.md,         name: "CEO" }
-          - { slug: retail,     file: 02-retail.md,      name: "Retail" }
-          - { slug: mayorista,  file: 03-mayorista.md,   name: "Mayorista" }
-          - { slug: compras,    file: 04-compras.md,     name: "Compras" }
-          - { slug: cfo,        file: 05-cfo.md,         name: "CFO" }
-          - { slug: producto,   file: 06-producto.md,    name: "Producto" }
-          - { slug: bi-skeptic, file: 07-bi-skeptic.md,  name: "BI Skeptic" }
+          - { slug: ceo,        file: 01-ceo.md,         name: "CEO",        model: "claude-sonnet-4-6" }
+          - { slug: retail,     file: 02-retail.md,      name: "Retail",     model: "claude-sonnet-4-6" }
+          - { slug: mayorista,  file: 03-mayorista.md,   name: "Mayorista",  model: "claude-sonnet-4-6" }
+          - { slug: compras,    file: 04-compras.md,     name: "Compras",    model: "claude-sonnet-4-6" }
+          - { slug: cfo,        file: 05-cfo.md,         name: "CFO",        model: "claude-opus-4-6" }
+          - { slug: producto,   file: 06-producto.md,    name: "Producto",   model: "claude-sonnet-4-6" }
+          - { slug: bi-skeptic, file: 07-bi-skeptic.md,  name: "BI Skeptic", model: "claude-opus-4-6" }
     steps:
       - uses: actions/checkout@v4
 
@@ -122,7 +130,7 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-opus-4-6 --permission-mode bypassPermissions --max-turns 30"
+          claude_args: "--model ${{ matrix.role.model }} --permission-mode bypassPermissions --max-turns 30"
           prompt: |
             ${{ steps.load-knowledge.outputs.bundle }}
 


### PR DESCRIPTION
Implements PR 5 (optional) of #625.

## What changes

`business-review-weekly.yml` runs 7 simulated business roles every Monday. Today all 7 run on Opus 4.6. This PR keeps Opus only for the two roles whose value is hardest to recover if downgraded; the other 5 move to Sonnet 4.6.

| Role | Model | Why |
|------|-------|-----|
| CEO | **Sonnet 4.6** | Strategic critique; Sonnet handles it |
| Retail | **Sonnet 4.6** | Same |
| Mayorista | **Sonnet 4.6** | Same |
| Compras | **Sonnet 4.6** | Same |
| **CFO** | **Opus 4.6** | Numerical / margin / financial accuracy critical |
| Producto | **Sonnet 4.6** | Same |
| **BI Skeptic** | **Opus 4.6** | "What could mislead" — catches data-quality failure modes the other roles miss |

## Implementation

Each matrix entry gains a `model` field; the `claude_args` line references `${{ matrix.role.model }}`. Adding a new role is one extra line in the matrix; the workflow body doesn't change.

## Token cost (Monday 06:00 UTC, weekly)

Was: 7 × Opus invocations.
Now: 5 × Sonnet + 2 × Opus. Roughly **70 % of the previous Opus message budget for this workflow** is freed each week.

## Test plan
- [ ] Manual dispatch with `dry_run=true` to confirm the matrix expansion is valid.
- [ ] Manual dispatch with `dry_run=true only_role=cfo` to confirm Opus 4.6 is selected.
- [ ] Manual dispatch with `dry_run=true only_role=ceo` to confirm Sonnet 4.6 is selected.
- [ ] After the first real Monday run, spot-check that the 5 Sonnet roles still produce useful proposals — if any role consistently underperforms, move it back to Opus by changing one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)