### PR TITLE
test(schema): reject positional params in widget SQL at the spec boundary

### DIFF
--- a/dashboard/lib/__tests__/schema.test.ts
+++ b/dashboard/lib/__tests__/schema.test.ts
@@ -435,3 +435,50 @@ describe("DashboardSpecSchema — default_time_range", () => {
     expect(() => DashboardSpecSchema.parse(spec)).toThrow(ZodError);
   });
 });
+
+describe("validateSpec — positional param guard", () => {
+  // DashboardRenderer never binds positional params; it only inlines
+  // :curr_*/:comp_* date tokens and __gf_<id>__ filter tokens. A saved/seeded
+  // widget SQL with $1 reaches Postgres unbound ("there is no parameter $1").
+  it("rejects a widget whose sql uses a positional param ($1)", () => {
+    const spec = {
+      title: "T",
+      widgets: [
+        { type: "table", title: "W", sql: "SELECT n FROM t WHERE d >= $1::date" },
+      ],
+    };
+    expect(() => validateSpec(spec)).toThrow(ZodError);
+  });
+
+  it("rejects a positional param in comparison_sql", () => {
+    const spec = {
+      title: "T",
+      widgets: [
+        {
+          type: "bar_chart",
+          title: "W",
+          sql: "SELECT a AS label, b AS value FROM t",
+          x: "label",
+          y: "value",
+          comparison_sql: "SELECT a, b FROM t WHERE d < $2::date",
+        },
+      ],
+    };
+    expect(() => validateSpec(spec)).toThrow(ZodError);
+  });
+
+  it("accepts widget sql using :curr_from / :curr_to date tokens", () => {
+    const spec = {
+      title: "T",
+      widgets: [
+        {
+          type: "number",
+          title: "W",
+          sql: "SELECT COUNT(*) FROM t WHERE d >= :curr_from::date AND d < :curr_to::date",
+          format: "number",
+        },
+      ],
+    };
+    expect(() => validateSpec(spec)).not.toThrow();
+  });
+});

