### PR TITLE
fix(prod-cli): bash-3.2 compatible push-knowledge (drop mapfile)

### DIFF
--- a/cli/commands/prod.sh
+++ b/cli/commands/prod.sh
@@ -354,8 +354,14 @@ cmd_push_knowledge() {
 
     # Source MDs are derived from docs/knowledge-sources.yml — the single source of truth.
     # This avoids drift; wren-push-metadata.py reads the same manifest at import time.
-    local -a source_mds
-    mapfile -t source_mds < <(python3 -c "
+    # Read line-by-line instead of `mapfile`/`readarray` — those are bash 4+
+    # builtins and macOS ships bash 3.2, where the knowledge push (run from the
+    # operator's Mac) would otherwise fail with `mapfile: command not found`.
+    local -a source_mds=()
+    local _md_path
+    while IFS= read -r _md_path; do
+        [ -n "$_md_path" ] && source_mds+=("$_md_path")
+    done < <(python3 -c "
 import yaml
 data = yaml.safe_load(open('$REPO_ROOT/docs/knowledge-sources.yml'))
 for s in data['sources']:


### PR DESCRIPTION
## Context

While running `ps prod push-knowledge` during the v0.5.0 production update, the command failed immediately with:

```
cli/commands/prod.sh: line 358: mapfile: command not found
```

`mapfile` / `readarray` are bash 4+ builtins. macOS ships **bash 3.2** as `/bin/bash`, which is what `#!/usr/bin/env bash` resolves to on a stock operator Mac — so the knowledge push (also invoked automatically inside `ps prod deploy` / `ps prod update`) was unrunnable there.

## Fix

Replace the single `mapfile` call in `cmd_push_knowledge` with a `while IFS= read -r` loop that builds the `source_mds` array the same way, compatible with bash 3.2+. No behaviour change on bash 4+.

Verified by completing the real knowledge push to production after applying it (51 instructions + 56 SQL pairs indexed).

## Review

Requesting an independent **Opus** review (dispatched manually). Copilot review not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
