### PR TITLE
fix(ai-factory): real-Opus-review marker + display_title run matching (D-033)

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,4 +1,11 @@
 name: AI PR Review
+# D-033: `run-name` embeds the PR number in the workflow-run title so the
+# watchdog can match dispatched runs by `display_title` instead of `head_sha`.
+# Without this, `workflow_dispatch` runs record `head_sha = main's SHA` and
+# are invisible to filters like `head_sha == PR.headRefOid`, causing the
+# watchdog to think "Opus never ran" even after dozens of successful runs.
+run-name: >-
+  AI PR Review — PR #${{ github.event.pull_request.number || inputs.pr_number }}
 on:
   pull_request:
     # Strict Copilot-then-Opus sequencing (D-031, issue #580 fallout):
@@ -84,11 +91,25 @@ jobs:
           set -euo pipefail
           HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .headRefOid)
 
-          # Head-SHA idempotency: if claude[bot] already submitted a review
-          # on this exact commit, skip silently. The first-fired run will
-          # post the review and labels; subsequent re-fires must be no-ops.
+          # Head-SHA idempotency: if claude[bot] already submitted a *real*
+          # Opus review on this exact commit, skip silently. The first-fired
+          # run will post the review and labels; subsequent re-fires must be
+          # no-ops.
+          #
+          # D-033: We must NOT count empty-body `state=COMMENTED` reviews.
+          # ai-address-feedback addresses each Copilot inline comment by
+          # submitting an inline-reply review (state=COMMENTED, body=""), so
+          # after a single round there are typically 3-10 such "reviews" on
+          # the new head SHA. Counting them caused every Opus dispatch to
+          # short-circuit, leaving PRs stranded in ai-phase-opus until the
+          # watchdog stamped ai-blocked (PRs #629, #640, #644-650 — see
+          # docs/decisions/D-033-opus-review-marker.md).
+          #
+          # Real Opus reviews have a non-empty body (the claude-code-action
+          # always posts a "## Review summary" header via use_sticky_comment).
+          # `(.body | length) > 0` cleanly discriminates.
           EXISTING_CLAUDE_REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
-            --jq "[.[] | select(.user.login == \"claude[bot]\" and .commit_id == \"$HEAD_SHA\")] | length" 2>/dev/null || echo "0")
+            --jq "[.[] | select(.user.login == \"claude[bot]\" and .commit_id == \"$HEAD_SHA\" and (.body | length) > 0)] | length" 2>/dev/null || echo "0")
           if ! [[ "$EXISTING_CLAUDE_REVIEWS" =~ ^[0-9]+$ ]]; then
             EXISTING_CLAUDE_REVIEWS=0
           fi

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -108,8 +108,14 @@ jobs:
           # Real Opus reviews have a non-empty body (the claude-code-action
           # always posts a "## Review summary" header via use_sticky_comment).
           # `(.body | length) > 0` cleanly discriminates.
-          EXISTING_CLAUDE_REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
-            --jq "[.[] | select(.user.login == \"claude[bot]\" and .commit_id == \"$HEAD_SHA\" and (.body | length) > 0)] | length" 2>/dev/null || echo "0")
+          #
+          # `--paginate` is required: address-feedback can add 3-10 empty-body
+          # review submissions per Copilot round, and PRs that go through
+          # several rounds easily exceed one page (100 reviews). Without
+          # pagination, a real Opus review on a later page would be missed
+          # and we'd post a duplicate.
+          EXISTING_CLAUDE_REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" --paginate \
+            --jq ".[] | select(.user.login == \"claude[bot]\" and .commit_id == \"$HEAD_SHA\" and (.body | length) > 0) | .id" 2>/dev/null | wc -l | tr -d ' ')
           if ! [[ "$EXISTING_CLAUDE_REVIEWS" =~ ^[0-9]+$ ]]; then
             EXISTING_CLAUDE_REVIEWS=0
           fi

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -304,17 +304,22 @@ jobs:
             # detail endpoint). That filter always returned empty, so the
             # watchdog never recognised a recent run and re-dispatched every
             # cycle (root cause of the #629/#640/#644-650 stall cascade).
