### PR TITLE
fix(ci): ai-auto-release uses workflow_runs(ci.yml) — actual fix for #674

### DIFF
--- a/.github/workflows/ai-auto-release.yml
+++ b/.github/workflows/ai-auto-release.yml
@@ -18,6 +18,7 @@ permissions:
   contents: write
   issues: read
   pull-requests: read
+  actions: read  # required by the Check CI status step's actions/workflows/ci.yml/runs query
 
 jobs:
   release:

--- a/.github/workflows/ai-auto-release.yml
+++ b/.github/workflows/ai-auto-release.yml
@@ -143,14 +143,31 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          CI_STATUS=$(gh api repos/${{ github.repository }}/commits/main/status --jq '.state' 2>/dev/null || echo "unknown")
-          echo "ci_status=${CI_STATUS}" >> $GITHUB_OUTPUT
+          # Why workflow_runs (ci.yml) and not commits/<sha>/check-runs:
+          # The legacy Commit Status API (gh api .../commits/main/status) returns
+          # 'pending' with total_count=0 because this repo's CI runs only as
+          # Check Runs, never as Commit Statuses.
+          # The Check Runs API on main HEAD also doesn't work cleanly: this
+          # repo runs many factory workflows (review, address, resolve, scan,
+          # ...) that fire continuously on PR events and leave check-runs in
+          # 'in_progress' or 'failure' on main HEAD. A bare `commits/main/check-runs`
+          # query would always return 'pending' or 'failure' even when the real
+          # CI workflow (ci.yml) is fully green.
+          # The robust query is "what was the latest ci.yml workflow run on main?"
+          # — that ignores all other workflows by design.
+          CI_STATUS=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?branch=${{ github.event.repository.default_branch }}&per_page=1" \
+            --jq '.workflow_runs[0] // {} |
+                  if (.status // "") != "completed" then "pending"
+                  elif .conclusion == "success" then "success"
+                  else "failure"
+                  end' 2>/dev/null || echo "unknown")
+          echo "ci_status=${CI_STATUS}" >> "$GITHUB_OUTPUT"
           if [ "$CI_STATUS" != "success" ]; then
-            echo "CI status is '${CI_STATUS}' on main (expected 'success'). Skipping release."
-            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Latest ci.yml run on main is '${CI_STATUS}' (expected 'success'). Skipping release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            echo "CI status: ${CI_STATUS}. Proceeding with release."
-            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "Latest ci.yml run on main: success. Proceeding with release."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create release


### PR DESCRIPTION
## Summary

Actually fixes the bug in `ai-auto-release.yml` that #674 documented and PR #739 attempted to fix.

**What #739 missed**: it correctly identified D-029 (worker can't push under `.github/workflows/`) and put the YAML proposal in the PR body for human commit. But the proposed YAML (`commits/main/check-runs` with tri-state jq) had a different bug — this repo runs many factory workflows (`review`, `address`, `resolve`, `scan`, ...) that fire continuously on PR events and leave check-runs in `in_progress` or `failure` on `main` HEAD. A bare check-runs query would still mis-report even when `ci.yml` is green. Verified empirically: `gh api repos/alvarolobato/powershop-analytics/commits/main/check-runs` on the current main returns 1 `in_progress` review + 1 `failure` scan alongside the 5 green CI jobs.

**The correct query**: filter precisely to the `ci.yml` workflow's latest run on main using `actions/workflows/ci.yml/runs?branch=main&per_page=1`. Factory check-runs are ignored by construction because they run under different workflow files.

```yaml
CI_STATUS=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?branch=${{ github.event.repository.default_branch }}&per_page=1" \
  --jq '.workflow_runs[0] // {} |
        if (.status // "") != "completed" then "pending"
        elif .conclusion == "success" then "success"
        else "failure"
        end' 2>/dev/null || echo "unknown")
```

Tri-state:
- `status != "completed"` → `pending` (CI still in flight)
- `conclusion == "success"` → `success`
- otherwise → `failure`

**Dry-run against current main**: `success` (latest ci.yml run on `5e954d2` is green).

## Per D-029

This workflow YAML is committed by a Claude Code on the Web session, not the in-repo `claude-code-action` worker. Same path as #734 and #741.

## Why #674 was reopened

PR #739 closed #674 via the `Closes #674` trailer despite having zero file changes — the worker followed the D-029 "put YAML in body" pattern but inadvertently merged an empty PR that closed the bug without fixing it. Filed a separate follow-up issue to prevent that worker pattern from recurring (the worker should refuse `Closes` keywords on zero-file PRs whose only deliverable is a workflow YAML in the body).

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` — YAML parses
- [x] Dry-run query against current main → `success` (latest ci.yml on 5e954d2)
- [ ] CI green on this PR
- [ ] Owner manually triggers `gh workflow run ai-auto-release.yml --field version_bump=patch` after merge — confirms the gate now proceeds instead of skipping with "CI status is 'pending'"

Closes #674


---
_Generated by [Claude Code](https://claude.ai/code/session_01EAvS3DMYhBvQmqxvW1aFed)_