### PR TITLE
ci: add typecheck step to dashboard-test (closes EC-4 gap from #711)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       - run: npm ci
       - name: knowledge.ts drift guard
         run: npm run build:knowledge && git diff --exit-code lib/knowledge.ts
+      - run: npm run typecheck
       - run: npm test
       - run: npm run test:coverage
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Adds the `npm run typecheck` step to the `dashboard-test` job in `.github/workflows/ci.yml`. Closes the workflow-YAML gap from PR #742 (DashboardLlmProviderId fix, closed #711): the TS fixes landed, but the CI guard that would catch type drift between test-time and build-time was left as a YAML proposal in #742's body because the worker couldn't push under D-029.

Without this step, future regressions of the same shape (a type widened in one place but not the consumer) won't fail CI — only the Docker image build, where the cost of detection is much higher.

The step goes between the existing `knowledge.ts drift guard` and `npm test`:

```yaml
- run: npm ci
- name: knowledge.ts drift guard
  run: npm run build:knowledge && git diff --exit-code lib/knowledge.ts
- run: npm run typecheck   # NEW
- run: npm test
```

`working-directory: dashboard` is already set at the job level.

## Per D-029

Workflow file change committed by a Claude Code on the Web session, not the in-repo worker. Same path as #715, #734, #741, #743, #738, #740, #746.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` — passes
- [x] `cd dashboard && npm run typecheck` on current main — exit 0
- [ ] CI green on this PR (the new step itself will run and confirm)

Part of #711 (closes the EC-4 gap — proposed typecheck YAML — that PR #742 left pending).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EAvS3DMYhBvQmqxvW1aFed)_