### PR TITLE
fix(ai-factory): guard .claude-contexts/* lookups on PR-head workflows

### DIFF
--- a/.github/workflows/ai-address-feedback.yml
+++ b/.github/workflows/ai-address-feedback.yml
@@ -330,12 +330,20 @@ jobs:
 
       - name: Use role-specific CLAUDE.md
         run: |
-          cp .claude-contexts/feedback.md CLAUDE.md
-          # Hide the swap from git so workflows that commit/push
-          # (worker, address-feedback, ci-remediation) don't sweep
-          # it into commits, and `git rebase` (mergeability) isn't
-          # blocked by an uncommitted tracked-file change.
-          git update-index --skip-worktree CLAUDE.md
+          # Guarded: PR branches that predate #627 don't carry .claude-contexts/.
+          # Fall back to the repo's default CLAUDE.md (see ai-pr-review.yml for
+          # the same pattern; recovery for PRs #629/#640/#645-650 on 2026-05-16
+          # hit the unguarded `cp`).
+          if [ -f .claude-contexts/feedback.md ]; then
+            cp .claude-contexts/feedback.md CLAUDE.md
+            # Hide the swap from git so workflows that commit/push
+            # (worker, address-feedback, ci-remediation) don't sweep
+            # it into commits, and `git rebase` (mergeability) isn't
+            # blocked by an uncommitted tracked-file change.
+            git update-index --skip-worktree CLAUDE.md
+          else
+            echo "::notice::.claude-contexts/feedback.md not present on this ref (predates #627); using default CLAUDE.md"
+          fi
 
       - name: Address Review Feedback
         id: address

--- a/.github/workflows/ai-ci-remediation.yml
+++ b/.github/workflows/ai-ci-remediation.yml
@@ -138,12 +138,19 @@ jobs:
 
       - name: Use role-specific CLAUDE.md
         run: |
-          cp .claude-contexts/worker-impl.md CLAUDE.md
-          # Hide the swap from git so workflows that commit/push
-          # (worker, address-feedback, ci-remediation) don't sweep
-          # it into commits, and `git rebase` (mergeability) isn't
-          # blocked by an uncommitted tracked-file change.
-          git update-index --skip-worktree CLAUDE.md
+          # Guarded: PR branches that predate #627 don't carry .claude-contexts/.
+          # Fall back to the repo's default CLAUDE.md (see ai-pr-review.yml for
+          # the same pattern).
+          if [ -f .claude-contexts/worker-impl.md ]; then
+            cp .claude-contexts/worker-impl.md CLAUDE.md
+            # Hide the swap from git so workflows that commit/push
+            # (worker, address-feedback, ci-remediation) don't sweep
+            # it into commits, and `git rebase` (mergeability) isn't
+            # blocked by an uncommitted tracked-file change.
+            git update-index --skip-worktree CLAUDE.md
+          else
+            echo "::notice::.claude-contexts/worker-impl.md not present on this ref (predates #627); using default CLAUDE.md"
+          fi
 
       - name: Auto-fix with Claude
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/ai-pr-mergeability.yml
+++ b/.github/workflows/ai-pr-mergeability.yml
@@ -226,12 +226,19 @@ jobs:
       # (the dedup step earlier guarantees we won't loop on the same SHA).
       - name: Use role-specific CLAUDE.md
         run: |
-          cp .claude-contexts/mergeability.md CLAUDE.md
-          # Hide the swap from git so workflows that commit/push
-          # (worker, address-feedback, ci-remediation) don't sweep
-          # it into commits, and `git rebase` (mergeability) isn't
-          # blocked by an uncommitted tracked-file change.
-          git update-index --skip-worktree CLAUDE.md
+          # Guarded: PR branches that predate #627 don't carry .claude-contexts/.
+          # Fall back to the repo's default CLAUDE.md (see ai-pr-review.yml for
+          # the same pattern).
+          if [ -f .claude-contexts/mergeability.md ]; then
+            cp .claude-contexts/mergeability.md CLAUDE.md
+            # Hide the swap from git so workflows that commit/push
+            # (worker, address-feedback, ci-remediation) don't sweep
+            # it into commits, and `git rebase` (mergeability) isn't
+            # blocked by an uncommitted tracked-file change.
+            git update-index --skip-worktree CLAUDE.md
+          else
+            echo "::notice::.claude-contexts/mergeability.md not present on this ref (predates #627); using default CLAUDE.md"
+          fi
 
       - name: Auto-resolve conflicts with Claude
         id: claude_resolve

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -261,12 +261,24 @@ jobs:
 
       - name: Use role-specific CLAUDE.md
         run: |
-          cp .claude-contexts/review.md CLAUDE.md
-          # Hide the swap from git so workflows that commit/push
-          # (worker, address-feedback, ci-remediation) don't sweep
-          # it into commits, and `git rebase` (mergeability) isn't
-          # blocked by an uncommitted tracked-file change.
-          git update-index --skip-worktree CLAUDE.md
+          # `.claude-contexts/review.md` was added in #627. PR branches that
+          # predate that commit (or get re-dispatched via workflow_dispatch
+          # against an older head ref) will be missing the file. The original
+          # `cp` was unguarded and hard-failed in that case (recovery dispatch
+          # for PRs #629/#640/#645-650 on 2026-05-16 all hit "cp: cannot stat
+          # '.claude-contexts/review.md'"). Fall back to the repo's regular
+          # CLAUDE.md when the role-specific file is absent — the review
+          # still runs, just without the role-tailored context.
+          if [ -f .claude-contexts/review.md ]; then
+            cp .claude-contexts/review.md CLAUDE.md
+            # Hide the swap from git so workflows that commit/push
+            # (worker, address-feedback, ci-remediation) don't sweep
+            # it into commits, and `git rebase` (mergeability) isn't
+            # blocked by an uncommitted tracked-file change.
+            git update-index --skip-worktree CLAUDE.md
+          else
+            echo "::notice::.claude-contexts/review.md not present on this ref (predates #627); using default CLAUDE.md"
+          fi
 
       - name: Claude PR Review
         if: steps.d021.outputs.skip != 'true' && steps.cap.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Follow-up to #657. The recovery dispatch (via `workflow_dispatch`) for PRs #629/#640/#645-650 against their existing head SHAs failed with:

```
cp: cannot stat '.claude-contexts/review.md': No such file or directory
```

Those PR branches predate #627, which introduced `.claude-contexts/`. Workflows that check out the PR head SHA (`ai-pr-review.yml`, `ai-address-feedback.yml`, `ai-ci-remediation.yml`, `ai-pr-mergeability.yml`) hard-failed on the unguarded `cp`.

Guard the copy in those four workflows: if the role-specific file is present (post-#627 refs), use it; otherwise fall back to the default `CLAUDE.md` with a `::notice::` log entry. The review/feedback/remediation/mergeability run still completes — just without the role-tailored context, which is a small functional degradation, not a failure.

Workflows that run against `main` directly (`ai-issue-triage.yml`, `ai-bug-hunter.yml`, audit workflows, etc.) keep the original unguarded `cp` since `.claude-contexts/` is always present on `main` post-#627.

## Test plan

- [ ] CI passes
- [ ] Copilot review (one round)
- [ ] After merge: re-dispatch `ai-pr-review.yml` for PRs #629/#640/#645-650 — they should now succeed end-to-end (Opus actually reviews, address-feedback transitions to `ai-awaiting-owner`).

## Notes

- PR touches `.github/workflows/*` so Opus can't self-review (D-029 / workflow-file gate). Copilot + human review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)