### PR TITLE
fix(factory): auto-kick next phase on PR merge + two phase-walker bugs

### DIFF
--- a/.github/workflows/ai-post-merge-verify.yml
+++ b/.github/workflows/ai-post-merge-verify.yml
@@ -1,9 +1,17 @@
 name: AI Post-Merge EC Verify
-# Safety net: when a PR merges and auto-closes a linked issue, check whether
-# the issue's Exit Criteria (EC) items are all verified. If any are unverified,
-# re-open the issue and add `fact-parent-incomplete` so it doesn't silently vanish.
-# Complements the Phase-walker EC guard in ai-worker.yml (which blocks `Closes #N`
-# before the PR is created). This workflow catches cases the worker misses.
+# Two responsibilities, both triggered when a PR merges:
+#
+# 1. Exit Criteria safety net: when a PR auto-closes a linked issue, check
+#    whether the issue's EC items are all verified. If any are unverified,
+#    re-open the issue and add `fact-parent-incomplete` so it doesn't
+#    silently vanish. Complements the Phase-walker EC guard in
+#    ai-worker.yml (which blocks `Closes #N` before the PR is created).
+#
+# 2. Phase-walker auto-kickoff: when a phase PR (branch `ai/issue-N-pK`)
+#    merges and the issue has more phases left, automatically add
+#    `ai-work` to the issue so Phase K+1 starts implementing without
+#    manual intervention. Closes the gap where the owner had to notice
+#    a merged phase PR and remember to re-label the issue.
 on:
   pull_request:
     types: [closed]
@@ -130,3 +138,87 @@ jobs:
               echo "Issue #$ISSUE_NUM: all EC items verified (or none defined) — no action needed."
             fi
           done
+
+      - name: Auto-kick next phase (multi-phase phase-walker)
+        run: |
+          set -uo pipefail
+
+          # Only act on factory phase branches: ai/issue-<N>-p<K>.
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          PHASE_MATCH=$(echo "$BRANCH" | grep -oE '^ai/issue-([0-9]+)-p([0-9]+)$' || true)
+          if [ -z "$PHASE_MATCH" ]; then
+            echo "Branch '$BRANCH' is not a phase branch — skipping next-phase kick."
+            exit 0
+          fi
+          ISSUE_NUM=$(echo "$BRANCH" | sed -E 's|^ai/issue-([0-9]+)-p([0-9]+)$|\1|')
+          CURRENT_PHASE=$(echo "$BRANCH" | sed -E 's|^ai/issue-([0-9]+)-p([0-9]+)$|\2|')
+          echo "Phase branch: issue=#$ISSUE_NUM current_phase=$CURRENT_PHASE"
+
+          # Skip if the PR body says "Closes #N" — that's the final phase
+          # marker; no next phase exists. (`Part of #N` indicates a
+          # non-final phase OR a final phase with EC items still pending —
+          # in the EC-pending case the previous step has already added
+          # `fact-parent-incomplete` and re-opened the issue; we further
+          # guard below by checking that label.)
+          PR_BODY=$(gh pr view "$PR" --repo "$REPO" --json body --jq '.body' 2>/dev/null || echo "")
+          if echo "$PR_BODY" | grep -qE "Closes #${ISSUE_NUM}\b"; then
+            echo "PR #$PR closes issue #$ISSUE_NUM — final phase, not kicking next."
+            exit 0
+          fi
+
+          # Read the issue's state + labels + body in one call.
+          ISSUE_JSON=$(gh issue view "$ISSUE_NUM" --repo "$REPO" \
+            --json state,labels,body 2>/dev/null || echo "")
+          if [ -z "$ISSUE_JSON" ]; then
+            echo "Issue #$ISSUE_NUM not found — skipping."
+            exit 0
+          fi
+
+          ISSUE_STATE=$(echo "$ISSUE_JSON" | jq -r '.state')
+          ISSUE_LABELS=$(echo "$ISSUE_JSON" | jq -r '[.labels[].name] | join(",")')
+          ISSUE_BODY=$(echo "$ISSUE_JSON" | jq -r '.body')
+
+          if [ "$ISSUE_STATE" = "CLOSED" ]; then
+            echo "Issue #$ISSUE_NUM is CLOSED — not kicking next phase."
+            exit 0
+          fi
+
+          # Hard skips — owner is already on the hook or the factory is paused.
+          for BLOCKER in no-ai needs-human-approval fact-parent-incomplete ai-blocked; do
+            if echo ",$ISSUE_LABELS," | grep -q ",${BLOCKER},"; then
+              echo "Issue #$ISSUE_NUM has '$BLOCKER' — not kicking next phase."
+              exit 0
+            fi
+          done
+
+          # Already kicked / running — idempotency.
+          for ALREADY in ai-work fact-in-progress; do
+            if echo ",$ISSUE_LABELS," | grep -q ",${ALREADY},"; then
+              echo "Issue #$ISSUE_NUM already has '$ALREADY' — next phase is queued or running."
+              exit 0
+            fi
+          done
+
+          # Count phase headings in the issue body to confirm there is a next phase.
+          # The planner writes `## Phase N — <name>` (em-dash or hyphen).
+          TOTAL_PHASES=$(printf '%s' "$ISSUE_BODY" \
+            | grep -cE '^## Phase [0-9]+( |$)' || true)
+          if [ "${TOTAL_PHASES:-0}" -lt 2 ]; then
+            echo "Issue #$ISSUE_NUM has $TOTAL_PHASES phase headings — nothing to kick."
+            exit 0
+          fi
+          NEXT_PHASE=$(( CURRENT_PHASE + 1 ))
+          if [ "$NEXT_PHASE" -gt "$TOTAL_PHASES" ]; then
+            echo "Issue #$ISSUE_NUM: merged Phase $CURRENT_PHASE was the last of $TOTAL_PHASES — done."
+            exit 0
+          fi
+
+          # Add ai-work — this fires the labeled-event-driven implementer.
+          echo "Adding ai-work to issue #$ISSUE_NUM (Phase $CURRENT_PHASE of $TOTAL_PHASES merged; Phase $NEXT_PHASE up next)."
+          gh api -X POST "repos/$REPO/issues/$ISSUE_NUM/labels" \
+            -f "labels[]=ai-work" >/dev/null 2>&1 || true
+
+          gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "$(cat <<EOF
+          ⏭️ **AI Factory**: Phase $CURRENT_PHASE merged (#$PR). Auto-added \`ai-work\` to start **Phase $NEXT_PHASE of $TOTAL_PHASES**. The implementer should open the next PR shortly. If you'd rather pause here, remove \`ai-work\` and add \`ai-blocked\`.
+          EOF
+          )" 2>/dev/null || true

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -97,7 +97,13 @@ jobs:
             fi
 
             # Determine which phase to dispatch.
