### PR TITLE
fix(dashboard): conversation streaming reliability — per-turn state, replay tagging, durable thinking/errors, bounded events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ otel/local/*.json
 # Playwright e2e output (local runs; CI uploads these as workflow artifacts)
 dashboard/test-results/
 dashboard/playwright-report/
+node_modules/

--- a/dashboard/app/api/conversations/[id]/stream/__tests__/route.test.ts
+++ b/dashboard/app/api/conversations/[id]/stream/__tests__/route.test.ts
@@ -219,10 +219,28 @@ describe("GET /api/conversations/:id/stream", () => {
       expect(events[1].data.eventType).toBe("log");
       expect(events[2].id).toBe(3);
       expect(events[2].data.eventType).toBe("complete");
-      // Catch-up frames are tagged so the client can distinguish them from
-      // live events (no refetch / no pending-turn adoption — #825/#836).
+      // Catch-up frames on a FRESH connection are tagged so the client can
+      // distinguish them from live events (no refetch / no adoption — #825/#836).
       for (const ev of events) {
         expect(ev.data.replay).toBe(true);
+      }
+    });
+
+    it("does NOT tag replayed frames on a resumption connection (Last-Event-ID)", async () => {
+      mockGetConversation.mockResolvedValue(BASE_CONV);
+      mockGetConversationEvents.mockResolvedValue(TURN_EVENTS.slice(2));
+
+      const req = makeRequest(CONV_ID, "2");
+      const res = await GET(req, makeContext(CONV_ID));
+      const text = await readStreamChunks(res.body as ReadableStream<Uint8Array>);
+      const events = parseSseText(text);
+
+      // These frames are live events the client missed while disconnected
+      // (possibly a complete/error) — the client must run its normal
+      // refetch/settlement logic, so no replay tag.
+      expect(events.length).toBeGreaterThan(0);
+      for (const ev of events) {
+        expect(ev.data.replay).toBeUndefined();
       }
     });
 

--- a/dashboard/app/api/conversations/[id]/stream/__tests__/route.test.ts
+++ b/dashboard/app/api/conversations/[id]/stream/__tests__/route.test.ts
@@ -219,6 +219,37 @@ describe("GET /api/conversations/:id/stream", () => {
       expect(events[1].data.eventType).toBe("log");
       expect(events[2].id).toBe(3);
       expect(events[2].data.eventType).toBe("complete");
+      // Catch-up frames are tagged so the client can distinguish them from
+      // live events (no refetch / no pending-turn adoption — #825/#836).
+      for (const ev of events) {
+        expect(ev.data.replay).toBe(true);
+      }
+    });
+
+    it("live events published after replay carry no replay tag", async () => {
+      mockGetConversation.mockResolvedValue(BASE_CONV);
+      mockGetConversationEvents.mockResolvedValue([]);
+
+      const req = makeRequest(CONV_ID);
+      const res = await GET(req, makeContext(CONV_ID));
+
+      // Publish a live event once the subscription is registered.
+      await vi.waitFor(() => {
+        if (!capturedListener) throw new Error("not subscribed yet");
+      });
+      capturedListener!({
+        dbEventId: 10,
+        turnId: "t1",
+        seq: 0,
+        eventType: "token",
+        payload: { text: "hola" },
+      });
+
+      const text = await readStreamChunks(res.body as ReadableStream<Uint8Array>);
+      const events = parseSseText(text);
+      const live = events.find((e) => e.id === 10);
+      expect(live).toBeDefined();
+      expect(live!.data.replay).toBeUndefined();
     });
 
     it("calls getConversationEvents with no sinceId when no Last-Event-ID header", async () => {

--- a/dashboard/app/api/conversations/[id]/stream/route.ts
+++ b/dashboard/app/api/conversations/[id]/stream/route.ts
@@ -131,10 +131,16 @@ export async function GET(
         }
       });
 
-      // Replay historical events. Frames are tagged `replay: true` so the
-      // client can distinguish catch-up data (accumulate state, no refetch,
-      // no pending-turn adoption) from genuinely live events — see
-      // ConversationPane's handleEvent and issues #825/#836.
+      // Replay historical events. On a FRESH connection (no Last-Event-ID)
+      // these frames are tagged `replay: true` so the client treats them as
+      // catch-up data (accumulate state; no refetch per historical turn; no
+      // pending-turn adoption) — see ConversationPane's handleEvent and issues
+      // #825/#836. On a RESUMPTION connection (Last-Event-ID > 0) the replayed
+      // frames are live events the client missed during the disconnect —
+      // including a possible complete/error — so they are NOT tagged, letting
+      // the client run its normal refetch/settlement logic immediately instead
+      // of waiting for the liveness poll.
+      const isFreshConnection = sinceIdParam === undefined;
       let historicalEvents;
       try {
         historicalEvents = await getConversationEvents(id, sinceIdParam);
@@ -154,7 +160,7 @@ export async function GET(
               seq: ev.seq,
               eventType: ev.event_type,
               payload: ev.payload,
-              replay: true,
+              ...(isFreshConnection ? { replay: true } : {}),
             }),
           );
         } catch {
@@ -164,9 +170,11 @@ export async function GET(
         }
       }
 
-      // Flush buffered live events, skipping those already sent via history replay.
-      // These arrived while the snapshot query ran — they are effectively part of
-      // the catch-up batch, so they carry the replay tag too.
+      // Flush buffered live events, skipping those already sent via history
+      // replay. These arrived while the snapshot query ran — they are LIVE
+      // events (just slightly delayed), so they are never tagged as replay:
+      // a complete/error landing in this window must trigger the client's
+      // normal refetch/settlement logic.
       replayDone = true;
       for (const ev of liveBuffer) {
         if (ev.dbEventId <= maxReplayedId) continue;
@@ -177,7 +185,6 @@ export async function GET(
               seq: ev.seq,
               eventType: ev.eventType,
               payload: ev.payload,
-              replay: true,
             }),
           );
         } catch {

--- a/dashboard/app/api/conversations/[id]/stream/route.ts
+++ b/dashboard/app/api/conversations/[id]/stream/route.ts
@@ -131,7 +131,10 @@ export async function GET(
         }
       });
 
-      // Replay historical events.
+      // Replay historical events. Frames are tagged `replay: true` so the
+      // client can distinguish catch-up data (accumulate state, no refetch,
+      // no pending-turn adoption) from genuinely live events — see
+      // ConversationPane's handleEvent and issues #825/#836.
       let historicalEvents;
       try {
         historicalEvents = await getConversationEvents(id, sinceIdParam);
@@ -151,6 +154,7 @@ export async function GET(
               seq: ev.seq,
               eventType: ev.event_type,
               payload: ev.payload,
+              replay: true,
             }),
           );
         } catch {
@@ -161,6 +165,8 @@ export async function GET(
       }
 
       // Flush buffered live events, skipping those already sent via history replay.
+      // These arrived while the snapshot query ran — they are effectively part of
+      // the catch-up batch, so they carry the replay tag too.
       replayDone = true;
       for (const ev of liveBuffer) {
         if (ev.dbEventId <= maxReplayedId) continue;
@@ -171,6 +177,7 @@ export async function GET(
               seq: ev.seq,
               eventType: ev.eventType,
               payload: ev.payload,
+              replay: true,
             }),
           );
         } catch {

--- a/dashboard/components/ConversationPane.tsx
+++ b/dashboard/components/ConversationPane.tsx
@@ -27,7 +27,17 @@ interface TurnData {
    * lives in a file and is lazy-loaded from /context/:turnId when expanded.
    */
   hasContext: boolean;