+            #
+            # `--paginate` + a server-side `created` filter is required: under
+            # burst load (the failure mode this whole PR addresses) the repo
+            # easily generates >100 runs/hour and the target PR's run can be
+            # pushed off the first page. The `created` query parameter
+            # short-circuits pagination once we cross the 30-minute boundary
+            # so we don't walk the entire history.
             NOW=$(date -u +%s)
+            SINCE_ISO=$(date -u -d "@$((NOW - 1800))" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
             RECENT_RUNS=$(gh api \
-              "repos/$REPO_FULL/actions/workflows/ai-pr-review.yml/runs?per_page=20" \
-              --jq "[.workflow_runs[] |
-                select((.created_at | fromdateiso8601) > ($NOW - 1800)) |
-                .display_title]" 2>/dev/null || echo "[]")
+              "repos/$REPO_FULL/actions/workflows/ai-pr-review.yml/runs?per_page=100&created=%3E${SINCE_ISO}" \
+              --paginate \
+              --jq '.workflow_runs[] | .display_title' 2>/dev/null || true)
 
             # Match "PR #<NUM>" with a non-digit boundary so #64 doesn't match #647.
-            if echo "$RECENT_RUNS" | jq -e --arg num "$NUM" '
-              any(.[]; test("PR #" + $num + "(\\D|$)"))
-            ' >/dev/null 2>&1; then
+            if echo "$RECENT_RUNS" | grep -E "PR #${NUM}([^0-9]|$)" >/dev/null 2>&1; then
               echo "PR #$NUM: pr-review already dispatched recently — skipping"
               continue
             fi
@@ -634,17 +639,25 @@ jobs:
             # PR head SHA (non-empty body, see D-033 / ai-pr-review.yml
             # head-SHA idempotency). A successful workflow run that
             # short-circuited via idempotency doesn't count as "Opus ran".
-            REAL_OPUS_ON_HEAD=$(gh api "repos/$REPO_FULL/pulls/$NUM/reviews?per_page=100" \
-              --jq "[.[] | select(.user.login == \"claude[bot]\" and .commit_id == \"$HEAD\" and (.body | length) > 0)] | length" 2>/dev/null || echo "0")
+            #
+            # `--paginate` mirrors the pr-review.yml idempotency: high-review
+            # PRs can push a real Opus review onto a later page. Missing it
+            # here would send us down the "Opus never ran" retry path even
+            # though Opus already reviewed.
+            REAL_OPUS_ON_HEAD=$(gh api "repos/$REPO_FULL/pulls/$NUM/reviews?per_page=100" --paginate \
+              --jq ".[] | select(.user.login == \"claude[bot]\" and .commit_id == \"$HEAD\" and (.body | length) > 0) | .id" 2>/dev/null | wc -l | tr -d ' ' || echo "0")
             if ! [[ "$REAL_OPUS_ON_HEAD" =~ ^[0-9]+$ ]]; then
               REAL_OPUS_ON_HEAD=0
             fi
             if [ "$REAL_OPUS_ON_HEAD" -gt 0 ]; then
               # Opus genuinely reviewed this head — but address-feedback
               # didn't transition. Look up the workflow run anyway as the
