### PR TITLE
fix(etl): data-correctness cluster — traspasos PK scale, stock bad-row resilience, force-resync abort

### DIFF
--- a/etl/main.py
+++ b/etl/main.py
@@ -550,6 +550,7 @@ def run_full_sync(
         reset_watermarks,
         try_acquire_run_lock,
         update_run_trace_context,
+        update_trigger_run_id,
     )
 
     # Cross-process exclusion. _is_run_active (row check) can race with
@@ -607,6 +608,26 @@ def run_full_sync(
         # watermarks is idempotent and safe: the worst case is one extra pass over
         # incremental tables on the next sync.
         # ------------------------------------------------------------------
+        def _abort_forced_run(scope: str) -> None:
+            """Record a FAILED run for an aborted force-resync (issue #828).
+
+            The operator asked for a from-scratch resync precisely because the
+            watermarks are suspect. If the reset fails, running anyway would
+            execute a normal stale-watermark sync while the dashboard reports
+            the requested force-resync as done — the data the operator wanted
+            re-pulled would still be missing, silently. Recording a failed run
+            (and linking it to the trigger row) surfaces the abort instead.
+            """
+            try:
+                aborted_run_id = create_run(conn_pg, trigger, kind=kind)
+                finish_run(conn_pg, aborted_run_id, "failed", 0, 1, total_rows_synced=0)
+                if trigger_id is not None:
+                    update_trigger_run_id(conn_pg, trigger_id, aborted_run_id)
+            except Exception:
+                logger.exception(
+                    "Could not record the aborted force-resync run (%s)", scope
+                )
+
         if trigger == "manual" and trigger_id is not None:
             if force_flags is not None:
                 # Pre-read by the scheduler loop (the normal path now). Using
@@ -649,9 +670,13 @@ def run_full_sync(
                     )
                 except Exception:
                     logger.exception(
-                        "Trigger %d: force_full watermark reset failed; continuing",
+                        "Trigger %d: force_full watermark reset FAILED — aborting "
+                        "the run (a stale-watermark sync would silently skip the "
+                        "data the operator asked to re-pull; issue #828)",
                         trigger_id,
                     )
+                    _abort_forced_run("force_full")
+                    return
             elif force_tables:
                 # Filter to known watermark-backed syncs only. A name absent from
                 # SYNC_NAMES_WITH_WATERMARK is dropped with a warning — API/UI
@@ -679,9 +704,14 @@ def run_full_sync(
                         )
                     except Exception:
                         logger.exception(
-                            "Trigger %d: reset_watermarks failed; continuing incrementally",
+                            "Trigger %d: force_tables watermark reset FAILED — "
+                            "aborting the run (a stale-watermark sync would "
+                            "silently skip the data the operator asked to "
+                            "re-pull; issue #828)",
                             trigger_id,
                         )
+                        _abort_forced_run("force_tables")
+                        return
 
         run_id: int | None = None
         try:
@@ -855,8 +885,6 @@ def run_full_sync(
                 logger.exception("Monitoring: finish_run failed")
 
             if trigger == "manual" and trigger_id is not None:
-                from etl.db.postgres import update_trigger_run_id
-
                 try:
                     update_trigger_run_id(conn_pg, trigger_id, run_id)
                 except Exception:

--- a/etl/main.py
+++ b/etl/main.py
@@ -546,6 +546,7 @@ def run_full_sync(
         create_run,
         finish_run,
         get_trigger_force_flags,
+        record_table_sync,
         release_run_lock,
         reset_watermarks,
         try_acquire_run_lock,
@@ -608,7 +609,7 @@ def run_full_sync(
         # watermarks is idempotent and safe: the worst case is one extra pass over
         # incremental tables on the next sync.
         # ------------------------------------------------------------------
-        def _abort_forced_run(scope: str) -> None:
+        def _abort_forced_run(scope: str, err_msg: str) -> None:
             """Record a FAILED run for an aborted force-resync (issue #828).
 
             The operator asked for a from-scratch resync precisely because the
@@ -617,9 +618,28 @@ def run_full_sync(
             the requested force-resync as done — the data the operator wanted
             re-pulled would still be missing, silently. Recording a failed run
             (and linking it to the trigger row) surfaces the abort instead.
+
+            A synthetic "(watermark_reset)" table row carries the error message
+            so the dashboard details view shows WHY the run aborted, mirroring
+            the "(4d_connection)" row written by _record_connection_failure.
             """
             try:
                 aborted_run_id = create_run(conn_pg, trigger, kind=kind)
+                now = datetime.now(timezone.utc)
+                try:
+                    record_table_sync(
+                        conn_pg,
+                        aborted_run_id,
+                        "(watermark_reset)",
+                        0,
+                        0,
+                        status="failed",
+                        started_at=now,
+                        finished_at=now,
+                        error_msg=f"{scope}: {err_msg}"[:2000],
+                    )
+                except Exception:
+                    logger.exception("Could not record watermark-reset failure row")
                 finish_run(conn_pg, aborted_run_id, "failed", 0, 1, total_rows_synced=0)
                 if trigger_id is not None:
                     update_trigger_run_id(conn_pg, trigger_id, aborted_run_id)
@@ -668,14 +688,14 @@ def run_full_sync(
                         trigger_id,
                         deleted,
                     )
-                except Exception:
+                except Exception as reset_exc:
                     logger.exception(
                         "Trigger %d: force_full watermark reset FAILED — aborting "
                         "the run (a stale-watermark sync would silently skip the "
                         "data the operator asked to re-pull; issue #828)",
                         trigger_id,
                     )
-                    _abort_forced_run("force_full")
+                    _abort_forced_run("force_full", str(reset_exc))
                     return
             elif force_tables:
                 # Filter to known watermark-backed syncs only. A name absent from
@@ -702,7 +722,7 @@ def run_full_sync(
                             trigger_id,
                             deleted,
                         )
-                    except Exception:
+                    except Exception as reset_exc:
                         logger.exception(
                             "Trigger %d: force_tables watermark reset FAILED — "
                             "aborting the run (a stale-watermark sync would "
@@ -710,7 +730,7 @@ def run_full_sync(
                             "re-pull; issue #828)",
                             trigger_id,
                         )
-                        _abort_forced_run("force_tables")
+                        _abort_forced_run("force_tables", str(reset_exc))
                         return
 
         run_id: int | None = None

--- a/etl/schema/init.sql
+++ b/etl/schema/init.sql
@@ -1039,7 +1039,7 @@ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM etl_one_time_migrations WHERE id = 'm827-traspasos-rekey'
   ) THEN
-    DELETE FROM ps_traspasos;
+    TRUNCATE ps_traspasos;
     DELETE FROM etl_watermarks WHERE table_name = 'traspasos';
     INSERT INTO etl_one_time_migrations (id) VALUES ('m827-traspasos-rekey');
   END IF;

--- a/etl/schema/init.sql
+++ b/etl/schema/init.sql
@@ -1019,6 +1019,32 @@ END $$;
 -- Add logs column to persist streaming log lines alongside the assistant message.
 ALTER TABLE conversation_messages ADD COLUMN IF NOT EXISTS logs JSONB DEFAULT NULL;
 
+-- Run-once destructive migrations need a marker so re-applying this file
+-- (every container start) does not repeat them.
+CREATE TABLE IF NOT EXISTS etl_one_time_migrations (
+    id         TEXT        PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One-time migration: re-key ps_traspasos after the scale-2 → scale-3 PK
+-- quantization fix (issue #827). The pre-fix ETL rounded RegTraspaso to 2
+-- decimals: 3-decimal source PKs collided (one row lost per collision via
+-- ON CONFLICT DO NOTHING) and the survivors sit under wrong keys — which the
+-- fixed ETL would duplicate when it re-inserts them under their correct keys
+-- (ps_traspasos is append-only, never truncated). Wipe the table and clear
+-- its watermark so the next sync re-pulls everything with correct keys.
+-- Remove this block once it has run on production (follow-up PR, per AGENTS.md).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM etl_one_time_migrations WHERE id = 'm827-traspasos-rekey'
+  ) THEN
+    DELETE FROM ps_traspasos;
+    DELETE FROM etl_watermarks WHERE table_name = 'traspasos';
+    INSERT INTO etl_one_time_migrations (id) VALUES ('m827-traspasos-rekey');
+  END IF;
+END $$;
+
 -- ============================================================
 -- ANALYZE (update planner statistics after initial load)
 -- ============================================================

--- a/etl/sync/stock.py
+++ b/etl/sync/stock.py
@@ -84,8 +84,11 @@ _EXPO_COLUMNS = ", ".join(_EXPO_FIXED_COLS + _EXPO_TALLA_COLS + _EXPO_STOCK_COLS
 # Stable ORDER BY for deterministic LIMIT/OFFSET pagination.
 _EXPO_ORDER_BY = "ORDER BY Codigo, TiendaCodigo"
 
-# Quantize target for NUMERIC(20,2) PK values.
-_TWO_PLACES = Decimal("0.01")
+# Quantize target for NUMERIC(20,3) PK values. Three decimal places, matching
+# the ps_* schema convention (see etl/schema/init.sql header): some 4D Real PKs
+# carry 3-decimal values (e.g. 4.152 vs 4.153) — quantizing to 2 places made
+# them collide on the same key and silently lose rows (issue #827).
+_THREE_PLACES = Decimal("0.001")
 
 
 def _validate_since(since: datetime, name: str = "since") -> None:
@@ -261,6 +264,7 @@ def sync_stock(conn_4d, conn_pg, since: datetime | None = None) -> int:
     logger.info("sync_stock: processing %d stores progressively", len(stores))
 
     total_processed = 0
+    total_skipped = 0
     for store_idx, store_code in enumerate(stores):
         # Validate store code before interpolating into SQL (defense-in-depth).
         # ERP codes are numeric or alphanumeric with optional slashes/dashes.
@@ -284,10 +288,23 @@ def sync_stock(conn_4d, conn_pg, since: datetime | None = None) -> int:
         if not store_rows:
             continue
 
-        # Normalize and upsert this store's data
+        # Normalize and upsert this store's data. A row with a missing PK
+        # component (Codigo / TiendaCodigo) is logged and skipped — one corrupt
+        # source record must not abort the sync for all ~50 stores and stall
+        # the watermark in a permanent retry loop (issue #820).
         pg_buffer: list[dict] = []
+        store_skipped = 0
         for src_row in store_rows:
-            pg_buffer.extend(_normalize_expo_row(src_row))
+            try:
+                pg_buffer.extend(_normalize_expo_row(src_row))
+            except ValueError as exc:
+                store_skipped += 1
+                logger.warning(
+                    "sync_stock: skipping invalid row in store %s: %s",
+                    store_code,
+                    exc,
+                )
+        total_skipped += store_skipped
 
         # Upsert in batches
         store_processed = 0
@@ -312,6 +329,12 @@ def sync_stock(conn_4d, conn_pg, since: datetime | None = None) -> int:
             total_processed,
         )
 
+    if total_skipped > 0:
+        logger.warning(
+            "sync_stock: skipped %d invalid source row(s) across the run — "
+            "check the warnings above and fix the source data in 4D",
+            total_skipped,
+        )
     logger.info(
         "sync_stock: done — %d normalized rows processed across %d stores",
         total_processed,
@@ -337,9 +360,11 @@ _TRASPASOS_ORDER_BY = "ORDER BY RegTraspaso"
 def _map_traspaso_row(src: dict) -> dict:
     """Map a safe_fetch row (lowercase keys) to ps_traspasos column names.
 
-    4D float PKs are converted to Decimal and quantized to 2 decimal places
-    (matching the NUMERIC(20,2) PG schema) to prevent float-string artifacts
+    4D float PKs are converted to Decimal and quantized to 3 decimal places
+    (matching the NUMERIC(20,3) PG schema) to prevent float-string artifacts
     such as trailing ...99999 digits from causing unexpected key differences.
+    Scale 3 is required: real RegTraspaso values can differ only in the third
+    decimal, and rounding to 2 places collides them (issue #827).
     """
     reg = src.get("regtraspaso")
     if reg is None:
@@ -349,7 +374,7 @@ def _map_traspaso_row(src: dict) -> dict:
             f"_map_traspaso_row: source row is missing RegTraspaso "
             f"(codigo={src.get('codigo')!r}, fechas={src.get('fechas')!r})"
         )
-    reg_decimal = Decimal(str(reg)).quantize(_TWO_PLACES, rounding=ROUND_HALF_UP)
+    reg_decimal = Decimal(str(reg)).quantize(_THREE_PLACES, rounding=ROUND_HALF_UP)
     return {
         "reg_traspaso": reg_decimal,
         "codigo": src.get("codigo"),

--- a/etl/tests/test_main.py
+++ b/etl/tests/test_main.py
@@ -354,3 +354,101 @@ class TestResetWatermarksBeforeCreateRun:
             # should fire — confirms the watermark-reset block is using the
             # passed-in flags rather than the (now unread) DB row.
             mock_reset.assert_called_once()
+
+
+class TestForcedRunAbortsOnResetFailure:
+    """Issue #828: a manual force-resync whose watermark reset FAILS must abort
+    and record a failed run — not silently degrade to a stale-watermark sync
+    while the dashboard reports the requested resync as done.
+    """
+
+    def _run_with_failing_reset(
+        self, force_flags: tuple[bool, list[str], str | None]
+    ) -> dict[str, MagicMock]:
+        mocks: dict[str, MagicMock] = {}
+        with ExitStack() as stack:
+            for path in _SYNC_FN_PATHS:
+                short = path.rsplit(".", 1)[-1]
+                mocks[short] = stack.enter_context(patch(path, return_value=100))
+
+            for path in _POSTGRES_HELPER_PATHS:
+                short = path.rsplit(".", 1)[-1]
+                mocks[short] = stack.enter_context(patch(path))
+            mocks["create_run"].return_value = 42
+
+            mocks["reset_watermarks"] = stack.enter_context(
+                patch(
+                    "etl.db.postgres.reset_watermarks",
+                    side_effect=RuntimeError("pg down"),
+                )
+            )
+            mocks["update_trigger_run_id"] = stack.enter_context(
+                patch("etl.db.postgres.update_trigger_run_id")
+            )
+            stack.enter_context(
+                patch("etl.sync.articulos.get_ma_article_codes", return_value=[])
+            )
+            stack.enter_context(patch("etl.main._get_rows_total", return_value=None))
+
+            conn_4d, conn_pg = MagicMock(), MagicMock()
+            run_full_sync(
+                conn_4d,
+                conn_pg,
+                trigger="manual",
+                trigger_id=7,
+                force_flags=force_flags,
+            )
+        return mocks
+
+    def test_force_full_reset_failure_aborts_without_syncing(self):
+        mocks = self._run_with_failing_reset((True, [], "dashboard"))
+
+        # No sync module may run — the operator's reset did not happen.
+        for path in _SYNC_FN_PATHS:
+            short = path.rsplit(".", 1)[-1]
+            assert mocks[short].call_count == 0, f"{short} ran despite aborted reset"
+
+        # A failed run is recorded and linked to the trigger row.
+        mocks["create_run"].assert_called_once()
+        args, kwargs = mocks["finish_run"].call_args
+        assert args[2] == "failed"
+        mocks["update_trigger_run_id"].assert_called_once()
+        assert mocks["update_trigger_run_id"].call_args[0][1:] == (7, 42)
+
+    def test_force_tables_reset_failure_aborts_without_syncing(self):
+        mocks = self._run_with_failing_reset((False, ["traspasos"], "dashboard"))
+
+        for path in _SYNC_FN_PATHS:
+            short = path.rsplit(".", 1)[-1]
+            assert mocks[short].call_count == 0, f"{short} ran despite aborted reset"
+        args, kwargs = mocks["finish_run"].call_args
+        assert args[2] == "failed"
+
+    def test_successful_reset_still_runs_the_sync(self):
+        """Control: when the reset succeeds the pipeline proceeds as before."""
+        with ExitStack() as stack:
+            sync_mocks: dict[str, MagicMock] = {}
+            for path in _SYNC_FN_PATHS:
+                short = path.rsplit(".", 1)[-1]
+                sync_mocks[short] = stack.enter_context(patch(path, return_value=1))
+            for path in _POSTGRES_HELPER_PATHS:
+                stack.enter_context(patch(path))
+            stack.enter_context(
+                patch("etl.db.postgres.reset_watermarks", return_value=3)
+            )
+            stack.enter_context(patch("etl.db.postgres.update_trigger_run_id"))
+            stack.enter_context(
+                patch("etl.sync.articulos.get_ma_article_codes", return_value=[])
+            )
+            stack.enter_context(patch("etl.main._get_rows_total", return_value=None))
+
+            conn_4d, conn_pg = MagicMock(), MagicMock()
+            run_full_sync(
+                conn_4d,
+                conn_pg,
+                trigger="manual",
+                trigger_id=7,
+                force_flags=(True, [], "dashboard"),
+            )
+
+        assert sync_mocks["sync_stock"].call_count == 1

--- a/etl/tests/test_main.py
+++ b/etl/tests/test_main.py
@@ -415,6 +415,13 @@ class TestForcedRunAbortsOnResetFailure:
         mocks["update_trigger_run_id"].assert_called_once()
         assert mocks["update_trigger_run_id"].call_args[0][1:] == (7, 42)
 
+        # A synthetic "(watermark_reset)" table row explains the abort in the
+        # dashboard details view (mirrors the "(4d_connection)" precedent).
+        rts_args, rts_kwargs = mocks["record_table_sync"].call_args
+        assert rts_args[2] == "(watermark_reset)"
+        assert rts_kwargs["status"] == "failed"
+        assert "pg down" in rts_kwargs["error_msg"]
+
     def test_force_tables_reset_failure_aborts_without_syncing(self):
         mocks = self._run_with_failing_reset((False, ["traspasos"], "dashboard"))
 

--- a/etl/tests/test_sync_stock.py
+++ b/etl/tests/test_sync_stock.py
@@ -518,3 +518,111 @@ class TestSyncStockIntegration:
             f"Traspasos count mismatch: 4D has {source_count}, "
             f"PostgreSQL has {pg_count}"
         )
+
+
+class TestMapTraspasoRowQuantization:
+    """Issue #827: RegTraspaso must be quantized to 3 decimal places.
+
+    ps_traspasos.reg_traspaso is NUMERIC(20,3) and real 4D PKs can differ only
+    in the third decimal (e.g. 4.152 vs 4.153). The previous scale-2 quantize
+    collided such pairs onto one key, silently losing rows via the append-only
+    ON CONFLICT DO NOTHING insert.
+    """
+
+    @staticmethod
+    def _src(reg: float) -> dict:
+        return {
+            "regtraspaso": reg,
+            "codigo": "144880",
+            "descripcion": "test",
+            "talla": "38",
+            "unidadess": 1,
+            "unidadese": 1,
+            "tiendasalida": "104",
+            "tiendaentrada": "105",
+            "fechas": None,
+            "fechae": None,
+            "tipo": None,
+            "concepto": None,
+            "entrada": None,
+        }
+
+    def test_three_decimal_pks_stay_distinct(self):
+        from etl.sync.stock import _map_traspaso_row
+
+        a = _map_traspaso_row(self._src(4.152))["reg_traspaso"]
+        b = _map_traspaso_row(self._src(4.153))["reg_traspaso"]
+        assert a != b, "scale-2 rounding would collide 4.152 and 4.153"
+        assert str(a) == "4.152"
+        assert str(b) == "4.153"
+
+    def test_float_artifacts_still_normalised(self):
+        from etl.sync.stock import _map_traspaso_row
+
+        v = _map_traspaso_row(self._src(10.989999999999998))["reg_traspaso"]
+        assert str(v) == "10.990"
+
+
+class TestSyncStockSkipsInvalidRows:
+    """Issue #820: a row with a missing PK component must be skipped with a
+    warning — not abort the whole multi-store sync and stall the watermark."""
+
+    @staticmethod
+    def _expo_row(codigo: str | None, tienda_codigo: str | None) -> dict:
+        row: dict = {
+            "codigo": codigo,
+            "tiendacodigo": tienda_codigo,
+            "tienda": "104",
+            "ccstock": 1.0,
+            "ststock": 1.0,
+            "fechamodifica": None,
+        }
+        for i in range(1, 35):
+            row[f"talla{i}"] = "38" if i == 1 else None
+            row[f"stock{i}"] = 2 if i == 1 else None
+        return row
+
+    def test_bad_row_is_skipped_and_good_rows_land(self, caplog):
+        conn_4d, conn_pg = MagicMock(), MagicMock()
+        rows = [
+            self._expo_row("144880", "104/169"),  # good
+            self._expo_row(None, "104/169"),  # corrupt: Codigo NULL
+            self._expo_row("144881", "104/169"),  # good
+        ]
+        with (
+            patch("etl.sync.stock._count_expo", return_value=3),
+            patch("etl.sync.stock._build_expo_where", return_value=""),
+            patch("etl.sync.stock._get_store_codes", return_value=["104"]),
+            patch("etl.sync.stock.safe_fetch", return_value=rows),
+            patch(
+                "etl.sync.stock.upsert", side_effect=lambda c, t, rs, pk_cols: len(rs)
+            ) as mock_upsert,
+        ):
+            import logging
+
+            with caplog.at_level(logging.WARNING, logger="etl.sync.stock"):
+                total = sync_stock(conn_4d, conn_pg, since=None)
+
+        # The two good source rows (one talla pair each) were upserted.
+        assert total == 2
+        assert mock_upsert.call_count == 1
+        upserted = mock_upsert.call_args[0][2]
+        assert {r["codigo"] for r in upserted} == {"144880", "144881"}
+        # The skip is loud: per-row warning + end-of-run summary.
+        assert any("skipping invalid row" in r.message for r in caplog.records)
+        assert any("skipped 1 invalid source row" in r.message for r in caplog.records)
+
+    def test_all_rows_bad_completes_with_zero(self):
+        conn_4d, conn_pg = MagicMock(), MagicMock()
+        rows = [self._expo_row(None, None)]
+        with (
+            patch("etl.sync.stock._count_expo", return_value=1),
+            patch("etl.sync.stock._build_expo_where", return_value=""),
+            patch("etl.sync.stock._get_store_codes", return_value=["104"]),
+            patch("etl.sync.stock.safe_fetch", return_value=rows),
+            patch("etl.sync.stock.upsert") as mock_upsert,
+        ):
+            total = sync_stock(conn_4d, conn_pg, since=None)
+
+        assert total == 0
+        mock_upsert.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes the three ETL data-correctness issues from the audit (cluster 1), in one PR.

Closes #827. Closes #820. Closes #828.

### 1. Traspasos PK quantized to the wrong scale (#827, p1 — silent data loss)

`_map_traspaso_row` quantized `RegTraspaso` to **2** decimals while `ps_traspasos.reg_traspaso` is `NUMERIC(20,3)`. The init.sql type-convention header explicitly warns that some 4D Real PKs differ only in the third decimal — scale-2 rounding collides them, and the append-only `ON CONFLICT DO NOTHING` insert silently drops one row per collision; survivors sit under wrong keys.

- `etl/sync/stock.py`: `_THREE_PLACES = Decimal("0.001")` (matches `ccstock.py`), docstring corrected.
- **Run-once data correction** in `etl/schema/init.sql`: new `etl_one_time_migrations` marker table + a guarded block that wipes `ps_traspasos` and clears its watermark, so the next sync re-pulls all ~262K rows under correct keys. Without this, the fixed ETL would *duplicate* every surviving wrong-key row (the table is never truncated). Verified run-once against live Postgres (second apply leaves data intact). Per AGENTS.md, the block should be removed in a follow-up PR once production has applied it.

### 2. One corrupt row aborts the whole stock sync (#820, p1)

A single `Exportaciones` row with NULL `Codigo`/`TiendaCodigo` raised `ValueError` out of `sync_stock`, failing the run for **all ~50 stores** and stalling the watermark in a permanent retry loop. Invalid rows are now skipped with a per-row warning and an end-of-run summary count; the rest of the store and the run proceed.

### 3. Failed watermark reset silently degrades a force-resync (#828)

When a manual trigger requests `force_full`/`force_tables` and `reset_watermarks` raises, the run used to continue as a normal stale-watermark sync while the dashboard showed the requested resync as done. It now **aborts**: a FAILED run row is recorded and linked to the trigger row, so the operator sees the resync did not happen. Control test confirms the success path is unchanged.

## Tests

- `TestMapTraspasoRowQuantization`: 4.152 vs 4.153 stay distinct; float artifacts still normalise to 3 places.
- `TestSyncStockSkipsInvalidRows`: bad row skipped + good rows land (with log assertions); all-bad-rows run completes with 0.
- `TestForcedRunAbortsOnResetFailure`: abort for both force scopes (no sync fn runs, failed run recorded + linked) + success-path control.
- Full ETL suite: **200 passed, 69 skipped** (integration tests skip without live 4D/PG). `ruff format` + `ruff check` clean.

## Operational note

After this deploys, the first ETL start applies the migration and the next full sync re-pulls Traspasos (~262K rows, batched). No action needed beyond a normal deploy; `ps etl status` will show the traspasos watermark re-materialise.

https://claude.ai/code/session_01STxL6Ge4ri8RyfWhz9Sig6