### PR TITLE
fix(factory): digest redispatch (OIDC 401) + deterministic EC ticking (#751)

### DIFF
--- a/.github/ai-factory/fixtures/tick-metachars.md
+++ b/.github/ai-factory/fixtures/tick-metachars.md
@@ -1,0 +1,7 @@
+## Exit criteria / Validation
+
+- [ ] **EC-1**: Drift guard runs `npm run build:knowledge && git diff --exit-code lib/knowledge.ts` between steps — *Verified by*: CI run.
+- [ ] **EC-2**: Path uses a/b and a|b and $HOME and `back``ticks` — *Verified by*: file diff.
+- [x] **EC-3**: Already checked — *Human-only*.
+- [ ] **EC-10**: Must NOT be flipped when only EC-1 is requested — *Verified by*: test.
+- [ ] **EC-11**: Also must NOT be flipped — *Human-only*.

--- a/.github/ai-factory/prompts/ec-validator.md
+++ b/.github/ai-factory/prompts/ec-validator.md
@@ -105,21 +105,35 @@ The validator **MUST NOT** close the issue when any `human_only=true` item is un
 
 ### Step 7 — Tick verified items in the issue body
 
-For each EC item where `verify-ec.sh` returned `verified=true` AND the item is not already checked:
+**Do NOT edit the body with a manual `sed`/string replacement.** EC lines can
+contain `&`, `|`, `/`, `$`, and backticks; a `sed s///` replacement misinterprets
+them (e.g. `&` expands to the whole matched line) and corrupts the body — this
+happened on issue #704 (see #751). Use the deterministic ticker script instead.
+
+Collect the ids of every EC item where `verify-ec.sh` returned `verified=true`,
+then run the script — it flips only `- [ ] **EC-N**` → `- [x] **EC-N**` for the
+exact ids given (EC-1 never matches EC-10), leaving all other content
+byte-identical:
 
 ```bash
+# Build the list of verified, not-already-checked ids from RESULTS + EC_ITEMS.
+VERIFIED_IDS=$(printf '%s' "$RESULTS" | jq -r '.[] | select(.verified == true) | .id')
+
 BODY=$(gh issue view "$ISSUE_NUMBER" --json body --jq '.body')
-# For each verified item EC-N, replace '- [ ] **EC-N**' with '- [x] **EC-N**' globally
-# Do this only for items where the script said verified=true.
+BODY_FILE=$(mktemp /tmp/issue-body-XXXXXX.md)
+printf '%s' "$BODY" > "$BODY_FILE"
+
+if [ -n "$VERIFIED_IDS" ]; then
+  NEW_BODY=$(bash .github/ai-factory/scripts/tick-ec.sh "$BODY_FILE" $VERIFIED_IDS)
+  printf '%s' "$NEW_BODY" > "$BODY_FILE"
+  gh issue edit "$ISSUE_NUMBER" --body-file "$BODY_FILE"
+fi
+rm -f "$BODY_FILE"
 ```
 
-After updating all verified items, write the new body back:
-```bash
-TMP=$(mktemp /tmp/issue-body.XXXXXX)
-printf '%s' "$UPDATED_BODY" > "$TMP"
-gh issue edit "$ISSUE_NUMBER" --body-file "$TMP"
-rm -f "$TMP"
-```
+`tick-ec.sh` is metacharacter-safe (awk-based, no `sed s///`) and only flips
+unchecked boxes for the named ids — never the reverse, never a partial-number
+match.
 
 ### Step 8 — Build the validation comment
 

--- a/.github/ai-factory/scripts/tick-ec.sh
+++ b/.github/ai-factory/scripts/tick-ec.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# tick-ec.sh — Deterministically flip "- [ ] **EC-N**" to "- [x] **EC-N**"
+# for a given set of EC ids, without the metacharacter hazards of an
+# LLM-driven sed substitution.
+#
+# Background (issue #751): the EC validator's prompt previously instructed the
+# LLM to "replace '- [ ] **EC-N**' with '- [x] **EC-N**'". On issue #704 the
+# agent used a sed s/// substitution, and the EC line contained "&&" — sed's
+# replacement '&' expands to the whole matched text, so the line was
+# re-inserted into itself and corrupted. D-038 says "the LLM is scribe, bash is
+# judge" — body ticking must be deterministic too, not LLM-driven.
+#
+# Usage:
+#   tick-ec.sh <body-file> <EC-id> [EC-id ...]
+#
+#   <body-file>  Path to a file containing the issue body markdown.
+#   <EC-id>      One or more ids like "EC-1" "EC-3" — only these unchecked
+#                items are flipped to [x]. Already-checked lines are left alone.
+#
+# Output: the modified body to stdout. Non-EC lines and unmatched EC lines are
+# emitted byte-for-byte unchanged. EC-1 never matches EC-10 (exact id compare).
+#
+# Why awk and not sed: awk's sub(regexp, repl, line) only touches the matched
+# prefix "- [ ] "; the replacement string "- [x] " contains no "&", and the
+# rest of the line (which may contain &&, |, /, $, backticks) is preserved as
+# the awk field value, never interpreted as a replacement string.
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: tick-ec.sh <body-file> <EC-id> [EC-id ...]" >&2
+  exit 2
+fi
+
+BODY_FILE="$1"
+shift
+
+if [ ! -f "$BODY_FILE" ]; then
+  echo "tick-ec.sh: body file not found: $BODY_FILE" >&2
+  exit 2
+fi
+
+# Build a space-delimited set of target ids: " EC-1  EC-3 "
+IDS=" "
+for id in "$@"; do
+  IDS="${IDS}${id} "
+done
+
+awk -v ids="$IDS" '
+{
+  line = $0
+  # Match an unchecked EC line:  - [ ] **EC-<n>**
+  if (line ~ /^- \[ \] \*\*EC-[0-9]+\*\*/) {
+    # Extract the exact EC id from the matched prefix.
+    if (match(line, /EC-[0-9]+/)) {
+      ecid = substr(line, RSTART, RLENGTH)
+      # Exact whole-token membership test — " EC-1 " never matches " EC-10 ".
+      if (index(ids, " " ecid " ") > 0) {
+        # Flip only the leading checkbox; the rest of the line is untouched.
+        sub(/^- \[ \]/, "- [x]", line)
+      }
+    }
+  }
+  print line
+}
+' "$BODY_FILE"

--- a/.github/ai-factory/tests/test-tick-ec.sh
+++ b/.github/ai-factory/tests/test-tick-ec.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Tests tick-ec.sh — the deterministic EC checkbox flipper (issue #751).
+# Verifies metacharacter safety (&&, |, /, $, backticks) and EC-1≠EC-10
+# word-boundary disambiguation. The regression case mirrors the #704
+# corruption where '&&' in an EC line broke a sed-based substitution.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TICK="$SCRIPT_DIR/../scripts/tick-ec.sh"
+FIXTURE="$SCRIPT_DIR/../fixtures/tick-metachars.md"
+
+PASS=0
+FAIL=0
+
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  ✓ %s\n' "$name"
+    PASS=$((PASS + 1))
+  else
+    printf '  ✗ %s\n     expected: %s\n     actual:   %s\n' "$name" "$expected" "$actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Flip EC-1 and EC-2 only.
+OUT=$("$TICK" "$FIXTURE" EC-1 EC-2)
+
+echo "== checkbox state after ticking EC-1 EC-2 =="
+check "EC-1 flipped to [x]"        "1" "$(printf '%s\n' "$OUT" | grep -c '^- \[x\] \*\*EC-1\*\*')"
+check "EC-2 flipped to [x]"        "1" "$(printf '%s\n' "$OUT" | grep -c '^- \[x\] \*\*EC-2\*\*')"
+check "EC-3 stays [x] (was checked)" "1" "$(printf '%s\n' "$OUT" | grep -c '^- \[x\] \*\*EC-3\*\*')"
+check "EC-10 NOT flipped (still [ ])" "1" "$(printf '%s\n' "$OUT" | grep -c '^- \[ \] \*\*EC-10\*\*')"
+check "EC-11 NOT flipped (still [ ])" "1" "$(printf '%s\n' "$OUT" | grep -c '^- \[ \] \*\*EC-11\*\*')"
+
+echo "== content integrity (no corruption) =="
+# The EC-1 line content after the checkbox must be byte-identical to the fixture's.
+FIX_EC1_CONTENT=$(grep '\*\*EC-1\*\*' "$FIXTURE" | sed -E 's/^- \[[ x]\] //')
+OUT_EC1_CONTENT=$(printf '%s\n' "$OUT" | grep '\*\*EC-1\*\*' | sed -E 's/^- \[[ x]\] //')
+check "EC-1 content (with '&&') intact" "$FIX_EC1_CONTENT" "$OUT_EC1_CONTENT"
+
+FIX_EC2_CONTENT=$(grep '\*\*EC-2\*\*' "$FIXTURE" | sed -E 's/^- \[[ x]\] //')
+OUT_EC2_CONTENT=$(printf '%s\n' "$OUT" | grep '\*\*EC-2\*\*' | sed -E 's/^- \[[ x]\] //')
+check "EC-2 content (|, /, \$, backticks) intact" "$FIX_EC2_CONTENT" "$OUT_EC2_CONTENT"
+
+echo "== line count unchanged (no duplication) =="
+check "same number of EC lines" \
+  "$(grep -cE '^\- \[[ x]\] \*\*EC-' "$FIXTURE")" \
+  "$(printf '%s\n' "$OUT" | grep -cE '^\- \[[ x]\] \*\*EC-')"
+
+echo "== idempotency: re-ticking already-checked items is a no-op =="
+OUT2=$("$TICK" "$FIXTURE" EC-3)
+check "EC-3 re-tick leaves exactly one EC-3 line" \
+  "1" "$(printf '%s\n' "$OUT2" | grep -c '\*\*EC-3\*\*')"
+
+echo "== regression: whole body byte-stable except the two flips =="
+EXPECTED=$(sed -E '
+  s/^- \[ \] (\*\*EC-1\*\*)/- [x] \1/;
+  s/^- \[ \] (\*\*EC-2\*\*)/- [x] \1/' "$FIXTURE")
+check "body matches expected two-flip diff" "$EXPECTED" "$OUT"
+
+echo
+printf '== Summary: %d passed, %d failed ==\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.github/workflows/ai-pre-merge-digest.yml
+++ b/.github/workflows/ai-pre-merge-digest.yml
@@ -12,9 +12,7 @@ run-name: >-
   AI Pre-Merge Digest — PR #${{ github.event.pull_request.number || inputs.pr_number }}
 on:
   pull_request:
-    types: [labeled]
-  pull_request_target:
-    types: [synchronize]
+    types: [labeled, synchronize]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -31,30 +29,45 @@ permissions:
   pull-requests: write
   issues: read
   id-token: write
+  actions: write
 
 jobs:
-  digest:
-    # Fire on label events only when the label is ai-awaiting-owner.
-    # Fire on synchronize only when the PR already has ai-awaiting-owner
-    # (so a new commit after convergence also gets a fresh digest).
+  # claude-code-action's OIDC→app-token exchange fails (401) on raw
+  # pull_request / pull_request_target events in this repo. The established
+  # factory pattern (see ai-pr-review.yml + ai-address-feedback.yml) is to run
+  # claude-code-action only via workflow_dispatch and re-dispatch from event
+  # triggers. This job is the cheap re-dispatcher — it runs no LLM, just
+  # `gh workflow run`, so it has no auth problem.
+  redispatch:
     if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'no-ai') &&
+      !contains(github.event.pull_request.labels.*.name, 'no-pr-review') &&
       (
-        github.event_name == 'workflow_dispatch'
-      ) || (
-        github.event_name == 'pull_request' &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'ai-awaiting-owner' &&
-        !contains(github.event.pull_request.labels.*.name, 'no-ai') &&
-        !contains(github.event.pull_request.labels.*.name, 'no-pr-review') &&
-        github.event.pull_request.head.repo.full_name == github.repository
-      ) || (
-        github.event_name == 'pull_request_target' &&
-        github.event.action == 'synchronize' &&
-        contains(github.event.pull_request.labels.*.name, 'ai-awaiting-owner') &&
-        !contains(github.event.pull_request.labels.*.name, 'no-ai') &&
-        !contains(github.event.pull_request.labels.*.name, 'no-pr-review') &&
-        github.event.pull_request.head.repo.full_name == github.repository
+        (github.event.action == 'labeled' && github.event.label.name == 'ai-awaiting-owner') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ai-awaiting-owner'))
       )
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Re-dispatch digest via workflow_dispatch
+        run: |
+          echo "PR #$PR_NUMBER landed/updated with ai-awaiting-owner — dispatching digest (workflow_dispatch auth path)."
+          gh workflow run ai-pre-merge-digest.yml \
+            --repo "$REPO" \
+            --field pr_number="$PR_NUMBER" 2>/dev/null || {
+            echo "::warning::Failed to dispatch ai-pre-merge-digest.yml for PR #$PR_NUMBER."
+          }
+
+  digest:
+    # Only the workflow_dispatch path runs claude-code-action — its OIDC
+    # app-token exchange works on workflow_dispatch but 401s on pull_request.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## Summary

Fixes the two outstanding factory problems surfaced during the EC-validator / pre-merge-digest rollout.

### (1) Pre-merge digest — OIDC 401 on `pull_request` events

The digest's first real run (on PR #749) failed: `claude-code-action`'s OIDC→app-token exchange returns **401 Invalid OIDC token** on raw `pull_request` / `pull_request_target` events in this repo. The established factory pattern (`ai-pr-review.yml` + `ai-address-feedback.yml`, which "explicitly dispatch … so it runs via workflow_dispatch") is to run `claude-code-action` **only** via `workflow_dispatch` and re-dispatch from event triggers. `workflow_dispatch` auth is proven to work (pr-review succeeds that way).

Restructured `ai-pre-merge-digest.yml`:
- New **`redispatch`** job on `pull_request: [labeled, synchronize]` — runs **no LLM**, just `gh workflow run` (so no OIDC exchange, no auth problem). Gated to `ai-awaiting-owner` + same-repo + not `no-ai`/`no-pr-review`.
- **`digest`** job (the `claude-code-action` step) is now `if: github.event_name == 'workflow_dispatch'` only.
- Dropped `pull_request_target` (security footgun + same auth failure).
- Added `actions: write` for the redispatch.

### (2) EC validator corrupted issue bodies — #751

The validator prompt's Step 7 told the LLM to `sed`-replace `- [ ] **EC-N**` → `- [x] **EC-N**`. On #704 the EC line contained `` `npm run build:knowledge && git diff` `` — `sed`'s replacement `&` expands to the whole matched line, so the line was re-inserted into itself and corrupted. Per D-038 ("the LLM is scribe, bash is judge") the body write must be deterministic too.

- New `.github/ai-factory/scripts/tick-ec.sh` — **awk-based**, flips only `- [ ] **EC-N**` → `- [x] **EC-N**` for the exact ids passed (EC-1 never matches EC-10), immune to `&`, `|`, `/`, `$`, backticks in the line content (the content is never in a replacement-string position).
- `ec-validator.md` Step 7 rewritten to call `tick-ec.sh`, with an explicit "do NOT sed-replace" warning referencing #704/#751.
- `test-tick-ec.sh` — 10 assertions: the `&&` regression, EC-1≠EC-10 word boundary, content-integrity for all metacharacters, line-count stability, idempotency, and a whole-body two-flip diff.

## Per D-029

The `.github/workflows/ai-pre-merge-digest.yml` change is committed from a Claude Code on the Web session (same path as the rest of this session's factory fixes). The fix-(2) files are under `.github/ai-factory/` (scripts/prompts/tests/fixtures) — not workflow-blocked.

## Test plan

```
bash .github/ai-factory/tests/test-tick-ec.sh      → 10 passed, 0 failed
bash .github/ai-factory/tests/test-ec-parser.sh    → 31 passed, 0 failed
bash .github/ai-factory/tests/test-pr-body-rules.sh → 20 passed, 0 failed
python3 -c 'yaml.safe_load(...)'  on ai-pre-merge-digest.yml → ok
```

- [x] tick-ec.sh metacharacter + word-boundary tests pass locally
- [x] digest YAML parses
- [ ] CI green on this PR
- [ ] After merge: this PR landing `ai-awaiting-owner` should trigger the `redispatch` job → a `workflow_dispatch` digest run that posts a comment without the OIDC 401 (live confirmation of fix 1)
- [ ] After merge: re-run the EC validator on #704 via `ai-validate-ec` and confirm EC-1 stays a clean single line (live confirmation of fix 2 — #751 EC-4)

Closes #751


---
_Generated by [Claude Code](https://claude.ai/code/session_01EAvS3DMYhBvQmqxvW1aFed)_