### PR TITLE
fix(prod): postgres shm_size + structured home errors + review-dashboard params

### DIFF
--- a/dashboard/app/__tests__/inicio-page.test.tsx
+++ b/dashboard/app/__tests__/inicio-page.test.tsx
@@ -338,4 +338,28 @@ describe("InicioPage", () => {
     expect(deltaChip!.getAttribute("aria-label")).toMatch(/%$/);
     expect(deltaChip!.getAttribute("aria-label")).not.toMatch(/pp$/);
   });
+
+  it("renders structured error details (ErrorDisplay) when /api/home returns a 500", async () => {
+    const apiError = {
+      error: "No se pudo cargar el inicio.",
+      code: "DB_QUERY",
+      details: "could not resize shared memory segment",
+      timestamp: "2026-06-03T08:00:00.000Z",
+      requestId: "req_test123",
+    };
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve(apiError),
+    });
+    render(<InicioPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Error al cargar los datos")).toBeInTheDocument();
+    });
+    // Structured ApiErrorResponse → expandable technical details + copy-as-JSON,
+    // mirroring how widget errors render (not a bare "HTTP 500" string).
+    expect(screen.getByText("No se pudo cargar el inicio.")).toBeInTheDocument();
+    expect(screen.getByText("Detalles técnicos")).toBeInTheDocument();
+    expect(screen.getByText("Copiar como JSON")).toBeInTheDocument();
+  });
 });

--- a/dashboard/app/api/home/route.ts
+++ b/dashboard/app/api/home/route.ts
@@ -25,6 +25,11 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { query } from "@/lib/db";
+import {
+  formatApiError,
+  generateRequestId,
+  sanitizeErrorMessage,
+} from "@/lib/errors";
 import type { HomeViewModel, Metric } from "@/lib/home-types";
 
 export const dynamic = "force-dynamic";
@@ -1515,9 +1520,19 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json(payload);
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
+    // Return the standard ApiErrorResponse shape (code / timestamp / requestId /
+    // sanitized details) so the home surfaces technical details + "Copiar como
+    // JSON" exactly like widget errors do. The whole view model is built from
+    // read-only queries, so DB_QUERY is the right code.
+    const requestId = generateRequestId();
+    console.error(`[api/home] failed to build view model (${requestId}):`, err);
     return NextResponse.json(
-      { error: "Failed to load home view model", details: message },
+      formatApiError(
+        "No se pudo cargar el inicio.",
+        "DB_QUERY",
+        sanitizeErrorMessage(err),
+        requestId,
+      ),
       { status: 500 },
     );
   }

--- a/dashboard/app/inicio/page.tsx
+++ b/dashboard/app/inicio/page.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { HomeViewModel } from "@/lib/home-types";
+import { ErrorDisplay } from "@/components/ErrorDisplay";
+import { isApiErrorResponse, type ApiErrorResponse } from "@/lib/errors";
 import { HeroToday } from "@/components/home/HeroToday";
 import { PeriodGrid } from "@/components/home/PeriodGrid";
 import { DailyTrendChart } from "@/components/home/DailyTrendChart";