--- a/dashboard/lib/schema.ts
+++ b/dashboard/lib/schema.ts
@@ -32,19 +32,33 @@ const KpiFormatSchema = z.preprocess(
 /** Optional string that must be non-empty when provided. */
 const optStr = z.string().min(1).optional();
 
+/**
+ * Widget SQL must not contain positional params ($1, $2, …). DashboardRenderer
+ * executes saved widget SQL after inlining the :curr_ and :comp_ date tokens
+ * and __gf_<id>__ filter tokens — it never binds positional params, so a
+ * leftover `$1` reaches Postgres unbound and fails with "there is no parameter
+ * $1" (the review-semanal dashboards shipped this bug — see review-dashboard-seed).
+ * Reject it at the spec boundary so it can never be saved or seeded again.
+ */
+const POSITIONAL_PARAM_MSG =
+  "widget SQL must not use positional params ($1, $2, …); use :curr_from/:curr_to date tokens or __gf_<id>__ filter tokens";
+const hasNoPositionalParam = (s: string) => !/\$\d/.test(s);
+const widgetSql = z.string().min(1).refine(hasNoPositionalParam, { message: POSITIONAL_PARAM_MSG });
+const optWidgetSql = widgetSql.optional();
+
 const KpiItemSchema = z.object({
   label: z.string().min(1),
-  sql: z.string().min(1),
+  sql: widgetSql,
   format: KpiFormatSchema,
   prefix: optStr,
   /** Optional SQL for trend/comparison period. Returns a single numeric value.
    *  The trend percentage is computed as (current - comparison) / abs(comparison) * 100. */
-  trend_sql: optStr,
+  trend_sql: optWidgetSql,
   /** Optional SQL for anomaly detection. Returns N rows of historical values for
    *  the same metric. The first row is the current period value; remaining rows
    *  are historical values in descending chronological order.
    *  The frontend computes a z-score client-side to detect unusual values. */
-  anomaly_sql: optStr,
+  anomaly_sql: optWidgetSql,
   /** Optional delta ratio (e.g. 0.083 = +8.3%). Overrides computed trend if provided. */
   delta: z.number().optional(),
   /** Optional absolute comparison value for display. */
@@ -69,54 +83,54 @@ const BarChartWidgetSchema = z.object({
   id: optStr,
   type: z.literal("bar_chart"),
   title: z.string().min(1),
-  sql: z.string().min(1),
+  sql: widgetSql,
   x: z.string().min(1),
   y: z.string().min(1),
-  comparison_sql: optStr,
+  comparison_sql: optWidgetSql,
 }).strict();
 
 const LineChartWidgetSchema = z.object({
   id: optStr,
   type: z.literal("line_chart"),
   title: z.string().min(1),
-  sql: z.string().min(1),
+  sql: widgetSql,
   x: optStr,
   y: optStr,
-  comparison_sql: optStr,
+  comparison_sql: optWidgetSql,
 }).strict();
 
 const AreaChartWidgetSchema = z.object({
   id: optStr,
   type: z.literal("area_chart"),
   title: z.string().min(1),
-  sql: z.string().min(1),
+  sql: widgetSql,
   x: optStr,
   y: optStr,
-  comparison_sql: optStr,
+  comparison_sql: optWidgetSql,
 }).strict();
 
 const DonutChartWidgetSchema = z.object({
   id: optStr,
   type: z.literal("donut_chart"),
   title: z.string().min(1),
-  sql: z.string().min(1),
+  sql: widgetSql,
   x: optStr,
   y: optStr,
-  comparison_sql: optStr,
+  comparison_sql: optWidgetSql,
 }).strict();
 
 const TableWidgetSchema = z.object({
   id: optStr,
   type: z.literal("table"),
   title: z.string().min(1),
-  sql: z.string().min(1),
+  sql: widgetSql,
 }).strict();
 
 const NumberWidgetSchema = z.object({
   id: optStr,
   type: z.literal("number"),
   title: z.string().min(1),
-  sql: z.string().min(1),
+  sql: widgetSql,
   format: KpiFormatSchema,
   prefix: optStr,
 }).strict();


### PR DESCRIPTION
## Context

Follow-up hardening after the production "there is no parameter $1" incident (PR #798), answering "why didn't tests catch the positional-param bug?".

The review-semanal dashboards embedded SQL with positional params (`$1`/`$2`) that `DashboardRenderer` never binds — it only inlines `:curr_`/`:comp_` date tokens and `__gf_<id>__` filter tokens. #798 fixed the seed and added a seed-level regression test. This PR adds the **broad invariant** at the spec boundary.

## Change

`DashboardSpecSchema` now rejects positional params (`$1`, `$2`, …) in every widget SQL field — `sql`, `trend_sql`, `anomaly_sql`, `comparison_sql` — via a `.refine`. So no dashboard (seeded, LLM-generated, or user-saved) can ever persist a spec that the renderer can't execute.

Scope notes:
- `options_sql` (global-filter options) is a **different execution path** and is intentionally left untouched.
- Positional params remain legitimate at the `/api/query` runtime layer (that's how global filters bind `__gf__` → `$1` + params); this guard is only on **stored specs**, which use tokens, never raw `$N`.
- Verified no existing valid spec/fixture uses `$N` in a widget SQL field, so nothing is broken.

## Tests
New `validateSpec — positional param guard` block: rejects `$1` in `sql` and in `comparison_sql`, accepts `:curr_from`/`:curr_to` tokens. Full dashboard vitest suite passes (the one unrelated `ChatSidebar` failure is a pre-existing local-env flake — it fails identically on `main` and is green in CI).

## Remaining gap → #800
This is a static guard. The runtime gap (a saved spec that renders an error against real data) is tracked in **#800** (e2e against a seeded Postgres), which includes the test-data anonymization decision.

## Review
Requesting an independent **Opus** review. Copilot review not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
