### PR TITLE
fix(ec-validator): raise max-turns 25 → 50 (agent exhausted budget on #751)

### DIFF
--- a/.github/workflows/ai-ec-validator.yml
+++ b/.github/workflows/ai-ec-validator.yml
@@ -110,7 +110,10 @@ jobs:
           # as github-actions[bot], so the workflow_dispatch actor is a bot.
           # claude-code-action refuses bot actors unless allow-listed.
           allowed_bots: "github-actions[bot],claude[bot]"
-          claude_args: "--model claude-haiku-4-5-20251001 --permission-mode bypassPermissions --max-turns 25"
+          # Budget scales with EC-item count: parse (1) + verify-ec.sh per item
+          # + tick + comment + close/label. 25 turns exhausted on #751 (4 items);
+          # large issues like #720 (12 items) need substantially more headroom.
+          claude_args: "--model claude-haiku-4-5-20251001 --permission-mode bypassPermissions --max-turns 50"
           prompt: |
             Read and follow the instructions in .github/ai-factory/prompts/ec-validator.md exactly.
 


### PR DESCRIPTION
## Summary

The EC validator agent hit `error_max_turns` (25) on #751 (4 EC items). The agent's work per run is: parse body → `verify-ec.sh` per item → `tick-ec.sh` → post comment → close/label. That exceeded 25 agent turns on a 4-item issue; #720 (12 EC items) would exceed it by a wide margin.

Raise `--max-turns` 25 → 50.

## Context

This surfaced when the validator was re-run on #751 after the #753 (`allowed_bots`) fix. Two runs serialized on the per-issue concurrency group: one hit max-turns, the other completed and correctly ticked the body (no corruption — confirming the #752 `tick-ec.sh` fix works on #751's `&&`/backtick-laden EC text). The max-turns ceiling is the remaining reliability gap.

## Test plan

- [x] YAML parses
- [ ] CI green
- [ ] After merge: re-run on #751 via `ai-validate-ec` completes in a single run without `error_max_turns`

Follow-up to #749 / #751 / #753. No issue closure.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EAvS3DMYhBvQmqxvW1aFed)_