-            if echo ",$LABELS," | grep -q ",fact-task,"; then
+            # `fact-task` → legacy sub-task (path B) → implement.
+            # `fact-planned` (without fact-task) → D-034 single-track phased
+            #   issue → implement. The planner already rewrote the body and
+            #   set `fact-planned`; re-dispatching `plan` here would just
+            #   loop on an already-planned issue (#721 hit this).
+            # Neither → first-time planning → plan.
+            if echo ",$LABELS," | grep -qE ",(fact-task|fact-planned),"; then
               PHASE="implement"
             else
               PHASE="plan"
@@ -996,8 +1002,14 @@ jobs:
             gh issue comment "$NUM" --repo "$REPO_FULL" \
               --body "🔄 AI Factory watchdog: auto-retrying (attempt $ATTEMPT of $MAX_RETRIES) after transient failure. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})." || true
 
-            # Determine phase: sub-tasks (fact-task) → implement, parents → plan
-            if echo ",$LABELS," | grep -q ",fact-task,"; then
+            # Determine phase: sub-tasks (fact-task) or already-planned
+            # single-track phased issues (fact-planned without fact-task) →
+            # implement; otherwise first-time planning → plan. Without the
+            # fact-planned check this loop would keep re-dispatching the
+            # planner on an issue that was already planned (#721 hit this
+            # after Phase 1 merged: subsequent transient failures kept being
+            # retried with phase=plan, which kept failing).
+            if echo ",$LABELS," | grep -qE ",(fact-task|fact-planned),"; then
               PHASE="implement"
             else
               PHASE="plan"

--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -437,10 +437,24 @@ jobs:
           set -euo pipefail
           # Look for a PR whose head branch follows ai/issue-<N>-... OR whose
           # body contains "Closes #<N>".
