### PR TITLE
ci: add knowledge.ts drift guard to dashboard-test job (closes #715)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
           cache: npm
           cache-dependency-path: dashboard/package-lock.json
       - run: npm ci
+      - name: knowledge.ts drift guard
+        run: npm run build:knowledge && git diff --exit-code lib/knowledge.ts
       - run: npm test
       - run: npm run test:coverage
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Adds the `knowledge.ts drift guard` step to the `dashboard-test` job in `.github/workflows/ci.yml`. Closes the 1-gap finding from the Factory Manager verification of #704: source MD changes that aren't followed by `npm run build:knowledge` would leave `dashboard/lib/knowledge.ts` stale, and the dashboard LLM would silently use the old bundle. AGENTS.md already documents this guard as active — this commit makes the doc accurate.

The new step runs in `working-directory: dashboard` (the job already sets that), between `npm ci` and `npm test`:

```yaml
- run: npm ci
- name: knowledge.ts drift guard
  run: npm run build:knowledge && git diff --exit-code lib/knowledge.ts
- run: npm test
```

Verified locally: on current `main`, `npm run build:knowledge` produces no diff (regenerated `knowledge.ts` is byte-identical to the committed file), so the guard is green from day one.

## Per D-029

This is a workflow file change; D-029 says the AI worker must not push under `.github/workflows/`. Committed by a Claude Code on the Web session (not the in-repo worker), same path as #734.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'` — passes
- [x] Local `npm run build:knowledge` produces no diff against `lib/knowledge.ts` on main — the guard will be green on this PR
- [ ] CI run on this PR — `dashboard-test` job shows the new step executing between `npm ci` and `npm test`
- [ ] Negative confirmation (future-proof): the next PR that edits a source MD without regenerating will fail at this step

Part of #715 (single-phase issue, 1 EC item which is Human-only by D-029 attribution — but it's a CI run, so machine-verifiable via this PR's check log).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EAvS3DMYhBvQmqxvW1aFed)_