### PR TITLE
fix(ec-validator): allow github-actions[bot] actor (auto-dispatch was failing)

### DIFF
--- a/.github/workflows/ai-ec-validator.yml
+++ b/.github/workflows/ai-ec-validator.yml
@@ -106,6 +106,10 @@ jobs:
           REPO: ${{ env.REPO }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The post-merge dispatch (ai-post-merge-verify.yml) runs `gh workflow run`
+          # as github-actions[bot], so the workflow_dispatch actor is a bot.
+          # claude-code-action refuses bot actors unless allow-listed.
+          allowed_bots: "github-actions[bot],claude[bot]"
           claude_args: "--model claude-haiku-4-5-20251001 --permission-mode bypassPermissions --max-turns 25"
           prompt: |
             Read and follow the instructions in .github/ai-factory/prompts/ec-validator.md exactly.


### PR DESCRIPTION
## Summary

The EC validator's auto-dispatch path was broken. When `ai-post-merge-verify.yml` dispatches the validator via `gh workflow run` (using `github.token`), the resulting `workflow_dispatch` event's actor is `github-actions[bot]`. `claude-code-action@v1` **refuses bot actors** unless they're allow-listed:

```
Action failed with error: Workflow initiated by non-human actor: github-actions (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

This surfaced when PR #752 merged and the dispatch step (added in #749) correctly fired the validator on #751 — but the run failed at the `claude-code-action` step. The three manual validation runs earlier (#698/#704/#718) passed only because **a human** dispatched them.

`ai-pre-merge-digest.yml` already sets `allowed_bots`; the EC validator omitted it. Fix: add `allowed_bots: "github-actions[bot],claude[bot]"` to the `Run EC validator` step.

## Why the rest of the pipeline is confirmed working

The #752 merge exercised the full chain end-to-end:
- D-037 post-merge guard auto-closed #751 (via `Closes #751`), saw 4 unverified EC items, **reopened it** with `fact-parent-incomplete` ✅
- the dispatch step in `ai-post-merge-verify.yml` **auto-fired** the EC validator on #751 ✅

Only the bot-actor gate was missing. This one-line fix closes that gap.

## Test plan

- [x] YAML parses
- [ ] CI green
- [ ] After merge: re-trigger via `ai-validate-ec` on #751 (or any EC issue) — the run should now pass the actor gate and post the validation comment. This also exercises the #752 `tick-ec.sh` fix on #751's `&&`-laden EC text (the original corruption scenario).

No issue closure — this is a follow-up fix to the validator shipped in #749. References #735, #751.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EAvS3DMYhBvQmqxvW1aFed)_