-          PR_BY_BRANCH=$(gh pr list --state all --search "head:ai/issue-${ISSUE_NUMBER}-" \
-            --json number,state --jq '.[0].number // empty')
-          PR_BY_BODY=$(gh pr list --state all --search "Closes #${ISSUE_NUMBER} in:body" \
-            --json number,state --jq '.[0].number // empty')
+          #
+          # `--state open` is intentional: this step is asking "did THIS
+          # worker run produce a PR?". A merged PR from a previous phase
+          # satisfies the same branch-prefix search (e.g. ai/issue-721-p1
+          # is matched by `head:ai/issue-721-` even after Phase 1 was
+          # merged) and would make the verify step report `pr_created` on
+          # a Phase 2 run that actually failed without opening anything —
+          # the success path then re-fires on the merged Phase 1 PR and
+          # the failure path also fires, producing the confusing dual
+          # comment seen on #721 (2026-05-22 20:50). Only open PRs count.
+          # Sort newest first so a stale open PR on a different phase
+          # branch never wins over the just-pushed one.
+          PR_BY_BRANCH=$(gh pr list --state open --search "head:ai/issue-${ISSUE_NUMBER}-" \
+            --json number,state,createdAt \
+            --jq 'sort_by(.createdAt) | reverse | .[0].number // empty')
+          PR_BY_BODY=$(gh pr list --state open --search "Closes #${ISSUE_NUMBER} in:body" \
+            --json number,state,createdAt \
+            --jq 'sort_by(.createdAt) | reverse | .[0].number // empty')
           PR_NUMBER="${PR_BY_BRANCH:-$PR_BY_BODY}"
 
           # Also check if the issue was closed by the worker (deliberate no-op).

--- a/docs/issue-format.md
+++ b/docs/issue-format.md
@@ -237,7 +237,8 @@ Phases live as `## Phase N — <name>` headings **inside the issue body**. They 
 - Phase 1 starts when `ai-work` is added to the issue.
 - The implementer finds the next un-merged phase (checks whether each phase's branch has a merged PR via `gh pr list --search "head:<branch>" --state merged`).
 - Phase N+1 starts only after Phase N's PR is **merged and `main` is green**.
-- The owner adds `ai-work` again to trigger Phase N+1 (or the watchdog re-triggers if `fact-in-progress` is stalled with unchecked tasks remaining).
+- **Auto-kickoff**: when a phase PR (branch `ai/issue-<N>-p<K>`) merges and the issue still has unmerged phases, `ai-post-merge-verify.yml` auto-adds `ai-work` to the issue, triggering Phase K+1. The owner does not need to re-label per phase. The auto-kick is skipped if the issue has `no-ai`, `needs-human-approval`, `fact-parent-incomplete`, `ai-blocked`, `ai-work`, or `fact-in-progress`. Final-phase PRs (`Closes #N`) never kick.
+- To pause between phases, add `ai-blocked` after merging Phase K — auto-kickoff respects it.
 
 **Single phase** (default): issue has one `## Phase 1` block. The implementer walks its `### Tasks` checklist, commits per task, ticks checkboxes via `gh issue edit --body`, opens one PR.
 


### PR DESCRIPTION
Three related fixes for the multi-phase D-034 single-track flow, all
surfaced by issue #721 (Phase 1 merged, then the issue got trapped in
a planner-retry loop with no Phase 2 PR).

1. Auto-kickoff next phase on PR merge.
   `ai-post-merge-verify.yml` now adds `ai-work` to the issue when a
   phase PR (branch `ai/issue-<N>-p<K>`) merges and unmerged phases
   remain. Closes the gap where the owner had to notice a merged
   phase PR and remember to re-label. Skipped when the issue has
   `no-ai`, `needs-human-approval`, `fact-parent-incomplete`,
   `ai-blocked`, `ai-work`, or `fact-in-progress`; never fires on
   `Closes #N` (final phase). To pause between phases, add
   `ai-blocked` after merging.

2. Watchdog phase selection for D-034 single-track issues.
   Both `PHASE=` blocks in `ai-watchdog.yml` previously routed to
   `plan` unless `fact-task` was present. Single-track phased issues
   carry `fact-planned` (no `fact-task`), so the watchdog kept
   re-dispatching the planner on already-planned #721, which failed
   every time. Now routes `fact-task` OR `fact-planned` → implement.

3. Worker verify-PR step now searches `--state open` only.
   `head:ai/issue-721-` matches both `ai/issue-721-p1` (merged) and
   `ai/issue-721-p2`. When the Phase 2 agent failed, the verify step
   reported `pr_created` against the merged Phase 1 PR, firing both
   the success path (`♻️ found existing PR #727`) and the failure
   path simultaneously. Restricting to open PRs (sorted newest-first)
   ensures the verify only matches a PR this run could have produced.

Also documents the new behaviour in `docs/issue-format.md` § Phase
execution order.