@@ -70,7 +72,7 @@ export default function InicioPage() {
 
   const [data, setData] = useState<HomeViewModel | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<ApiErrorResponse | string | null>(null);
 
   const load = useCallback(async (date: string | null) => {
     setLoading(true);
@@ -78,7 +80,18 @@ export default function InicioPage() {
     try {
       const url = date ? `/api/home?date=${encodeURIComponent(date)}` : "/api/home";
       const res = await fetch(url);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      if (!res.ok) {
+        // Prefer the structured ApiErrorResponse body so the UI can show the
+        // technical details (code / id / detail) and "Copiar como JSON".
+        let body: unknown = null;
+        try {
+          body = await res.json();
+        } catch {
+          /* non-JSON error body */
+        }
+        setError(isApiErrorResponse(body) ? body : `HTTP ${res.status}`);
+        return;
+      }
       const json: HomeViewModel = await res.json();
       setData(json);
     } catch (err) {
@@ -282,25 +295,12 @@ export default function InicioPage() {
       {/* Error state                                                       */}
       {/* ──────────────────────────────────────────────────────────────── */}
       {!loading && error && (
-        <div
-          style={{
-            margin: "24px",
-            background: "var(--down-bg)",
-            border: "1px solid var(--down)",
-            borderRadius: 10,
-            padding: 20,
-            color: "var(--down)",
-          }}
-        >
-          <div style={{ fontWeight: 600, marginBottom: 4 }}>Error al cargar los datos</div>
-          <div style={{ fontSize: 13, color: "var(--fg-muted)" }}>{error}</div>
-          <button
-            type="button"
-            onClick={() => load(dateParam)}
-            style={{ ...outlineBtn, marginTop: 12 }}
-          >
-            Reintentar
-          </button>
+        <div style={{ margin: "24px" }}>
+          <ErrorDisplay
+            error={error}
+            title="Error al cargar los datos"
+            onRetry={() => load(dateParam)}
+          />
         </div>
       )}
 

--- a/dashboard/lib/__tests__/review-dashboard-seed.test.ts
+++ b/dashboard/lib/__tests__/review-dashboard-seed.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { buildSpec } from "@/lib/review-dashboard-seed";
+import { REVIEW_DASHBOARD_KEYS } from "@/lib/review-schema";
+
+/**
+ * Regression guard for the "there is no parameter $1" production bug.
+ *
+ * REVIEW_QUERIES use positional params ($1/$2) that the weekly-review API
+ * binds. When the same SQL is embedded into a SAVED dashboard, it is executed
+ * by DashboardRenderer, which only substitutes :curr_from/:curr_to date tokens
+ * and passes NO positional params — so any leftover `$1` reaches Postgres
+ * unbound and fails. This invariant (embedded widget SQL must be renderable:
+ * date tokens only, never positional params) was previously untested: the
+ * review queries were only exercised in the review flow where the params ARE
+ * bound, and the seed itself had no test.
+ */
+describe("review dashboard seed — embedded SQL is renderable", () => {
+  for (const key of REVIEW_DASHBOARD_KEYS) {
+    it(`buildSpec(${key}) embeds no unbound positional params`, () => {
+      const spec = buildSpec(key);
+      for (const widget of spec.widgets) {
+        const sql = (widget as { sql?: string }).sql ?? "";
+        // No $1, $2, … — DashboardRenderer never binds positional params.
+        expect(sql).not.toMatch(/\$\d/);
+      }
+    });
+  }
+
+  it("maps the closed-week range to :curr_from / :curr_to date tokens", () => {
+    const spec = buildSpec("compras");
+    const sql = (spec.widgets[0] as { sql: string }).sql;
+    expect(sql).toContain(":curr_from");
+    expect(sql).toContain(":curr_to");
+  });
+});

--- a/dashboard/lib/review-dashboard-seed.ts
+++ b/dashboard/lib/review-dashboard-seed.ts
@@ -40,7 +40,9 @@ function pickSql(key: ReviewDashboardKey): { title: string; sql: string; format:
   }
 }
 
-function buildSpec(key: ReviewDashboardKey) {
+// Exported for unit tests: lets us assert the embedded widget SQL is
+// renderable by DashboardRenderer (date tokens only, no positional params).
+export function buildSpec(key: ReviewDashboardKey) {
   const { title, sql: widgetSql, format } = pickSql(key);
   // REVIEW_QUERIES use positional params ($1 = inclusive week start,
   // $2 = exclusive week end) that the weekly-review API binds. Embedded in a

--- a/dashboard/lib/review-dashboard-seed.ts
+++ b/dashboard/lib/review-dashboard-seed.ts
@@ -42,6 +42,16 @@ function pickSql(key: ReviewDashboardKey): { title: string; sql: string; format:
 
 function buildSpec(key: ReviewDashboardKey) {
   const { title, sql: widgetSql, format } = pickSql(key);
+  // REVIEW_QUERIES use positional params ($1 = inclusive week start,
+  // $2 = exclusive week end) that the weekly-review API binds. Embedded in a
+  // saved dashboard they are rendered by DashboardRenderer, which only
+  // substitutes :curr_from/:curr_to date tokens and passes NO positional
+  // params — so an un-mapped `$1` reaches Postgres unbound and fails with
+  // "there is no parameter $1". Map the params to the date tokens; the
+  // dashboard's default_time_range (last_7_days) supplies the actual range.
+  const embeddedSql = widgetSql
+    .replaceAll("$1", ":curr_from")
+    .replaceAll("$2", ":curr_to");
   const raw = {
     title: reviewDashboardDisplayName(key),
     description: "Dashboard de apoyo para la revisión semanal (enlace desde la revisión).",
@@ -51,7 +61,7 @@ function buildSpec(key: ReviewDashboardKey) {
         id: "review_metric",
         type: "number" as const,
         title,
-        sql: widgetSql,
+        sql: embeddedSql,
         format,
       },
     ],

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,6 +33,12 @@ services:
   # ---------------------------------------------------------------------------
   postgres:
     image: postgres:16-alpine
+    # Default Docker /dev/shm is 64 MB; parallel-query workers (heavy home /
+    # dashboard aggregations) exhaust it and fail with "could not resize shared
+    # memory segment ... No space left on device". Must stay in sync with the
+    # dev docker-compose.yml. Do NOT drop this — `ps prod update` overwrites the
+    # prod compose from this file, so a missing line silently breaks production.
+    shm_size: 1gb
     command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Context

After updating production from v0.3.0 → v0.5.0, the home and every dashboard returned **HTTP 500**, and the home showed only a flat `HTTP 500` with no technical detail (unlike widget errors, which show a JSON breakdown). Investigation surfaced three distinct issues.

## Root causes & fixes

### 1. Postgres `shm_size` lost on prod → "No space left on device" (the actual 500)
`docker-compose.prod.yml` never carried the `shm_size: 1gb` that the dev `docker-compose.yml` has (added in #779). Prod had it as a **manual local edit**, which `ps prod update` clobbered when it pulled the release's prod compose. Postgres fell back to the 64 MB Docker default; heavy home/dashboard parallel-query aggregations exhausted `/dev/shm` and failed with `could not resize shared memory segment ... No space left on device`.
→ **Add `shm_size: 1gb` to `docker-compose.prod.yml`** (with a comment so it can't silently disappear again).

### 2. Home errors weren't structured
`/api/home` returned a bare `{ error, details: rawMessage }` (unsanitized) and the page rendered a flat `HTTP 500`.
→ **`/api/home` now returns the standard `ApiErrorResponse`** (`formatApiError` + `sanitizeErrorMessage`), and **`inicio/page.tsx` renders it with `ErrorDisplay`** — so the home shows Código / Hora / ID / Detalle + “Copiar como JSON”, matching widget errors. New test covers it.

### 3. Review-semanal dashboards: `there is no parameter $1`
The seed embedded `REVIEW_QUERIES` SQL using positional params (`$1`/`$2`, bound only by the weekly-review API) into saved dashboards. The generic `DashboardRenderer` only substitutes `:curr_from`/`:curr_to` tokens and passes no positional params, so `$1` reached Postgres unbound.
→ **Seed now maps `$1`→`:curr_from`, `$2`→`:curr_to`** so the renderer inlines them. (Pre-existing since v0.2 — not caused by the update, but fixed here.)

## Prod already hot-patched (out of band)
To restore service immediately: postgres recreated with `shm_size: 1gb`; existing review-dashboard rows (10–13) migrated with the same `$1`/`$2` → token swap. This PR makes both durable in the codebase. After merge + a release, `ps prod update` keeps the shm fix permanently.

## Tests
`tsc` (changed files), eslint, and vitest pass locally (`inicio-page`, `api/home`, `review-helpers`, `ErrorDisplay`). The only `tsc` errors are pre-existing in unrelated `analyze-route*.test.ts`.

## Review
Requesting an independent **Opus** review. Copilot review not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