-  thinking: string | null; // final extended-thinking text (persisted after complete)
+  /**
+   * Cumulative extended-thinking text. Accumulated per turn (NOT gated on this
+   * client having initiated the turn) so replayed events after a mid-turn
+   * reload and live events in a second window render identically — issues
+   * #825/#836. For completed turns the durable copy is `content.thinking` on
+   * the assistant message; this field also serves as the fallback for turns
+   * recorded before that field existed.
+   */
+  thinking: string | null;
+  /** Cumulative streamed answer text (token events). Same accumulation rules. */
+  streamText: string;
   logs: LogLine[];
   complete: boolean;
   error: string | null;
@@ -36,6 +46,7 @@ interface TurnData {
 const EMPTY_TURN: TurnData = {
   hasContext: false,
   thinking: null,
+  streamText: "",
   logs: [],
   complete: false,
   error: null,
@@ -426,10 +437,6 @@ export function ConversationPane({
   // Currently streaming turn
   const [pendingTurnId, setPendingTurnId] = useState<string | null>(null);
   const [pendingUserMsg, setPendingUserMsg] = useState("");
-  // Accumulated streaming text (token events) for the active turn
-  const [streamingText, setStreamingText] = useState("");
-  // Accumulated extended thinking text for the active turn
-  const [thinkingText, setThinkingText] = useState("");
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
@@ -439,7 +446,9 @@ export function ConversationPane({
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const lastEventIdRef = useRef(0);
   const pendingTurnIdRef = useRef<string | null>(null);
-  const thinkingTextRef = useRef("");
+  // Mirror of the turns map so async SSE callbacks can read the latest
+  // accumulated state without stale-closure issues.
+  const turnsRef = useRef<Map<string, TurnData>>(new Map());
   const autosendFiredRef = useRef(false);
 
   // Keep refs in sync
@@ -447,8 +456,8 @@ export function ConversationPane({
     pendingTurnIdRef.current = pendingTurnId;
   }, [pendingTurnId]);
   useEffect(() => {
-    thinkingTextRef.current = thinkingText;
-  }, [thinkingText]);
+    turnsRef.current = turns;
+  }, [turns]);
 
   // Sync onProcessingChange
   useEffect(() => {
@@ -466,8 +475,6 @@ export function ConversationPane({
     setMsgToTurn(new Map());
     setPendingTurnId(null);
     setPendingUserMsg("");
-    setStreamingText("");
-    setThinkingText("");
     lastEventIdRef.current = 0;
   }, [initialConversationId]);
 
@@ -552,6 +559,33 @@ export function ConversationPane({
       const turnId = data.turnId as string;
       const eventType = data.eventType as string;
       const payload = data.payload as Record<string, unknown>;
+      // Frames sent during connect-time catch-up carry replay=true (stream
+      // route). Replay frames only rebuild per-turn state — they must not
+      // trigger refetches, clear pending state, or adopt turns.
+      const isReplay = data.replay === true;
+
+      // Adopt a turn that started elsewhere (second window / another tab) as
+      // the pending turn so its live stream renders here too (issue #825).
+      // Live events only; completed/errored turns are never adopted.
+      if (
+        !isReplay &&
+        pendingTurnIdRef.current === null &&
+        (eventType === "context_ref" ||
+          eventType === "log" ||
+          eventType === "thinking" ||
+          eventType === "token")
+      ) {
+        const known = turnsRef.current.get(turnId);
+        if (!known?.complete && !known?.error) {
+          // Set the ref synchronously: more events may arrive before React
+          // commits, and the guard above must only fire once.
+          pendingTurnIdRef.current = turnId;
+          setPendingTurnId(turnId);
+          // Refresh so the in-flight turn's user message (persisted before any
+          // event was emitted) appears above the stream.
+          if (convId) void loadConversation(convId);
+        }
+      }
 
       if (eventType === "context_ref") {
         // The heavy context log lives in a file — just record that one exists so
@@ -574,18 +608,23 @@ export function ConversationPane({
           });
         }
       } else if (eventType === "thinking") {
-        // Extended thinking — cumulative. Empty string = tool round cleared.
+        // Extended thinking — cumulative. Accumulated per turn, regardless of
+        // which client initiated it (no pending gate — issues #825/#836).
         const text = (payload.text as string | undefined) ?? "";
-        if (pendingTurnIdRef.current === turnId) {
-          setThinkingText(text);
-        }
+        setTurns((prev) => {
+          const map = new Map(prev);
+          const existing = map.get(turnId) ?? EMPTY_TURN;
+          return map.set(turnId, { ...existing, thinking: text || null });
+        });
       } else if (eventType === "token") {
         // model_text_delta.text is CUMULATIVE (full text so far, not a delta).
-        // Replace streamingText entirely. Empty string = clear (tool round detected).
+        // Replace entirely; empty string = clear (tool round detected).
         const text = (payload.text as string | undefined) ?? (payload.delta as string | undefined) ?? "";
-        if (pendingTurnIdRef.current === turnId) {
-          setStreamingText(text);
-        }
+        setTurns((prev) => {
+          const map = new Map(prev);
+          const existing = map.get(turnId) ?? EMPTY_TURN;
+          return map.set(turnId, { ...existing, streamText: text });
+        });
       } else if (eventType === "spec_update") {
         handleSpecUpdateEvent(payload);
       } else if (eventType === "complete") {
@@ -593,41 +632,77 @@ export function ConversationPane({
         setTurns((prev) => {
           const map = new Map(prev);
           const existing = map.get(turnId) ?? EMPTY_TURN;
-          // Persist final thinking text into TurnData so it survives after complete.
-          const finalThinking = thinkingTextRef.current || null;
-          return map.set(turnId, { ...existing, complete: true, thinking: finalThinking });
+          return map.set(turnId, { ...existing, complete: true });
         });
         if (messageId) {
           setMsgToTurn((prev) => new Map(prev).set(messageId, turnId));
         }
-        // Always refresh messages so passive watchers (second browser window)
-        // also pick up the newly-persisted assistant message. Clear pending-
-        // turn state only when this client initiated the turn.
+        // Replayed completes need no refetch: loadConversation already
+        // supplies the persisted messages (and refetching once per historical
+        // turn would hammer the API on every reconnect).
+        if (isReplay) return;
+        // Refresh messages so this window (initiator or watcher) picks up the
+        // newly-persisted assistant message. Clear pending-turn state only when
+        // this client is showing the turn as pending.
         void fetch(`/api/conversations/${convId}`)
-          .then((r) => (r.ok ? r.json() : null))
+          .then((r) => (r.ok ? (r.json() as Promise<ConversationWithMessages>) : Promise.reject(new Error(`HTTP ${r.status}`))))
           .then((freshConv) => {
-            if (freshConv) setConv(freshConv as ConversationWithMessages);
+            setConv(freshConv);
             if (pendingTurnIdRef.current === turnId) {
               setPendingTurnId(null);
               setPendingUserMsg("");
-              setStreamingText("");
-              setThinkingText("");
             }
           })
           .catch(() => {
+            // Refresh failed (issue #811): synthesise the assistant message
+            // locally from the turn's streamed text so the reply doesn't
+            // silently vanish. The next successful refresh replaces it.
+            const turn = turnsRef.current.get(turnId);
+            if (messageId && convId) {
+              setConv((prev) => {
+                if (!prev || prev.messages.some((m) => m.id === messageId)) return prev;
+                const content: Record<string, unknown> = {
+                  text:
+                    turn?.streamText ||
+                    "(Respuesta recibida — recarga la página para ver el contenido completo.)",
+                };
+                if (turn?.thinking) content.thinking = turn.thinking;
+                const synthetic = {
+                  id: messageId,
+                  conversation_id: convId,
+                  role: "assistant",
+                  content,
+                  created_at: new Date().toISOString(),
+                } as unknown as ConversationMessage;
+                return { ...prev, messages: [...prev.messages, synthetic] };
+              });
+            }
             if (pendingTurnIdRef.current === turnId) {
               setPendingTurnId(null);
-              setStreamingText("");
-              setThinkingText("");
+              setPendingUserMsg("");
             }
           });
       } else if (eventType === "error") {
         const errText = (payload.message as string | undefined) ?? "Error desconocido";
+        const messageId = payload.messageId as string | undefined;
         setTurns((prev) => {
           const map = new Map(prev);
           const existing = map.get(turnId) ?? EMPTY_TURN;
           return map.set(turnId, { ...existing, error: errText });
         });
+        // The error is persisted as an is_error assistant message (issue #824);
+        // map it so the turn's logs/context panel attach to it after refresh.
+        if (messageId) {
+          setMsgToTurn((prev) => new Map(prev).set(messageId, turnId));
+        }
+        if (isReplay) return;
+        // Refresh so the persisted error bubble renders from messages.
+        void fetch(`/api/conversations/${convId}`)
+          .then((r) => (r.ok ? (r.json() as Promise<ConversationWithMessages>) : null))
+          .then((freshConv) => {
+            if (freshConv) setConv(freshConv);
+          })
+          .catch(() => {});
         if (pendingTurnIdRef.current === turnId) {
           setPendingTurnId(null);
           setPendingUserMsg("");
@@ -682,6 +757,15 @@ export function ConversationPane({
       setSending(true);
       setSendError(null);
 
+      // The input is cleared optimistically above; if the send fails, restore
+      // the typed text so the user doesn't have to retype it (issue #808).
+      // Only restore when the user hasn't started typing something new.
+      const restoreInput = () => {
+        if (overrideText === undefined) {
+          setInput((current) => (current === "" ? text : current));
+        }
+      };
+
       try {
         let currentConvId = convId;
 
@@ -689,6 +773,7 @@ export function ConversationPane({
         if (!currentConvId) {
           if (!newConversationConfig) {
             setSendError("No se puede enviar sin una conversación activa.");
+            restoreInput();
             return;
           }
           const res = await fetch("/api/conversations", {
@@ -702,6 +787,7 @@ export function ConversationPane({
           });
           if (!res.ok) {
             setSendError("No se pudo crear la conversación.");
+            restoreInput();
             return;
           }
           const created = (await res.json()) as { id: string };
@@ -727,6 +813,7 @@ export function ConversationPane({
             (errData as Record<string, string> | null)?.error ??
             "Error al enviar el mensaje.";
           setSendError(msg);
+          restoreInput();
           return;
         }
 
@@ -735,6 +822,7 @@ export function ConversationPane({
       } catch {
         setPendingUserMsg("");
         setSendError("No se pudo conectar con el servidor.");
+        restoreInput();
       } finally {
         setSending(false);
       }
@@ -834,9 +922,17 @@ export function ConversationPane({
           );
         }
 
-        if (turnData?.thinking) {
+        // Thinking: the durable copy lives on the message (content.thinking,
+        // persisted at turn completion — survives reloads, issue #825).
+        // TurnData.thinking covers turns recorded before that field existed,
+        // whose thinking events are still replayed.
+        const msgThinking =
+          (isAssistantContent(msg.content) && msg.content.thinking) ||
+          turnData?.thinking ||
+          null;
+        if (msgThinking) {
           items.push(
-            <ThinkingBlock key={`think-${msgId}`} text={turnData.thinking} />,
+            <ThinkingBlock key={`think-${msgId}`} text={msgThinking} />,
           );
         }
 
@@ -870,12 +966,18 @@ export function ConversationPane({
     return items;
   };
 
-  // Streaming turn rendering
+  // Streaming turn rendering. All stream state lives in the per-turn map, so
+  // this renders identically for the initiating client, a reloaded tab
+  // resuming mid-turn (replayed events repopulate the map before or after
+  // pendingTurnId is restored — no race), and a passive second window that
+  // adopted the turn (issues #825/#836).
   const renderPendingTurn = () => {
     if (!pendingTurnId) return null;
 
     const turnData = turns.get(pendingTurnId);
     const hasLogs = turnData && turnData.logs.length > 0;
+    const liveThinking = turnData?.thinking ?? "";
+    const liveText = turnData?.streamText ?? "";
 
     return (
       <>
@@ -900,11 +1002,11 @@ export function ConversationPane({
             <LogBlock lines={turnData.logs} streaming />
           </div>
         )}
-        {thinkingText && <ThinkingBlock text={thinkingText} streaming />}
-        {streamingText && (
-          <AssistantBubble key="streaming" text={streamingText} isError={false} />
+        {liveThinking && <ThinkingBlock text={liveThinking} streaming />}
+        {liveText && (
+          <AssistantBubble key="streaming" text={liveText} isError={false} />
         )}
-        {!thinkingText && !streamingText && !turnData?.complete && !turnData?.error && <LoadingDots />}
+        {!liveThinking && !liveText && !turnData?.complete && !turnData?.error && <LoadingDots />}
         {turnData?.error && (
           <AssistantBubble text={turnData.error} isError />
         )}

--- a/dashboard/components/ConversationPane.tsx
+++ b/dashboard/components/ConversationPane.tsx
@@ -52,6 +52,9 @@ const EMPTY_TURN: TurnData = {
   error: null,
 };
 
+/** Cadence of the SSE-liveness fallback poll while a turn is pending. */
+const TURN_LIVENESS_POLL_MS = 2_500;
+
 export interface NewConversationConfig {
   conversationMode: "modify" | "analyze" | "chat";
   contextKind: "dashboard" | "home" | "admin" | "global";
@@ -498,6 +501,49 @@ export function ConversationPane({
   useEffect(() => {
     if (convId) void loadConversation(convId);
   }, [convId, loadConversation]);
+
+  // Liveness fallback: SSE delivery can stall (observed with the Next.js dev
+  // server — the turn finishes server-side in <1s but the complete event never
+  // arrives, leaving the pane on "Procesando…" forever; see #836 root-cause
+  // notes). While a turn is pending, poll the conversation at a low cadence;
+  // the moment the server reports the turn finished (active_turn_id no longer
+  // ours), settle from the REST payload: messages refresh, the last assistant
+  // message is mapped to the turn (context panel/logs attach), pending state
+  // clears. SSE remains the fast path — a delivered complete event clears
+  // pendingTurnId and this effect unmounts the poll.
+  useEffect(() => {
+    if (!pendingTurnId || !convId) return;
+    const turnId = pendingTurnId;
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch(`/api/conversations/${convId}`);
+        if (!res.ok) return;
+        const data = (await res.json()) as ConversationWithMessages & {
+          active_turn_id?: string | null;
+        };
+        if (data.active_turn_id === turnId || pendingTurnIdRef.current !== turnId) {
+          return; // still running, or SSE already settled it
+        }
+        setConv(data);
+        const lastAssistant = [...data.messages]
+          .reverse()
+          .find((m) => m.role === "assistant");
+        if (lastAssistant) {
+          setMsgToTurn((prev) => new Map(prev).set(lastAssistant.id, turnId));
+        }
+        setTurns((prev) => {
+          const map = new Map(prev);
+          const existing = map.get(turnId) ?? EMPTY_TURN;
+          return map.set(turnId, { ...existing, complete: true });
+        });
+        setPendingTurnId(null);
+        setPendingUserMsg("");
+      } catch {
+        // transient — keep polling
+      }
+    }, TURN_LIVENESS_POLL_MS);
+    return () => clearInterval(interval);
+  }, [pendingTurnId, convId]);
 
   // Scroll to bottom when new messages arrive
   useEffect(() => {

--- a/dashboard/components/ConversationPane.tsx
+++ b/dashboard/components/ConversationPane.tsx
@@ -516,15 +516,24 @@ export function ConversationPane({
     const turnId = pendingTurnId;
     const interval = setInterval(async () => {
       try {
+        // Poll THIS turn's status — not the conversation's active_turn_id,
+        // which is merely "the most recent in-flight turn" and would falsely
+        // report our turn as finished if another client started a newer one.
+        const turnRes = await fetch(`/api/conversations/${convId}/turns/${turnId}`);
+        if (!turnRes.ok) return;
+        const turnData = (await turnRes.json()) as { turn?: { status?: string } };
+        const status = turnData.turn?.status;
+        if (status !== "complete" && status !== "error") return; // still running
+        if (pendingTurnIdRef.current !== turnId) return; // SSE already settled it
+
         const res = await fetch(`/api/conversations/${convId}`);
         if (!res.ok) return;
-        const data = (await res.json()) as ConversationWithMessages & {
-          active_turn_id?: string | null;
-        };
-        if (data.active_turn_id === turnId || pendingTurnIdRef.current !== turnId) {
-          return; // still running, or SSE already settled it
-        }
+        const data = (await res.json()) as ConversationWithMessages;
         setConv(data);
+        // Map the last assistant message to the turn so its context panel and
+        // logs attach (the SSE complete event that normally does this never
+        // arrived). With a stalled stream, no later turn can have started from
+        // this pane, so the last assistant message belongs to this turn.
         const lastAssistant = [...data.messages]
           .reverse()
           .find((m) => m.role === "assistant");
@@ -534,7 +543,11 @@ export function ConversationPane({
         setTurns((prev) => {
           const map = new Map(prev);
           const existing = map.get(turnId) ?? EMPTY_TURN;
-          return map.set(turnId, { ...existing, complete: true });
+          return map.set(turnId, {
+            ...existing,
+            complete: status === "complete",
+            error: status === "error" ? (existing.error ?? "Error") : existing.error,
+          });
         });
         setPendingTurnId(null);
         setPendingUserMsg("");

--- a/dashboard/components/__tests__/ConversationPane.test.tsx
+++ b/dashboard/components/__tests__/ConversationPane.test.tsx
@@ -675,3 +675,213 @@ describe("ConversationPane", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Stream-state reliability (#825 / #836 / #811 / #808)
+// ---------------------------------------------------------------------------
+
+const enc = new TextEncoder();
+
+function sseFrame(
+  id: number,
+  turnId: string,
+  eventType: string,
+  payload: Record<string, unknown>,
+  replay = false,
+): Uint8Array {
+  const data: Record<string, unknown> = { turnId, eventType, payload };
+  if (replay) data.replay = true;
+  return enc.encode(`id: ${id}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+describe("ConversationPane — stream-state reliability", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("#836: mid-turn resume renders replayed thinking/text even when the conversation fetch is slow", async () => {
+    const convId = "conv-resume";
+    const turnId = "turn-live";
+    // Conversation fetch resolves AFTER the SSE replay frames have been
+    // handled — the exact ordering that used to drop the replayed stream.
+    const conv = { id: convId, mode: "chat", title: null, active_turn_id: turnId, messages: [] };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        const u = url as string;
+        if (u.includes("/stream")) {
+          const stream = new ReadableStream<Uint8Array>({
+            start(ctrl) {
+              ctrl.enqueue(sseFrame(1, turnId, "thinking", { text: "razonando sobre ventas" }, true));
+              ctrl.enqueue(sseFrame(2, turnId, "token", { text: "Las ventas suben" }, true));
+              // Stream stays open (turn still in flight) — no more frames.
+            },
+          });
+          return Promise.resolve({ ok: true, body: stream } as unknown as Response);
+        }
+        return new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                json: () => Promise.resolve(conv),
+              } as unknown as Response),
+            60,
+          ),
+        );
+      }),
+    );
+
+    render(<ConversationPane conversationId={convId} mode="standalone" />);
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("thinking-block")).toBeInTheDocument();
+        expect(screen.getByText("Las ventas suben")).toBeInTheDocument();
+      },
+      { timeout: 4000 },
+    );
+  });
+
+  it("replayed complete events do not trigger per-turn refetches", async () => {
+    const convId = "conv-replay";
+    const messages = [
+      { id: "m1", conversation_id: convId, role: "user", content: { text: "hola" }, created_at: "2026-01-01" },
+      { id: "m2", conversation_id: convId, role: "assistant", content: { text: "respuesta" }, created_at: "2026-01-01" },
+    ];
+    const conv = { id: convId, mode: "chat", title: null, active_turn_id: null, messages };
+
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      const u = url as string;
+      if (u.includes("/stream")) {
+        const stream = new ReadableStream<Uint8Array>({
+          start(ctrl) {
+            ctrl.enqueue(sseFrame(1, "turn-old", "complete", { messageId: "m2" }, true));
+            // keep open
+          },
+        });
+        return Promise.resolve({ ok: true, body: stream } as unknown as Response);
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(conv) } as unknown as Response);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ConversationPane conversationId={convId} mode="standalone" />);
+    await waitFor(() => expect(screen.getByText("respuesta")).toBeInTheDocument());
+
+    // Only the initial loadConversation fetch — the replayed complete must not refetch.
+    const convFetches = fetchMock.mock.calls.filter(
+      ([u]) => (u as string).includes(`/api/conversations/${convId}`) && !(u as string).includes("/stream"),
+    );
+    expect(convFetches).toHaveLength(1);
+  });
+
+  it("#825: a passive window adopts a live turn and shows its stream", async () => {
+    const convId = "conv-passive";
+    const turnId = "turn-other-window";
+    const conv = { id: convId, mode: "chat", title: null, active_turn_id: null, messages: [] };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        const u = url as string;
+        if (u.includes("/stream")) {
+          const stream = new ReadableStream<Uint8Array>({
+            start(ctrl) {
+              // LIVE frames (no replay flag): another client started this turn.
+              setTimeout(() => {
+                ctrl.enqueue(sseFrame(1, turnId, "log", { kind: "meta", text: "Procesando…", ts: "2026-01-01T00:00:00Z" }));
+                ctrl.enqueue(sseFrame(2, turnId, "token", { text: "Hola desde otra ventana" }));
+              }, 10);
+            },
+          });
+          return Promise.resolve({ ok: true, body: stream } as unknown as Response);
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(conv) } as unknown as Response);
+      }),
+    );
+
+    render(<ConversationPane conversationId={convId} mode="standalone" />);
+
+    await waitFor(
+      () => expect(screen.getByText("Hola desde otra ventana")).toBeInTheDocument(),
+      { timeout: 4000 },
+    );
+  });
+
+  it("#811: synthesises the assistant message locally when the post-complete refetch fails", async () => {
+    const convId = "conv-refetch-fail";
+    const turnId = "turn-x";
+    const conv = { id: convId, mode: "chat", title: null, active_turn_id: turnId, messages: [] };
+    let convFetches = 0;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        const u = url as string;
+        if (u.includes("/stream")) {
+          const stream = new ReadableStream<Uint8Array>({
+            start(ctrl) {
+              setTimeout(() => {
+                ctrl.enqueue(sseFrame(1, turnId, "token", { text: "Respuesta completa del modelo" }));
+                ctrl.enqueue(sseFrame(2, turnId, "complete", { messageId: "m-new" }));
+              }, 10);
+            },
+          });
+          return Promise.resolve({ ok: true, body: stream } as unknown as Response);
+        }
+        convFetches++;
+        if (convFetches === 1) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(conv) } as unknown as Response);
+        }
+        // Post-complete refresh fails.
+        return Promise.resolve({ ok: false, status: 500 } as unknown as Response);
+      }),
+    );
+
+    render(<ConversationPane conversationId={convId} mode="standalone" />);
+
+    // The streamed text must survive as a synthetic message — not vanish.
+    await waitFor(
+      () => expect(screen.getByText("Respuesta completa del modelo")).toBeInTheDocument(),
+      { timeout: 4000 },
+    );
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("Escribe un mensaje…")).toBeEnabled(),
+    );
+  });
+
+  it("#808: restores the typed message into the input when the send fails", async () => {
+    const convId = "conv-send-fail";
+    const conv = { id: convId, mode: "chat", title: null, active_turn_id: null, messages: [] };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+        const u = url as string;
+        if (u.includes("/stream")) return makeStreamFetch();
+        if (u.includes("/turns") && opts?.method === "POST") {
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            json: () => Promise.resolve({ error: "Error al crear el turno." }),
+          } as unknown as Response);
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(conv) } as unknown as Response);
+      }),
+    );
+
+    render(<ConversationPane conversationId={convId} mode="standalone" />);
+    const input = screen.getByPlaceholderText("Escribe un mensaje…");
+    fireEvent.change(input, { target: { value: "mensaje importante" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(screen.getByText("Error al crear el turno.")).toBeInTheDocument(),
+    );
+    // The typed text is back in the input — not lost (issue #808).
+    expect(input).toHaveValue("mensaje importante");
+  });
+});

--- a/dashboard/components/__tests__/ConversationPane.test.tsx
+++ b/dashboard/components/__tests__/ConversationPane.test.tsx
@@ -885,3 +885,57 @@ describe("ConversationPane — stream-state reliability", () => {
     expect(input).toHaveValue("mensaje importante");
   });
 });
+
+describe("ConversationPane — SSE liveness fallback", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("settles a pending turn via polling when SSE delivers no events at all", async () => {
+    const convId = "conv-stalled";
+    const turnId = "turn-stalled";
+    // First conversation fetch: turn still active. Later fetches: finished,
+    // with the assistant message persisted. SSE delivers NOTHING (the stall).
+    let calls = 0;
+    const running = { id: convId, mode: "chat", title: null, active_turn_id: turnId, messages: [] };
+    const finished = {
+      id: convId,
+      mode: "chat",
+      title: null,
+      active_turn_id: null,
+      messages: [
+        { id: "mu", conversation_id: convId, role: "user", content: { text: "hola" }, created_at: "2026-01-01" },
+        { id: "ma", conversation_id: convId, role: "assistant", content: { text: "[e2e-stub] Respuesta a: \"hola\"" }, created_at: "2026-01-01" },
+      ],
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        const u = url as string;
+        if (u.includes("/stream")) {
+          // Open stream that never produces a frame — the stall.
+          const stream = new ReadableStream<Uint8Array>({ start() {} });
+          return Promise.resolve({ ok: true, body: stream } as unknown as Response);
+        }
+        calls++;
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(calls === 1 ? running : finished),
+        } as unknown as Response);
+      }),
+    );
+
+    render(<ConversationPane conversationId={convId} mode="standalone" />);
+
+    // The poll (2.5s cadence) must surface the persisted reply and re-enable input.
+    await waitFor(
+      () => expect(screen.getByText('[e2e-stub] Respuesta a: "hola"')).toBeInTheDocument(),
+      { timeout: 9000 },
+    );
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("Escribe un mensaje…")).toBeEnabled(),
+    );
+  }, 15_000);
+});

--- a/dashboard/components/__tests__/ConversationPane.test.tsx
+++ b/dashboard/components/__tests__/ConversationPane.test.tsx
@@ -919,6 +919,13 @@ describe("ConversationPane — SSE liveness fallback", () => {
           const stream = new ReadableStream<Uint8Array>({ start() {} });
           return Promise.resolve({ ok: true, body: stream } as unknown as Response);
         }
+        if (u.includes(`/turns/${turnId}`)) {
+          // The per-turn status poll: the turn finished server-side.
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ turn: { status: "complete" } }),
+          } as unknown as Response);
+        }
         calls++;
         return Promise.resolve({
           ok: true,

--- a/dashboard/lib/__tests__/turn-background.test.ts
+++ b/dashboard/lib/__tests__/turn-background.test.ts
@@ -10,11 +10,13 @@ import { describe, it, vi, expect, beforeEach } from "vitest";
 const mockUpdateTurnStatus = vi.fn();
 const mockInsertTurnEvent = vi.fn();
 const mockSetTurnContextFile = vi.fn();
+const mockPruneStreamEvents = vi.fn();
 
 vi.mock("@/lib/turn-events", () => ({
   updateTurnStatus: (...a: unknown[]) => mockUpdateTurnStatus(...a),
   insertTurnEvent: (...a: unknown[]) => mockInsertTurnEvent(...a),
   setTurnContextFile: (...a: unknown[]) => mockSetTurnContextFile(...a),
+  pruneStreamEvents: (...a: unknown[]) => mockPruneStreamEvents(...a),
 }));
 
 const mockWriteTurnContext = vi.fn();
@@ -115,6 +117,7 @@ beforeEach(() => {
   mockUpdateTurnStatus.mockResolvedValue(undefined);
   mockInsertTurnEvent.mockResolvedValue(undefined);
   mockSetTurnContextFile.mockResolvedValue(undefined);
+  mockPruneStreamEvents.mockResolvedValue(undefined);
   mockWriteTurnContext.mockResolvedValue("abcdef012345/turn-1.json");
   mockLoadMessages.mockResolvedValue([]);
   mockAppendMessage.mockResolvedValue({ id: "msg-001" });
@@ -342,6 +345,107 @@ describe("runTurnBackground — error path", () => {
     const errCall = mockInsertTurnEvent.mock.calls.find(([, , type]) => type === "error");
     expect(errCall).toBeDefined();
     expect((errCall?.[3] as Record<string, unknown>).message).toBe("boom");
+  });
+
+  it("persists an is_error assistant message so the failed turn survives reloads (#824)", async () => {
+    mockAssembleRequest.mockRejectedValue(new Error("LLM exploded"));
+    mockAppendMessage.mockResolvedValue({ id: "err-msg-001" });
+
+    await runTurnBackground(TURN_ID, makeConv(), "hello");
+
+    const assistantCall = mockAppendMessage.mock.calls.find(
+      ([, role]) => role === "assistant",
+    );
+    expect(assistantCall).toBeDefined();
+    expect(assistantCall?.[2]).toMatchObject({
+      text: "LLM exploded",
+      is_error: true,
+    });
+    // The error event carries the messageId so the client can attach the
+    // turn's logs/context panel to the persisted error message.
+    const errCall = mockInsertTurnEvent.mock.calls.find(([, , type]) => type === "error");
+    expect((errCall?.[3] as Record<string, unknown>).messageId).toBe("err-msg-001");
+  });
+
+  it("prunes transient stream events after an errored turn (#834)", async () => {
+    mockAssembleRequest.mockRejectedValue(new Error("boom"));
+
+    await runTurnBackground(TURN_ID, makeConv(), "hello");
+
+    expect(mockPruneStreamEvents).toHaveBeenCalledWith(TURN_ID);
+  });
+});
+
+describe("runTurnBackground — stream-state durability (#825/#834)", () => {
+  it("persists the final thinking text onto the assistant message", async () => {
+    mockAssembleRequest.mockImplementation(async (...args: unknown[]) => {
+      const opts = args[4] as {
+        ctx?: {
+          onSystemPromptReady?: (p: string, t?: unknown[]) => void;
+          onAgenticProgress?: (ev: Record<string, unknown>) => void;
+        };
+      };
+      opts?.ctx?.onSystemPromptReady?.("SYSTEM PROMPT", []);
+      // Cumulative thinking deltas — the LAST one is the final text.
+      opts?.ctx?.onAgenticProgress?.({ type: "model_thinking_delta", text: "pensando…" });
+      opts?.ctx?.onAgenticProgress?.({
+        type: "model_thinking_delta",
+        text: "pensando… ya casi está",
+      });
+      return { text: "respuesta final", usage: {}, model: "m" };
+    });
+
+    await runTurnBackground(TURN_ID, makeConv(), "hola");
+
+    const assistantCall = mockAppendMessage.mock.calls.find(
+      ([, role]) => role === "assistant",
+    );
+    expect(assistantCall?.[2]).toMatchObject({
+      text: "respuesta final",
+      thinking: "pensando… ya casi está",
+    });
+  });
+
+  it("omits thinking on the assistant message when the turn produced none", async () => {
+    await runTurnBackground(TURN_ID, makeConv(), "hola");
+
+    const assistantCall = mockAppendMessage.mock.calls.find(
+      ([, role]) => role === "assistant",
+    );
+    expect(assistantCall?.[2]).not.toHaveProperty("thinking");
+  });
+
+  it("prunes transient stream events after a completed turn", async () => {
+    await runTurnBackground(TURN_ID, makeConv(), "hola");
+
+    expect(mockUpdateTurnStatus).toHaveBeenLastCalledWith(TURN_ID, "complete");
+    expect(mockPruneStreamEvents).toHaveBeenCalledWith(TURN_ID);
+  });
+
+  it("inserts streamed events in seq order even when emitted in a burst", async () => {
+    const insertedSeqs: number[] = [];
+    mockInsertTurnEvent.mockImplementation((_turnId, seq) => {
+      insertedSeqs.push(seq as number);
+      // Random-ish completion latency: without the per-turn chain these
+      // inserts could land out of order.
+      return new Promise((resolve) =>
+        setTimeout(() => resolve(undefined), insertedSeqs.length % 3),
+      );
+    });
+    mockAssembleRequest.mockImplementation(async (...args: unknown[]) => {
+      const opts = args[4] as {
+        ctx?: { onAgenticProgress?: (ev: Record<string, unknown>) => void };
+      };
+      for (let i = 1; i <= 5; i++) {
+        opts?.ctx?.onAgenticProgress?.({ type: "model_text_delta", text: `t${i}` });
+      }
+      return { text: "done", usage: {}, model: "m" };
+    });
+
+    await runTurnBackground(TURN_ID, makeConv(), "hola");
+
+    const sorted = [...insertedSeqs].sort((a, b) => a - b);
+    expect(insertedSeqs).toEqual(sorted);
   });
 });
 

--- a/dashboard/lib/__tests__/turn-background.test.ts
+++ b/dashboard/lib/__tests__/turn-background.test.ts
@@ -374,6 +374,44 @@ describe("runTurnBackground — error path", () => {
 
     expect(mockPruneStreamEvents).toHaveBeenCalledWith(TURN_ID);
   });
+
+  it("flushes queued stream inserts before pruning on the error path", async () => {
+    // Queued token/thinking inserts resolve with latency; pruning must wait
+    // for them or it would delete nothing and the late inserts would
+    // resurrect the rows (Copilot review on #845).
+    const order: string[] = [];
+    mockInsertTurnEvent.mockImplementation(
+      (_turnId, _seq, type) =>
+        new Promise((resolve) =>
+          setTimeout(() => {
+            order.push(`insert:${type}`);
+            resolve(1);
+          }, 5),
+        ),
+    );
+    mockPruneStreamEvents.mockImplementation(() => {
+      order.push("prune");
+      return Promise.resolve();
+    });
+    mockAssembleRequest.mockImplementation(async (...args: unknown[]) => {
+      const opts = args[4] as {
+        ctx?: { onAgenticProgress?: (ev: Record<string, unknown>) => void };
+      };
+      opts?.ctx?.onAgenticProgress?.({ type: "model_text_delta", text: "parcial" });
+      opts?.ctx?.onAgenticProgress?.({ type: "model_thinking_delta", text: "hmm" });
+      throw new Error("mid-stream crash");
+    });
+
+    await runTurnBackground(TURN_ID, makeConv(), "hola");
+
+    const pruneIdx = order.indexOf("prune");
+    const tokenIdx = order.indexOf("insert:token");
+    const thinkingIdx = order.indexOf("insert:thinking");
+    expect(tokenIdx).toBeGreaterThanOrEqual(0);
+    expect(thinkingIdx).toBeGreaterThanOrEqual(0);
+    expect(pruneIdx).toBeGreaterThan(tokenIdx);
+    expect(pruneIdx).toBeGreaterThan(thinkingIdx);
+  });
 });
 
 describe("runTurnBackground — stream-state durability (#825/#834)", () => {

--- a/dashboard/lib/conversation-types.ts
+++ b/dashboard/lib/conversation-types.ts
@@ -81,6 +81,12 @@ export interface AssistantMessageContent {
   error_detail?: AgenticErrorDiagnostic;
   /** Agentic round number this message belongs to (1-based). */
   round?: number;
+  /**
+   * Final extended-thinking text for the turn that produced this message.
+   * Persisted here (durable) because the transient `thinking` turn_events are
+   * pruned once a turn completes — see pruneStreamEvents / issue #825.
+   */
+  thinking?: string;
 }
 
 export type MessageContent =

--- a/dashboard/lib/turn-background.ts
+++ b/dashboard/lib/turn-background.ts
@@ -299,6 +299,20 @@ export async function runTurnBackground(
   const requestId = generateRequestId();
   const seq = makeSeq();
   const conversationId = conversation.id;
+  const mode = conversation.mode;
+  const isFreeChatConv = conversation.context_kind === "global" || mode === "chat";
+  // One progress emitter per turn: serialised event inserts + final thinking
+  // capture. Token streaming is suppressed for dashboard modes (analyze/modify
+  // always end with a tool call, never prose — text deltas are tool-call JSON).
+  // Declared OUTSIDE the try so the catch block can flush the insert chain
+  // before pruning — otherwise queued token/thinking inserts could land after
+  // pruneStreamEvents and resurrect the rows it just deleted.
+  const progress = makeProgressHandler(
+    conversationId,
+    turnId,
+    seq,
+    mode === "analyze" || mode === "modify",
+  );
 
   try {
     await updateTurnStatus(turnId, "streaming");
@@ -334,17 +348,6 @@ export async function runTurnBackground(
     // Tool calls the model made this turn — persisted on the assistant message so
     // later turns retain the tool context (which query ran, with what result).
     let assistantToolCalls: AgenticToolCallRecord[] = [];
-    const mode = conversation.mode;
-    const isFreeChatConv = conversation.context_kind === "global" || mode === "chat";
-    // One progress emitter per turn: serialised event inserts + final thinking
-    // capture. Token streaming is suppressed for dashboard modes (analyze/modify
-    // always end with a tool call, never prose — text deltas are tool-call JSON).
-    const progress = makeProgressHandler(
-      conversationId,
-      turnId,
-      seq,
-      mode === "analyze" || mode === "modify",
-    );
 
     await emitTurnEvent(conversationId, turnId, seq(), "log", {
       kind: "meta",
@@ -467,6 +470,10 @@ export async function runTurnBackground(
   } catch (err) {
     const errText = err instanceof Error ? err.message : String(err);
     console.error(`[${requestId}] runTurnBackground error for turn ${turnId}:`, err);
+    // Settle any queued streaming inserts BEFORE the error event and prune:
+    // without this, late token/thinking inserts could publish after the error
+    // frame and re-create rows pruneStreamEvents just deleted.
+    await progress.flush().catch(() => {});
     // Persist the error as an assistant message so the failed turn remains
     // visible after a reload — without it, an errored turn shows only the user
     // bubble with no indication anything went wrong (issue #824). The client

--- a/dashboard/lib/turn-background.ts
+++ b/dashboard/lib/turn-background.ts
@@ -10,6 +10,7 @@ import {
   updateTurnStatus,
   insertTurnEvent,
   setTurnContextFile,
+  pruneStreamEvents,
   type TurnRow,
 } from "@/lib/turn-events";
 import { writeTurnContext } from "@/lib/conversation-context-store";
@@ -95,10 +96,28 @@ function formatToolArgs(toolName: string, argsPreview?: string): string {
 
 // ── Shared agentic progress handler ───────────────────────────────────────────
 
+/** Progress emitter handle: the callback plus turn-final accessors. */
+interface ProgressEmitter {
+  handler: (event: import("@/lib/llm-tools/types").AgenticProgressEvent) => void;
+  /** Resolves once every queued event insert has settled (issue #834 ordering). */
+  flush: () => Promise<void>;
+  /** Latest cumulative extended-thinking text seen this turn ("" if none). */
+  thinkingText: () => string;
+}
+
 /**
  * Creates an onAgenticProgress callback that emits SSE events for streaming
  * tokens, extended thinking, and tool progress. Used by both runFreeChatTurn
  * and runDashboardTurn so behaviour is identical across conversation modes.
+ *
+ * Event inserts are serialised through a per-turn promise chain so turn_events
+ * BIGSERIAL ids match the allocated seq order (fire-and-forget inserts could
+ * previously complete out of order — issue #834). The chain never rejects:
+ * each link swallows its own error so one failed insert doesn't drop the rest.
+ *
+ * The latest cumulative thinking text is captured so the caller can persist it
+ * durably on the assistant message before the transient thinking events are
+ * pruned (issues #825/#834).
  */
 function makeProgressHandler(
   conversationId: string,
@@ -106,10 +125,22 @@ function makeProgressHandler(
   seq: () => number,
   /** When true, token streaming is suppressed (analyze/modify use tool calls for output). */
   suppressTokens = false,
-): (event: import("@/lib/llm-tools/types").AgenticProgressEvent) => void {
+): ProgressEmitter {
   let inToolRound = false;
+  let latestThinking = "";
+  let chain: Promise<void> = Promise.resolve();
 
-  return (event: import("@/lib/llm-tools/types").AgenticProgressEvent) => {
+  const enqueue = (eventType: string, payload: Record<string, unknown>) => {
+    // Allocate the seq synchronously so ordering is fixed at enqueue time.
+    const eventSeq = seq();
+    chain = chain.then(() =>
+      emitTurnEvent(conversationId, turnId, eventSeq, eventType, payload).catch(
+        () => {},
+      ),
+    );
+  };
+
+  const handler = (event: import("@/lib/llm-tools/types").AgenticProgressEvent) => {
     if (event.type === "round") {
       inToolRound = false;
     } else if (event.type === "assistant_tools") {
@@ -117,14 +148,13 @@ function makeProgressHandler(
       // Clear streaming tokens that appeared before we knew this was a tool round.
       // Thinking text is preserved — it remains visible while tools execute.
       if (!suppressTokens) {
-        void emitTurnEvent(conversationId, turnId, seq(), "token", { text: "" }).catch(() => {});
+        enqueue("token", { text: "" });
       }
       return;
     } else if (event.type === "model_thinking_delta" && event.text) {
       if (!inToolRound) {
-        void emitTurnEvent(conversationId, turnId, seq(), "thinking", {
-          text: event.text,
-        }).catch(() => {});
+        latestThinking = event.text;
+        enqueue("thinking", { text: event.text });
       }
       return;
     } else if (event.type === "model_text_delta" && event.text) {
@@ -132,9 +162,7 @@ function makeProgressHandler(
       // For dashboard modes (analyze/modify), ALL text deltas are tool-call JSON —
       // suppress them so users don't see raw JSON streaming.
       if (!inToolRound && !suppressTokens) {
-        void emitTurnEvent(conversationId, turnId, seq(), "token", {
-          text: event.text,
-        }).catch(() => {});
+        enqueue("token", { text: event.text });
       }
       return;
     }
@@ -148,12 +176,18 @@ function makeProgressHandler(
       logText = `${event.ok ? "✓" : "✗"} ${event.name} (${event.ms}ms)`;
     }
     if (logText) {
-      void emitTurnEvent(conversationId, turnId, seq(), "log", {
+      enqueue("log", {
         kind: "tool",
         text: logText,
         ts: new Date().toISOString(),
-      }).catch(() => {});
+      });
     }
+  };
+
+  return {
+    handler,
+    flush: () => chain,
+    thinkingText: () => latestThinking,
   };
 }
 
@@ -302,6 +336,15 @@ export async function runTurnBackground(
     let assistantToolCalls: AgenticToolCallRecord[] = [];
     const mode = conversation.mode;
     const isFreeChatConv = conversation.context_kind === "global" || mode === "chat";
+    // One progress emitter per turn: serialised event inserts + final thinking
+    // capture. Token streaming is suppressed for dashboard modes (analyze/modify
+    // always end with a tool call, never prose — text deltas are tool-call JSON).
+    const progress = makeProgressHandler(
+      conversationId,
+      turnId,
+      seq,
+      mode === "analyze" || mode === "modify",
+    );
 
     await emitTurnEvent(conversationId, turnId, seq(), "log", {
       kind: "meta",
@@ -343,6 +386,7 @@ export async function runTurnBackground(
         conversationId,
         turnId,
         seq,
+        progress,
       );
       assistantText = res.text;
       assistantToolCalls = res.toolCalls;
@@ -356,6 +400,7 @@ export async function runTurnBackground(
         conversationId,
         turnId,
         seq,
+        progress,
       );
       assistantText = dashResult.text;
       assistantToolCalls = dashResult.toolCalls;
@@ -382,11 +427,19 @@ export async function runTurnBackground(
       assistantToolCalls = res.toolCalls;
     }
 
+    // All streamed events are inserted before the assistant message/complete
+    // event so replay ordering is deterministic (issue #834).
+    await progress.flush();
+
     // Persist final assistant message to conversation_messages — including the
-    // tool calls made this turn so later turns retain the tool context.
+    // tool calls made this turn so later turns retain the tool context, and the
+    // final thinking text so it survives reloads (the transient thinking events
+    // are pruned below — issues #825/#834).
     const assistantContent: AssistantMessageContent = { text: assistantText };
     const dbToolCalls = toDbToolCalls(assistantToolCalls);
     if (dbToolCalls.length > 0) assistantContent.tool_calls = dbToolCalls;
+    const finalThinking = progress.thinkingText();
+    if (finalThinking) assistantContent.thinking = finalThinking;
     const assistantMsg = await appendMessage(
       conversationId,
       "assistant",
@@ -401,6 +454,10 @@ export async function runTurnBackground(
 
     await updateTurnStatus(turnId, "complete");
 
+    // Drop the turn's transient token/thinking snapshots now that the durable
+    // copy lives on the assistant message (issue #834). Best-effort.
+    await pruneStreamEvents(turnId).catch(() => {});
+
     // Best-effort title generation — failure must not affect turn status.
     void maybeGenerateTitle(conversationId, [
       ...priorMessages,
@@ -410,11 +467,32 @@ export async function runTurnBackground(
   } catch (err) {
     const errText = err instanceof Error ? err.message : String(err);
     console.error(`[${requestId}] runTurnBackground error for turn ${turnId}:`, err);
+    // Persist the error as an assistant message so the failed turn remains
+    // visible after a reload — without it, an errored turn shows only the user
+    // bubble with no indication anything went wrong (issue #824). The client
+    // renders is_error content with the error styling it already supports.
+    let errorMessageId: string | null = null;
+    try {
+      const errorMsg = await appendMessage(conversationId, "assistant", {
+        text: errText,
+        is_error: true,
+      });
+      errorMessageId = errorMsg.id;
+    } catch (persistErr) {
+      console.error(
+        `[${requestId}] could not persist error message for turn ${turnId}:`,
+        persistErr,
+      );
+    }
     await emitTurnEvent(conversationId, turnId, seq(), "error", {
       message: errText,
       ts: new Date().toISOString(),
+      // Lets the client attach the turn's logs/context panel to the persisted
+      // error message, same as complete does via messageId.
+      ...(errorMessageId ? { messageId: errorMessageId } : {}),
     }).catch(() => {});
     await updateTurnStatus(turnId, "error", errText).catch(() => {});
+    await pruneStreamEvents(turnId).catch(() => {});
     await touchConversation(conversationId, "error").catch(() => {});
   }
 }
@@ -435,6 +513,7 @@ async function runFreeChatTurn(
   conversationId: string,
   turnId: string,
   seq: () => number,
+  progress: ProgressEmitter,
 ): Promise<TurnReply> {
   const { assembleRequest } = await import("@/lib/llm-context");
   const { AgenticRunnerError } = await import("@/lib/llm-tools/runner");
@@ -444,7 +523,7 @@ async function runFreeChatTurn(
     requestId,
     endpoint: "freeChat" as const,
     conversationId,
-    onAgenticProgress: makeProgressHandler(conversationId, turnId, seq),
+    onAgenticProgress: progress.handler,
     // Write the exact payload sent to the LLM to this turn's context-log file.
     onSystemPromptReady: makeSystemPromptReadyHandler(
       conversation,
@@ -506,6 +585,7 @@ async function runDashboardTurn(
   conversationId: string,
   turnId: string,
   seq: () => number,
+  progress: ProgressEmitter,
 ): Promise<DashboardTurnResult> {
   const { sql } = await import("@/lib/db-write");
   const ctxWrite: ContextWriteHandle = { done: Promise.resolve() };
@@ -516,10 +596,11 @@ async function runDashboardTurn(
       | "analyzeDashboard"
       | "modifyDashboard",
     conversationId: conversation.id,
-    // Wire agentic progress events to SSE. Suppress token streaming for dashboard
-    // modes — analyze/modify always end with a tool call (submit_dashboard_analysis
-    // or apply_dashboard_modification), never prose, so model_text_delta is JSON.
-    onAgenticProgress: makeProgressHandler(conversationId, turnId, seq, true),
+    // Wire agentic progress events to SSE. The emitter was created with token
+    // streaming suppressed for dashboard modes — analyze/modify always end with
+    // a tool call (submit_dashboard_analysis or apply_dashboard_modification),
+    // never prose, so model_text_delta is JSON.
+    onAgenticProgress: progress.handler,
     // Write the exact payload sent to the LLM to this turn's context-log file.
     onSystemPromptReady: makeSystemPromptReadyHandler(
       conversation,

--- a/dashboard/lib/turn-events.ts
+++ b/dashboard/lib/turn-events.ts
@@ -139,6 +139,23 @@ export async function getTurnContextFile(
   return rows[0]?.context_file ?? null;
 }
 
+/**
+ * Delete the transient streaming events (`token`, `thinking`) of a finished turn.
+ *
+ * These events carry CUMULATIVE snapshots per delta — O(n²) storage in response
+ * length — and are pure transport once the turn is complete: the final text
+ * lives on the assistant message (including its `thinking`). Pruning bounds
+ * turn_events growth and keeps SSE replay payloads small (issue #834).
+ * Durable events (log, context_ref, spec_update, complete, error) are kept.
+ */
+export async function pruneStreamEvents(turnId: string): Promise<void> {
+  await sql(
+    `DELETE FROM turn_events
+      WHERE turn_id = $1 AND event_type IN ('token', 'thinking')`,
+    [turnId],
+  );
+}
+
 export async function getTurnWithEvents(turnId: string): Promise<TurnWithEvents | null> {
   const turns = await sql<TurnRow>(
     `SELECT * FROM conversation_turns WHERE id = $1`,


### PR DESCRIPTION
## Summary

Fixes the conversation streaming/display-reliability cluster from the audit (cluster 2) — the family of bugs behind "I leave mid-turn and come back and the conversation isn't showing what it should".

Closes #836. Closes #825. Closes #824. Closes #834. Closes #811. Closes #808.

### The core change: per-turn stream state + replay tagging

`ConversationPane` previously kept the streamed answer/thinking in singleton state gated on `pendingTurnIdRef.current === turnId`. That gate is what dropped data in every reported scenario: mid-turn reload (replay races the conversation fetch — #836), post-complete reload (thinking persisted from an empty ref — #825), and second windows (events for turns this client didn't initiate — #825).

Now **all stream state accumulates per turn in the `turns` map, ungated**, and the stream route tags catch-up frames with `replay: true`:
- A reloaded tab resuming mid-turn renders identically whether the replay or the conversation fetch wins — the data is in the map either way.
- A passive second window **adopts** a live turn started elsewhere and renders its stream.
- Replayed `complete`/`error` frames rebuild state without one refetch per historical turn.

### Durability

- **Thinking** is persisted on the assistant message (`content.thinking`) at turn completion — survives reloads; replayed events remain the fallback for pre-existing turns (#825).
- **Errored turns** persist an `is_error` assistant message (the renderers already support it), and the error event carries its `messageId` so logs/context attach after reload (#824).
- **Refetch failure after complete** (#811): the assistant message is synthesised locally from the streamed text instead of silently vanishing; the next successful refresh replaces it.
- **Send failure** (#808): the typed message is restored into the input.

### Bounding (#834)

Token/thinking events are cumulative snapshots — O(n²) storage per response, previously kept forever and fully replayed on every connect. They are now **pruned once the turn completes or errors** (`pruneStreamEvents`): the durable copies live on the message, replay payloads stay small, and `turn_events` stops growing unboundedly. Insert order is also serialised through a per-turn promise chain so BIGSERIAL ids match `seq` order.

## Tests

- 6 new `turn-background` cases: error-message persistence + messageId on the error event, thinking persisted/omitted correctly, prune on complete **and** error, burst-insert ordering.
- 5 new `ConversationPane` cases mapping 1:1 to the issues: mid-turn resume with a slow conversation fetch (#836 — the exact race), replayed completes don't refetch, passive-window adoption (#825), refetch-failure synthesis (#811), input restore (#808).
- Stream route: replay tag present on catch-up frames, absent on live ones.
- Full unit suite: **2233 passed (167 files)**; typecheck/lint/guard scripts clean.
- **e2e: the full CI spec set (16 tests incl. conversation-engine AC-4–AC-9 and chat-dashboard EC-1–EC-3) passes locally** against seeded Postgres — these cover reload-during-streaming, two-window consistency, and reopening after close, i.e. the surfaces this PR changes (D-041).

## Compatibility notes

- Pre-existing turns (recorded before pruning) still replay their token/thinking events; the client renders them via the per-turn fallback, so old conversations display unchanged.
- No schema change: `content.thinking` is a new optional JSONB field on assistant messages.

https://claude.ai/code/session_01STxL6Ge4ri8RyfWhz9Sig6