-              # age anchor for retry.
-              LAST_OPUS_AT=$(gh api "repos/$REPO_FULL/actions/workflows/ai-pr-review.yml/runs?per_page=30" \
-                --jq "[.workflow_runs[] | select((.display_title // \"\") | test(\"PR #${NUM}(\\\\D|\$)\")) | select(.conclusion == \"success\")] | first | .updated_at // empty" 2>/dev/null || echo "")
+              # age anchor for retry. Use `created` to bound the search
+              # within STUCK_MAX_AGE_SECS and `--paginate` to be robust to
+              # bursty run histories.
+              SINCE_ISO_OPUS=$(date -u -d "@$((NOW - STUCK_MAX_AGE_SECS))" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+              LAST_OPUS_AT=$(gh api "repos/$REPO_FULL/actions/workflows/ai-pr-review.yml/runs?per_page=100&created=%3E${SINCE_ISO_OPUS}" --paginate \
+                --jq ".workflow_runs[] | select((.display_title // \"\") | test(\"PR #${NUM}(\\\\D|\$)\")) | select(.conclusion == \"success\") | .updated_at" 2>/dev/null | head -1 || echo "")
             else
               LAST_OPUS_AT=""
             fi

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -295,19 +295,26 @@ jobs:
               continue
             fi
 
-            # Find when ai-ready-for-review label was last added by looking at
-            # pr-review runs triggered for this PR in the last 30 minutes.
+            # Find recent pr-review runs for this PR (last 30 minutes).
+            #
+            # D-033: We match by `display_title` (set via top-level `run-name:`
+            # in ai-pr-review.yml: "AI PR Review — PR #NNN"). Previously this
+            # filtered by `.inputs.pr_number`, but `.inputs` is NOT in the
+            # workflow-runs LIST endpoint response (it's only in the single-run
+            # detail endpoint). That filter always returned empty, so the
+            # watchdog never recognised a recent run and re-dispatched every
+            # cycle (root cause of the #629/#640/#644-650 stall cascade).
             NOW=$(date -u +%s)
             RECENT_RUNS=$(gh api \
-              "repos/$REPO_FULL/actions/workflows/ai-pr-review.yml/runs?per_page=10" \
-              --jq ".workflow_runs[] |
-                select(
-                  .head_branch != null and
-                  (.created_at | fromdateiso8601) > ($NOW - 1800)
-                ) | .inputs // {} | .pr_number // \"\"" 2>/dev/null || echo "")
+              "repos/$REPO_FULL/actions/workflows/ai-pr-review.yml/runs?per_page=20" \
+              --jq "[.workflow_runs[] |
+                select((.created_at | fromdateiso8601) > ($NOW - 1800)) |
+                .display_title]" 2>/dev/null || echo "[]")
 
-            # Check if there's a recent run for this PR number
-            if echo "$RECENT_RUNS" | grep -qx "$NUM"; then
+            # Match "PR #<NUM>" with a non-digit boundary so #64 doesn't match #647.
+            if echo "$RECENT_RUNS" | jq -e --arg num "$NUM" '
+              any(.[]; test("PR #" + $num + "(\\D|$)"))
+            ' >/dev/null 2>&1; then
               echo "PR #$NUM: pr-review already dispatched recently — skipping"
               continue
             fi
@@ -614,10 +621,33 @@ jobs:
               continue
             fi
 
-            # Look for the most recent successful ai-pr-review on this head SHA.
-            # Best-effort; skip silently on API hiccup.
-            LAST_OPUS_AT=$(gh api "repos/$REPO_FULL/actions/workflows/ai-pr-review.yml/runs?per_page=20" \
-              --jq "[.workflow_runs[] | select(.head_sha == \"$HEAD\" and .conclusion == \"success\")] | first | .updated_at // empty" 2>/dev/null || echo "")
+            # Look for the most recent successful ai-pr-review for this PR.
+            #
+            # D-033: Match by `display_title` ("AI PR Review — PR #NNN" set
+            # via top-level run-name) instead of head_sha. workflow_dispatch
+            # runs record `head_sha = main's SHA`, not the PR's SHA, so the
+            # previous head_sha filter was blind to all watchdog/auto re-
+            # dispatches and made this step think "Opus never ran" every cycle
+            # even though dozens of runs had succeeded.
+            #
+            # Belt-and-braces: also verify a real Opus REVIEW exists on the
+            # PR head SHA (non-empty body, see D-033 / ai-pr-review.yml
+            # head-SHA idempotency). A successful workflow run that
+            # short-circuited via idempotency doesn't count as "Opus ran".
+            REAL_OPUS_ON_HEAD=$(gh api "repos/$REPO_FULL/pulls/$NUM/reviews?per_page=100" \
+              --jq "[.[] | select(.user.login == \"claude[bot]\" and .commit_id == \"$HEAD\" and (.body | length) > 0)] | length" 2>/dev/null || echo "0")
+            if ! [[ "$REAL_OPUS_ON_HEAD" =~ ^[0-9]+$ ]]; then
+              REAL_OPUS_ON_HEAD=0
+            fi
+            if [ "$REAL_OPUS_ON_HEAD" -gt 0 ]; then
+              # Opus genuinely reviewed this head — but address-feedback
+              # didn't transition. Look up the workflow run anyway as the
+              # age anchor for retry.
+              LAST_OPUS_AT=$(gh api "repos/$REPO_FULL/actions/workflows/ai-pr-review.yml/runs?per_page=30" \
+                --jq "[.workflow_runs[] | select((.display_title // \"\") | test(\"PR #${NUM}(\\\\D|\$)\")) | select(.conclusion == \"success\")] | first | .updated_at // empty" 2>/dev/null || echo "")
+            else
+              LAST_OPUS_AT=""
+            fi
             if [ -z "$LAST_OPUS_AT" ]; then
               # Opus has NEVER run on this PR head, but `ai-phase-opus` is set —
               # address-feedback transitioned the labels but its

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -19,6 +19,7 @@
 | [D-029](docs/decisions/D-029-no-worker-workflows.md) | The worker (and any claude-code-action job) must NOT write under `.github/workflows/`. Propose YAML in the PR body for a human commit. |
 | [D-030](docs/decisions/D-030-watchdog-cadence.md) | Watchdog cron is `*/30` + `pull_request_review:[submitted]` + `pull_request:[closed]` to compensate for GitHub schedule queue saturation. |
 | [D-031](docs/decisions/D-031-copilot-opus-sequencing.md) | `ai-pr-review.yml` fires only on `labeled:ai-ready-for-review`. Strict order: Copilot → address → Opus → address → owner-merge. No `\|\| true` on critical dispatches. |
+| [D-033](docs/decisions/D-033-opus-review-marker.md) | Opus head-SHA idempotency requires `(.body \| length) > 0` (inline replies have empty body). Workflow runs matched by `display_title` via top-level `run-name`, never `head_sha` or `.inputs.*`. |
 
 ## Runtime / infrastructure
 

--- a/docs/decisions/D-033-opus-review-marker.md
+++ b/docs/decisions/D-033-opus-review-marker.md
@@ -1,0 +1,56 @@
+---
+id: D-033
+title: Opus head-SHA idempotency requires non-empty body; workflow runs identified by run-name
+date: 2026-05-16
+---
+
+# D-033: Opus head-SHA idempotency requires non-empty body; workflow runs identified by run-name
+
+*Decided: 2026-05-16*
+
+**Context**
+
+On 2026-05-15, eight PRs created by the AI worker (#629, #640, #644, #645, #646, #647, #649, #650) all reached `ai-blocked` despite Copilot having reviewed them and address-feedback having pushed fix commits. The pattern was identical for every one: address-feedback addressed Copilot, transitioned to `ai-cp-after-1 + ai-phase-opus + ai-ready-for-review`, dispatched `ai-pr-review.yml` — and then Opus's review never actually ran. The watchdog re-dispatched five times (every 75 minutes), each dispatch completed `success`, and then the watchdog gave up and stamped `ai-blocked`.
+
+Investigation found **two compounding bugs** in the review state machine:
+
+1. **`ai-pr-review.yml` head-SHA idempotency was over-broad.** The check counted *any* `claude[bot]` review on the head SHA as "Opus already ran". But `ai-address-feedback.yml` posts each inline reply to a Copilot comment as a separate review submission (state=COMMENTED, body=""). After a single Copilot round, the new head SHA typically had 3–10 such empty-body "reviews". Every Opus dispatch saw them and short-circuited at line 90 of `ai-pr-review.yml`.
+
+   On PR #647: 4 empty-body `claude[bot]` reviews on commit `b691ef1`. Opus was dispatched at least 8 times (1 explicit from address-feedback + 1 labeled event + 3 stuck-opus retries + 5 stalled-rfr retries). Every dispatch short-circuited. Zero real Opus reviews on the head SHA.
+
+   The check was introduced for PR #561 (duplicate Opus reviews — three Claude reviews on the same SHA within 50 min). The fix prevented duplicates but couldn't distinguish a real review from an inline reply.
+
+2. **The watchdog's "recent run" detector matched on `head_sha` and `.inputs.pr_number`, both of which are wrong for `workflow_dispatch` runs.**
+
+   - `gh workflow run ai-pr-review.yml --field pr_number=N` defaults to the default branch as the workflow source, and the resulting run record has `head_sha = main's SHA`, not the PR's branch SHA. The "Stuck `ai-phase-opus`" detector at `ai-watchdog.yml:619-620` filtered `head_sha == PR.headRefOid` and therefore could not see the dispatched runs — even though dozens had completed `success`. It concluded "Opus never ran" every cycle and kept re-dispatching.
+   - The "Stalled `ai-ready-for-review`" detector at `ai-watchdog.yml:301-310` tried to read `.inputs.pr_number` from the workflow-runs *list* endpoint. That field is only available on the single-run detail endpoint, never on the list. The check always returned empty, so the detector never recognised a recent run.
+
+**Decision**
+
+Two binding rules apply going forward:
+
+1. **Head-SHA idempotency in `ai-pr-review.yml` must filter on `(.body | length) > 0`.** Real Opus reviews always carry a non-empty body — the `claude-code-action` posts a "## Review summary" via `use_sticky_comment: true`. Inline-reply review submissions from address-feedback always have an empty body. The length check cleanly discriminates the two; a future stricter version may also require the body to match a sentinel string the action emits, but body-length is sufficient and stable.
+
+2. **Workflow runs that need to be matched across `pull_request` and `workflow_dispatch` events must use top-level `run-name:` to embed the identifying token in `display_title`.** For PR-targeted workflows, the convention is `AI PR Review — PR #<N>`. Watchdogs match by `display_title` containing `PR #<N>` (with a non-digit boundary to avoid prefix matches), never by `head_sha` or `.inputs.*`. `head_sha` is unreliable for `workflow_dispatch` (defaults to default branch); `.inputs.*` is absent from the list endpoint.
+
+These rules also apply to similar checks in `ai-address-feedback.yml`, `ai-ci-remediation.yml`, and any future review/feedback workflow.
+
+**Alternatives rejected**
+
+- *Filter by review state in `[APPROVED, CHANGES_REQUESTED]`*: rejected — real Opus reviews can be submitted with state `COMMENTED` when Claude has no clear approve/changes verdict. Body-length is a more reliable discriminator.
+- *Have address-feedback post inline replies via `/pulls/{n}/comments/{cid}/replies` instead of submitting reviews*: rejected for this PR — would change the action's internal behaviour beyond the scope of a state-machine fix. Worth revisiting (PR-review-comment replies are not "reviews" and would avoid the conflation entirely).
+- *Use the `--ref` flag on `gh workflow run` so dispatched runs record the PR branch's head_sha*: rejected — runs the workflow file from the PR branch, which is the wrong thing for security (a PR could modify the workflow). Keep workflow source = default branch; identify runs by `run-name`.
+- *Consolidate the two competing watchdog detectors into one*: deferred to follow-up. Once the matching bugs above are fixed, both detectors correctly conclude "not stalled" and the consolidation is cosmetic.
+
+**Rationale**
+
+Both bugs were latent — they never fired in the steady state where one or two PRs progressed at a time. The 2026-05-15 episode bunched eight PRs into the Opus phase within a 90-minute window and exposed every concurrency-related defect at once. The fix preserves the original intent (no duplicate Opus reviews; auto-recover from dropped dispatches) while correctly identifying the "real review" event.
+
+**See**
+
+- `.github/workflows/ai-pr-review.yml` — head-SHA idempotency (the `EXISTING_CLAUDE_REVIEWS` jq filter near line 90) and top-level `run-name:`
+- `.github/workflows/ai-watchdog.yml` — "Stalled `ai-ready-for-review` PRs" and "Stuck `ai-phase-opus` PRs" steps (the `display_title` and real-Opus-on-head checks)
+- D-021 (two review rounds) — D-033 makes D-021 actually work under burst load
+- D-031 (Copilot → Opus sequencing) — D-033 fixes the Opus-side of the sequence
+- PRs #629, #640, #644, #645, #646, #647, #649, #650 — the eight stalled PRs that motivated this decision
+- PR #561 — the original motivation for the head-SHA idempotency check that D-033 tightens


### PR DESCRIPTION
## Summary

Fixes the head-SHA idempotency and watchdog run-detection bugs that stranded eight PRs in `ai-blocked` on 2026-05-15 (#629, #640, #644, #645, #646, #647, #649, #650).

Three compounding bugs, all addressed here:

- **`ai-pr-review.yml` head-SHA idempotency was over-broad.** It counted any `claude[bot]` review on the head SHA as "Opus already ran". But `ai-address-feedback.yml` submits each inline reply to Copilot's comments as a separate review (state=COMMENTED, body=""). After a single Copilot round, the new head SHA carried 3-10 such empty-body "reviews" — every Opus dispatch saw them and short-circuited. Filter now requires `(.body | length) > 0`. Real Opus reviews always carry a `## Review summary` body via `use_sticky_comment: true`.
- **`ai-watchdog.yml` "Stalled `ai-ready-for-review`" filtered by `.inputs.pr_number` from the workflow-runs *list* endpoint.** `.inputs` is only on the single-run detail endpoint. The filter always returned empty, so the watchdog never recognised a recent run and re-dispatched every 75 minutes until the 5-retry cap fired `ai-blocked`.
- **`ai-watchdog.yml` "Stuck `ai-phase-opus`" filtered runs by `head_sha == PR.headRefOid`.** `workflow_dispatch` runs (which is how the watchdog re-dispatches `ai-pr-review.yml`) record `head_sha = main's SHA`, not the PR's branch SHA. The filter never matched any dispatched run. Watchdog concluded "Opus never ran" each cycle and kept re-dispatching.

Both watchdog detectors now match workflow runs by `display_title` via a new top-level `run-name: AI PR Review — PR #NNN` on `ai-pr-review.yml`. The "Stuck `ai-phase-opus`" detector also verifies a real Opus review exists on the head SHA (non-empty body) before treating a workflow_run `success` as "Opus reviewed".

D-033 recorded with full context, alternatives rejected, and incident detail.

## Test plan

- [ ] CI passes
- [ ] Copilot review (one round)
- [ ] Opus review from clean context (one round)
- [ ] After merge: the 8 currently-blocked PRs are recovered by pushing empty commits to their branches and re-adding `ai-ready-for-review` (separate operation, follow-up). The new head-SHA on each branch will have zero `claude[bot]` reviews, so the tightened idempotency check will let Opus actually run.
- [ ] After merge: the next AI-worker PR exercises the new run-name + tightened idempotency end-to-end; the watchdog should never escalate to `ai-blocked` on a healthy Opus phase.

## Notes

- Bug 4 (two competing watchdog detectors with separate retry caps) is intentionally not addressed in this PR. Once Bugs 1-3 are fixed, both detectors correctly conclude "not stalled" and consolidation is cosmetic. Filed as follow-up.
- The fix touches `.github/workflows/*.yml`, which means **Opus cannot review this PR** (claude-code-action's OIDC exchange refuses self-review of workflow files — handled by `ai-pr-review.yml`'s workflow-file-change gate). Human + Copilot review only, per D-029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)